### PR TITLE
Fix reading the version from build in deploy-snapshots step

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -491,7 +491,7 @@ jobs:
   deploy-snapshot:
     name: Deploy Snapshot
     if: ${{ github.ref == 'refs/heads/main' }}
-    needs: [codeql, test, checkstyle, pmd, spotbugs, archetypes]
+    needs: [build, codeql, test, checkstyle, pmd, spotbugs, archetypes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
The `needs` property also has to contain `build`, since otherwise its output cannot be read.