### PR TITLE
Force Java 17 for CodeQL, same as in normal CI workflow

### DIFF
--- a/.github/workflows/build-sanity.yaml
+++ b/.github/workflows/build-sanity.yaml
@@ -207,6 +207,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v3
 
+      # Force Java 17
+      - name: Setup Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: "temurin"
+          java-version: 17
+
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v2


### PR DESCRIPTION
See for example a [failed run](https://github.com/SAP/cloud-sdk-java/actions/runs/6418792336/job/17427294605). The error message in the exception above the error log output tells the story.