### PR TITLE
Fix build pipeline after merging deployment to Maven Central

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           python .pipeline/scripts/generate-javadoc-sourcepath-properties.py
           mvn $MVN_CLI_ARGS install -DskipTests -DskipFormatting -Pdocs
-          python .pipeline/scripts/generate-release-artifacts.py --version ${{ steps.get-version.outputs.VERSION }} --path-prefix release --with-signing
+          python .pipeline/scripts/generate-release-artifacts.py --version ${{ steps.get-version.outputs.VERSION }} --path-prefix release
           zip -q -r sap-cloud-sdk-java-${{ steps.get-version.outputs.VERSION }}.zip release
           rm -rf release
       - name: Create module-inventory

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -533,14 +533,10 @@ jobs:
           -Dmaven.test.skip
           -Dmaven.compiler.showCompilationChanges
           -Dhttp.keepAlive=false
-          -Dgpg.passphrase="$PASSPHRASE"
-          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
           deploy
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
-          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
   notify-job:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -85,7 +85,7 @@ jobs:
         run: |
           python .pipeline/scripts/generate-javadoc-sourcepath-properties.py
           mvn $MVN_CLI_ARGS install -DskipTests -DskipFormatting -Pdocs
-          python .pipeline/scripts/generate-release-artifacts.py --version ${{ steps.get-version.outputs.VERSION }} --path-prefix release
+          python .pipeline/scripts/generate-release-artifacts.py --version ${{ steps.get-version.outputs.VERSION }} --path-prefix release --with-signing
           zip -q -r sap-cloud-sdk-java-${{ steps.get-version.outputs.VERSION }}.zip release
           rm -rf release
       - name: Create module-inventory

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -491,7 +491,7 @@ jobs:
 
   deploy-snapshot:
     name: Deploy Snapshot
-    if: ${{ github.ref == 'refs/heads/main' }}
+    #if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build, codeql, test, checkstyle, pmd, spotbugs, archetypes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -512,6 +512,13 @@ jobs:
         with:
           name: cloud-sdk-package
           path: .
+
+      - name: Import PGP Key
+        run: |
+          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
+        env:
+          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+
       - name: Publish Snapshot
         run: >
           unzip sap-cloud-sdk-java-${{ needs.build.outputs.version }}.zip -d .
@@ -526,10 +533,14 @@ jobs:
           -Dmaven.test.skip
           -Dmaven.compiler.showCompilationChanges
           -Dhttp.keepAlive=false
+          -Dgpg.passphrase="$PASSPHRASE"
+          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
           deploy
         env:
           ARTIFACTORY_USER: ${{ secrets.ARTIFACTORY_USER }}
           ARTIFACTORY_TOKEN: ${{ secrets.ARTIFACTORY_TOKEN }}
+          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
   notify-job:
     runs-on: ubuntu-latest
     needs:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -491,7 +491,7 @@ jobs:
 
   deploy-snapshot:
     name: Deploy Snapshot
-    #if: ${{ github.ref == 'refs/heads/main' }}
+    if: ${{ github.ref == 'refs/heads/main' }}
     needs: [build, codeql, test, checkstyle, pmd, spotbugs, archetypes]
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -512,12 +512,6 @@ jobs:
         with:
           name: cloud-sdk-package
           path: .
-
-      - name: Import PGP Key
-        run: |
-          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
-        env:
-          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
 
       - name: Publish Snapshot
         run: >

--- a/.github/workflows/prepare_release.yml
+++ b/.github/workflows/prepare_release.yml
@@ -91,7 +91,7 @@ jobs:
         run: |
           python .pipeline/scripts/generate-javadoc-sourcepath-properties.py
           mvn $MVN_CLI_ARGS install jacoco:report javadoc:aggregate -Pdocs
-          python .pipeline/scripts/generate-release-artifacts.py --version ${{ needs.prepare-release.outputs.release_version }} --path-prefix release
+          python .pipeline/scripts/generate-release-artifacts.py --version ${{ needs.prepare-release.outputs.release_version }} --path-prefix release --with-signing
           zip -q -r sap-cloud-sdk-java-${{ needs.prepare-release.outputs.release_version }}.zip release
       - name: Local Changes Check
         run: |

--- a/.pipeline/scripts/generate-release-artifacts.py
+++ b/.pipeline/scripts/generate-release-artifacts.py
@@ -157,7 +157,7 @@ def generate_pom(path_prefix, sdk_version, with_signing):
                     f.write(generate_execution(path_prefix, "install", "install-file", module, sdk_version))
             f.write(pom_end_plugin)
 
-            if with_signing == "true":
+            if with_signing is True:
                 f.write(pom_begin_gpg_plugin)
                 for module in module_inventory:
                     if module["releaseAudience"] == "Public":
@@ -187,6 +187,8 @@ def main():
                         help="Specify whether to sign all artifacts during deployment.")
 
     args = parser.parse_args()
+
+    print(args)
 
     if os.path.exists(args.path_prefix):
         shutil.rmtree(args.path_prefix)

--- a/.pipeline/scripts/generate-release-artifacts.py
+++ b/.pipeline/scripts/generate-release-artifacts.py
@@ -33,7 +33,6 @@ pom_begin_deploy_plugin = """
                 <executions>
 """
 
-
 pom_begin_gpg_plugin = """
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/.pipeline/scripts/generate-release-artifacts.py
+++ b/.pipeline/scripts/generate-release-artifacts.py
@@ -188,8 +188,6 @@ def main():
 
     args = parser.parse_args()
 
-    print(args)
-
     if os.path.exists(args.path_prefix):
         shutil.rmtree(args.path_prefix)
 


### PR DESCRIPTION
For unknown reasons, the Maven GPG Plugin cannot successfully deploy snapshots to the Artifactory. This PR adds the optinoal "--with-signing" flag to the Python script which generates the wrapper POM used for deploying artifacts. Only in the Prepare Release pipeline, this flag is passed. For the other CI pipelines, the JARs are not signed anymore as before.