### PR TITLE
Fix: Add `providerTenantId` to `MegacliteServiceBinding`

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -21,12 +21,12 @@ stages:
     checkstyle:
       high: '14'# Open tasks (to do or fix me)
       normal: '0'
-      low: '216'
+      low: '214'
     findbugs: #SpotBugs
       high: '0'
       normal: '0'
       low: '0'
     pmd:
       high: '0'
-      normal: '19'
+      normal: '18'
       low: '10'

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DwcConfiguration.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DwcConfiguration.java
@@ -51,18 +51,26 @@ final class DwcConfiguration
         this.providerTenant = Lazy.of(() -> providerTenant);
     }
 
+    @Nonnull
     URI megacliteUrl()
+        throws CloudPlatformException,
+            IllegalArgumentException
     {
         return megacliteUrl.get();
     }
 
+    @Nonnull
     String providerTenant()
+        throws CloudPlatformException,
+            IllegalArgumentException
     {
         return providerTenant.get();
     }
 
     @Nonnull
     private static URI loadMegacliteUri( @Nonnull final Function<String, String> environmentVariableReader )
+        throws CloudPlatformException,
+            IllegalArgumentException
     {
         final Option<String> dwcApplication = Option.of(environmentVariableReader.apply(DWC_APPLICATION));
         if( dwcApplication.isEmpty() ) {
@@ -75,6 +83,8 @@ final class DwcConfiguration
 
     @Nonnull
     private static String loadProviderTenantId( @Nonnull final Function<String, String> environmentVariableReader )
+        throws CloudPlatformException,
+            IllegalArgumentException
     {
         final Option<String> dwcApplication = Option.of(environmentVariableReader.apply(DWC_APPLICATION));
         if( dwcApplication.isEmpty() ) {

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -15,12 +15,14 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.Beta;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
+import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
+import lombok.Setter;
 import lombok.ToString;
 
 /**
@@ -66,8 +68,9 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Nullable
     private final MandateConfiguration subscriberConfiguration;
 
-    @Nullable
-    static DwcConfiguration dwcConfiguration;
+    @Nonnull
+    @Setter( AccessLevel.PACKAGE )
+    private DwcConfiguration dwcConfiguration = DwcConfiguration.getInstance();
 
     @Nonnull
     @Override
@@ -120,13 +123,10 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Nonnull
     @Override
     public Map<String, Object> getCredentials()
+        throws CloudPlatformException,
+            IllegalArgumentException
     {
-        return Collections
-            .singletonMap(
-                "tenantid",
-                dwcConfiguration == null
-                    ? DwcConfiguration.getInstance().providerTenant()
-                    : dwcConfiguration.providerTenant());
+        return Collections.singletonMap("tenantid", dwcConfiguration.providerTenant());
     }
 
     /**

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -61,6 +61,9 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Nonnull
     private final ServiceIdentifier service;
 
+    @Nonnull
+    private final String providerTenantId;
+
     @Nullable
     private final MandateConfiguration providerConfiguration;
     @Nullable
@@ -118,7 +121,7 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Override
     public Map<String, Object> getCredentials()
     {
-        return Collections.emptyMap();
+        return Collections.singletonMap("tenantid", providerTenantId);
     }
 
     /**
@@ -368,7 +371,12 @@ public final class MegacliteServiceBinding implements ServiceBinding
             } else {
                 subscriberConfiguration = currentConfiguration;
             }
-            return new MegacliteServiceBinding(service, providerConfiguration, subscriberConfiguration);
+            final String providerTenantId = DwcConfiguration.getInstance().providerTenant();
+            return new MegacliteServiceBinding(
+                service,
+                providerTenantId,
+                providerConfiguration,
+                subscriberConfiguration);
         }
 
         @Nonnull

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -61,13 +61,13 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Nonnull
     private final ServiceIdentifier service;
 
-    @Nonnull
-    private final String providerTenantId;
-
     @Nullable
     private final MandateConfiguration providerConfiguration;
     @Nullable
     private final MandateConfiguration subscriberConfiguration;
+
+    @Nullable
+    static DwcConfiguration dwcConfiguration;
 
     @Nonnull
     @Override
@@ -121,7 +121,12 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Override
     public Map<String, Object> getCredentials()
     {
-        return Collections.singletonMap("tenantid", providerTenantId);
+        return Collections
+            .singletonMap(
+                "tenantid",
+                dwcConfiguration == null
+                    ? DwcConfiguration.getInstance().providerTenant()
+                    : dwcConfiguration.providerTenant());
     }
 
     /**
@@ -371,12 +376,7 @@ public final class MegacliteServiceBinding implements ServiceBinding
             } else {
                 subscriberConfiguration = currentConfiguration;
             }
-            final String providerTenantId = DwcConfiguration.getInstance().providerTenant();
-            return new MegacliteServiceBinding(
-                service,
-                providerTenantId,
-                providerConfiguration,
-                subscriberConfiguration);
+            return new MegacliteServiceBinding(service, providerConfiguration, subscriberConfiguration);
         }
 
         @Nonnull

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
@@ -7,7 +7,11 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import java.net.URI;
+
 import org.junit.Test;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
@@ -17,20 +21,26 @@ public class MegacliteServiceBindingTest
     @Test
     public void testPropertiesOfTheOpenSourceServiceBinding()
     {
-        final ServiceBinding binding =
-            MegacliteServiceBinding
-                .forService(ServiceIdentifier.DESTINATION)
-                .providerConfiguration()
-                .name("destination-paas")
-                .version("v1")
-                .build();
+        try( final MockedStatic<DwcConfiguration> dwcConf = Mockito.mockStatic(DwcConfiguration.class) ) {
+            dwcConf
+                .when(DwcConfiguration::getInstance)
+                .thenReturn(new DwcConfiguration(URI.create("my.megaclite.sap"), "provider-tenant-id"));
 
-        assertThat(binding.getKeys()).isEmpty();
-        assertThat(binding.getName()).isEmpty();
-        assertThat(binding.getServiceName()).contains("destination");
-        assertThat(binding.getServicePlan()).isEmpty();
-        assertThat(binding.getTags()).isEmpty();
-        assertThat(binding.getCredentials()).isEmpty();
+            final ServiceBinding binding =
+                MegacliteServiceBinding
+                    .forService(ServiceIdentifier.DESTINATION)
+                    .providerConfiguration()
+                    .name("destination-paas")
+                    .version("v1")
+                    .build();
+
+            assertThat(binding.getKeys()).isEmpty();
+            assertThat(binding.getName()).isEmpty();
+            assertThat(binding.getServiceName()).contains("destination");
+            assertThat(binding.getServicePlan()).isEmpty();
+            assertThat(binding.getTags()).isEmpty();
+            assertThat(binding.getCredentials().get("tenantid")).isEqualTo("provider-tenant-id");
+        }
     }
 
     @Test

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
@@ -11,26 +11,22 @@ import java.net.URI;
 
 import org.junit.Test;
 
-import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
+import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
 public class MegacliteServiceBindingTest
 {
-    static {
-        MegacliteServiceBinding.dwcConfiguration =
-            new DwcConfiguration(URI.create("megaclite.com"), "provider-tenant-id");
-    }
-
     @Test
     public void testPropertiesOfTheOpenSourceServiceBinding()
     {
-        final ServiceBinding binding =
+        final MegacliteServiceBinding binding =
             MegacliteServiceBinding
                 .forService(ServiceIdentifier.DESTINATION)
                 .providerConfiguration()
                 .name("destination-paas")
                 .version("v1")
                 .build();
+        binding.setDwcConfiguration(new DwcConfiguration(URI.create("megaclite.com"), "provider-tenant-id"));
 
         assertThat(binding.getKeys()).isEmpty();
         assertThat(binding.getName()).isEmpty();
@@ -52,5 +48,22 @@ public class MegacliteServiceBindingTest
 
         assertThatThrownBy(() -> builder.and().providerConfiguration())
             .isExactlyInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testGetCredentialsThrowsExceptionWithoutProviderTenantId()
+    {
+        final MegacliteServiceBinding binding =
+            MegacliteServiceBinding
+                .forService(ServiceIdentifier.DESTINATION)
+                .providerConfiguration()
+                .name("destination-paas")
+                .version("v1")
+                .build();
+        binding.setDwcConfiguration(DwcConfiguration.getInstance());
+
+        assertThatThrownBy(binding::getCredentials)
+            .isExactlyInstanceOf(CloudPlatformException.class)
+            .hasMessage("No DWC_APPLICATION environment variable found. Cannot determine provider account id.");
     }
 }

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
@@ -10,37 +10,34 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import java.net.URI;
 
 import org.junit.Test;
-import org.mockito.MockedStatic;
-import org.mockito.Mockito;
 
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
 
 public class MegacliteServiceBindingTest
 {
+    static {
+        MegacliteServiceBinding.dwcConfiguration =
+            new DwcConfiguration(URI.create("megaclite.com"), "provider-tenant-id");
+    }
+
     @Test
     public void testPropertiesOfTheOpenSourceServiceBinding()
     {
-        try( final MockedStatic<DwcConfiguration> dwcConf = Mockito.mockStatic(DwcConfiguration.class) ) {
-            dwcConf
-                .when(DwcConfiguration::getInstance)
-                .thenReturn(new DwcConfiguration(URI.create("my.megaclite.sap"), "provider-tenant-id"));
+        final ServiceBinding binding =
+            MegacliteServiceBinding
+                .forService(ServiceIdentifier.DESTINATION)
+                .providerConfiguration()
+                .name("destination-paas")
+                .version("v1")
+                .build();
 
-            final ServiceBinding binding =
-                MegacliteServiceBinding
-                    .forService(ServiceIdentifier.DESTINATION)
-                    .providerConfiguration()
-                    .name("destination-paas")
-                    .version("v1")
-                    .build();
-
-            assertThat(binding.getKeys()).isEmpty();
-            assertThat(binding.getName()).isEmpty();
-            assertThat(binding.getServiceName()).contains("destination");
-            assertThat(binding.getServicePlan()).isEmpty();
-            assertThat(binding.getTags()).isEmpty();
-            assertThat(binding.getCredentials().get("tenantid")).isEqualTo("provider-tenant-id");
-        }
+        assertThat(binding.getKeys()).isEmpty();
+        assertThat(binding.getName()).isEmpty();
+        assertThat(binding.getServiceName()).contains("destination");
+        assertThat(binding.getServicePlan()).isEmpty();
+        assertThat(binding.getTags()).isEmpty();
+        assertThat(binding.getCredentials().get("tenantid")).isEqualTo("provider-tenant-id");
     }
 
     @Test


### PR DESCRIPTION
# Pull Request Description 🤖

This PR is part of the work on backlog item [#297](https://github.com/SAP/cloud-sdk-java-backlog/issues/297). This problem was uncovered after the use of ScpCf destination API on the v5 `DwC-test-app`.

## Changes

The changes in this PR include:

- A new `dwcConfiguration` field has been added to the `MegacliteServiceBinding` class, it can be (re)set after the binding is built.
- The `getCredentials()` method in the `MegacliteServiceBinding` class has been updated to return a map containing the `tenantid` and `providerTenantId`, or, throws the Exception created by `DwcConfiguration`.
- The `testPropertiesOfTheOpenSourceServiceBinding()` method in the `MegacliteServiceBindingTest` class has been updated to include a mock of the `DwcConfiguration` class and to check that the `tenantid` is correctly set in the credentials.
- `testGetCredentialsThrowsExceptionWithoutProviderTenantId()` has been added to check that the exception created by `DwcConfiguration` is propagated.

## Reviewer Instructions

Please review the changes in the context of the associated backlog item. Ensure that the changes align with the requirements and that the updated tests cover the new functionality.