### PR TITLE
322 - remove CURRENT_TENANT_THEN_PROVIDER

### DIFF
--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolver.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolver.java
@@ -254,7 +254,7 @@ class DestinationRetrievalStrategyResolver
             }
             default: {
                 throw new IllegalArgumentException(
-                    "The provided destination retrieval strategy " + strategy + "is not valid.");
+                    "The provided destination retrieval strategy " + strategy + " is not valid.");
             }
         }
     }

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
@@ -20,19 +20,6 @@ import lombok.Getter;
  */
 public enum ScpCfDestinationRetrievalStrategy
 {
-    /**
-     * Try to retrieve the current tenant's destination first. If the current tenant is a subscriber and no destination
-     * was found, fallback to the provider's destination. When loading all destinations both subaccount and instance
-     * level will be considered individually: If the current tenant is a subscriber and there are no destinations on the
-     * subaccount level, the subaccount level of the provider will be considered. Independently of that, if the current
-     * tenant is a subscriber and there are no destinations on the instance level, the provider instance level will be
-     * queried.
-     *
-     * @deprecated Please query subscriber and provider tenants individually instead using {@link #ONLY_SUBSCRIBER} and
-     *             {@link #ALWAYS_PROVIDER}.
-     */
-    @Deprecated
-    CURRENT_TENANT_THEN_PROVIDER("CurrentTenantThenProvider"),
 
     /**
      * Only load destination from the provider's sub-account, regardless if subscribers have a destination of the same

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
@@ -19,7 +19,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
@@ -40,7 +39,6 @@ import org.junit.jupiter.api.extension.RegisterExtension;
 import com.auth0.jwt.JWT;
 import com.auth0.jwt.algorithms.Algorithm;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
-import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationNotFoundException;
 import com.sap.cloud.sdk.cloudplatform.security.AuthToken;
 import com.sap.cloud.sdk.cloudplatform.security.AuthTokenAccessor;
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
@@ -161,63 +159,6 @@ class DestinationRetrievalStrategyResolverTest
                     subscriberT).isInstanceOf(DestinationAccessException.class));
 
         verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_PROVIDER, false)));
-        verifyNoMoreInteractions(destinationRetriever);
-    }
-
-    @Test
-    @DisplayName( "Test using CURRENT_TENANT_THEN_PROVIDER with LOOKUP_ONLY" )
-    void testSubThenProvLookupOnly()
-    {
-        doThrow(DestinationNotFoundException.class).when(destinationRetriever).apply(any());
-
-        // subscriber tenant is implied
-        assertThatThrownBy(sut.prepareSupplierForSubscriberThenProviderCase(LOOKUP_ONLY)::get)
-            .isInstanceOf(DestinationNotFoundException.class);
-
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_CURRENT_TENANT, false)));
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_PROVIDER, false)));
-        verifyNoMoreInteractions(destinationRetriever);
-    }
-
-    @Test
-    @DisplayName( "Test using CURRENT_TENANT_THEN_PROVIDER with FORWARD_USER_TOKEN" )
-    void testSubThenProvFwdUserToken()
-    {
-        doThrow(DestinationNotFoundException.class).when(destinationRetriever).apply(any());
-
-        // subscriber tenant is implied
-        assertThatThrownBy(sut.prepareSupplierForSubscriberThenProviderCase(FORWARD_USER_TOKEN)::get)
-            .isInstanceOf(DestinationNotFoundException.class);
-
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_CURRENT_TENANT, true)));
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_PROVIDER, false)));
-        verifyNoMoreInteractions(destinationRetriever);
-    }
-
-    @Test
-    @DisplayName( "Test using CURRENT_TENANT_THEN_PROVIDER with EXCHANGE_ONLY" )
-    void testSubThenProvExchangeOnly()
-    {
-        doAnswer(( any ) -> true).when(sut).doesDestinationConfigurationRequireUserTokenExchange(any());
-
-        // subscriber tenant is implied
-        sut.prepareSupplierForSubscriberThenProviderCase(EXCHANGE_ONLY).get();
-
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(NAMED_USER_CURRENT_TENANT, false)));
-        verifyNoMoreInteractions(destinationRetriever);
-    }
-
-    @Test
-    @DisplayName( "Test using CURRENT_TENANT_THEN_PROVIDER with LOOKUP_THEN_EXCHANGE" )
-    void testLookupThenExchangeWithCurrentTenantThenProvider()
-    {
-        doAnswer(( any ) -> true).when(sut).doesDestinationConfigurationRequireUserTokenExchange(any());
-
-        // subscriber tenant is implied
-        sut.prepareSupplierForSubscriberThenProviderCase(LOOKUP_THEN_EXCHANGE).get();
-
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_CURRENT_TENANT, false)));
-        verify(destinationRetriever, times(1)).apply(eq(new Strategy(NAMED_USER_CURRENT_TENANT, false)));
         verifyNoMoreInteractions(destinationRetriever);
     }
 

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
@@ -10,7 +10,6 @@ import static com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf.TECHNICAL_
 import static com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf.TECHNICAL_USER_PROVIDER;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy.ALWAYS_PROVIDER;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy.CURRENT_TENANT;
-import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy.CURRENT_TENANT_THEN_PROVIDER;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy.ONLY_SUBSCRIBER;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationTokenExchangeStrategy.EXCHANGE_ONLY;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationTokenExchangeStrategy.FORWARD_USER_TOKEN;
@@ -52,7 +51,6 @@ import io.vavr.Tuple;
 import io.vavr.Tuple3;
 import io.vavr.control.Try;
 
-@SuppressWarnings( "deprecation" )
 class DestinationRetrievalStrategyResolverTest
 {
     private static final Tenant providerT = new DefaultTenant("provider");
@@ -167,24 +165,6 @@ class DestinationRetrievalStrategyResolverTest
     }
 
     @Test
-    @DisplayName( "When current tenant == provider then CURRENT_TENANT_THEN_PROVIDER should be equal to CURRENT_TENANT" )
-    void testCurrentThenProviderSimpleCase()
-    {
-        TenantAccessor
-            .executeWithTenant(
-                providerT,
-                () -> sut.prepareSupplier(CURRENT_TENANT_THEN_PROVIDER, LOOKUP_THEN_EXCHANGE));
-
-        verify(sut, times(1)).resolveSingleRequestStrategy(CURRENT_TENANT, LOOKUP_ONLY);
-
-        TenantAccessor
-            .executeWithTenant(
-                providerT,
-                () -> assertThatThrownBy(() -> sut.prepareSupplierForSubscriberThenProviderCase(LOOKUP_ONLY))
-                    .isInstanceOf(IllegalStateException.class));
-    }
-
-    @Test
     @DisplayName( "Test using CURRENT_TENANT_THEN_PROVIDER with LOOKUP_ONLY" )
     void testSubThenProvLookupOnly()
     {
@@ -239,21 +219,6 @@ class DestinationRetrievalStrategyResolverTest
         verify(destinationRetriever, times(1)).apply(eq(new Strategy(TECHNICAL_USER_CURRENT_TENANT, false)));
         verify(destinationRetriever, times(1)).apply(eq(new Strategy(NAMED_USER_CURRENT_TENANT, false)));
         verifyNoMoreInteractions(destinationRetriever);
-    }
-
-    @Test
-    @DisplayName( "Test getting all destinations with CURRENT_TENANT_THEN_PROVIDER" )
-    void testAllDestinationsCurrTenThenProv()
-    {
-        doThrow(DestinationAccessException.class).when(allDestinationRetriever).apply(TECHNICAL_USER_CURRENT_TENANT);
-
-        // subscriber tenant is implied
-        sut.prepareSupplierAllDestinations(CURRENT_TENANT_THEN_PROVIDER).get();
-
-        verify(allDestinationRetriever, times(1)).apply(TECHNICAL_USER_CURRENT_TENANT);
-        verify(allDestinationRetriever, times(1)).apply(TECHNICAL_USER_PROVIDER);
-
-        verifyNoMoreInteractions(allDestinationRetriever);
     }
 
     @Test

--- a/release_notes_next_major.md
+++ b/release_notes_next_major.md
@@ -102,6 +102,7 @@ blog: https://blogs.sap.com/?p=xxx
 - Removed the following elements from enum `com.sap.cloud.sdk.cloudplatform.connectivity.AuthenticationType`:
   - `APP_TO_APP_SSO` 
   - `INTERNAL_SYSTEM_AUTHENTICATION` 
+- Removed the deprecated enum element `CURRENT_TENANT_THEN_PROVIDER` from `com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy`.
 - Removed the `javax.inject.Named` annotation from the OData Generator (v2, v4).
 - Other changes to the Destination API:
   - Retrieving a `Destination` from the Destination service (i.e. using the `ScpCfDestinationLoader`) will now throw an exception if any of the attached certificates isn't valid.

--- a/release_notes_next_major.md
+++ b/release_notes_next_major.md
@@ -103,6 +103,7 @@ blog: https://blogs.sap.com/?p=xxx
   - `APP_TO_APP_SSO` 
   - `INTERNAL_SYSTEM_AUTHENTICATION` 
 - Removed the deprecated enum element `CURRENT_TENANT_THEN_PROVIDER` from `com.sap.cloud.sdk.cloudplatform.connectivity.ScpCfDestinationRetrievalStrategy`.
+  As alternative please run the destination lookup queries separately in your application for `ONLY_SUBSCRIBER` and `ALWAYS_PROVIDER` as fallback.
 - Removed the `javax.inject.Named` annotation from the OData Generator (v2, v4).
 - Other changes to the Destination API:
   - Retrieving a `Destination` from the Destination service (i.e. using the `ScpCfDestinationLoader`) will now throw an exception if any of the attached certificates isn't valid.


### PR DESCRIPTION
Removed deprecated `ScpCfDestinationRetrievalStrategy.CURRENT_TENANT_THEN_PROVIDER`.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Documentation updated
- [x] Release notes updated