### PR TITLE
[OpenAPI] Ignore `getCustomFieldNames()` method from default Jackson serialization

### DIFF
--- a/datamodel/openapi/openapi-api-sample/pom.xml
+++ b/datamodel/openapi/openapi-api-sample/pom.xml
@@ -83,6 +83,16 @@
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-core</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.fasterxml.jackson.core</groupId>
+			<artifactId>jackson-databind</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Order.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Order.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -239,6 +240,7 @@ public class Order
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestamp.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestamp.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -279,6 +280,7 @@ public class OrderWithTimestamp
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestampAllOf.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestampAllOf.java
@@ -27,6 +27,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -84,6 +85,7 @@ public class OrderWithTimestampAllOf
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Soda.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Soda.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -200,6 +201,7 @@ public class Soda
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithId.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithId.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -239,6 +240,7 @@ public class SodaWithId
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithIdAllOf.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithIdAllOf.java
@@ -26,6 +26,7 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
@@ -83,6 +84,7 @@ public class SodaWithIdAllOf
      *
      * @return The set of properties names
      */
+    @JsonIgnore
     @Nonnull
     public Set<String> getCustomFieldNames()
     {

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/SerializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/SerializationTest.java
@@ -4,9 +4,13 @@
 
 package com.sap.cloud.sdk.datamodel.openapi.sample.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
@@ -27,7 +31,7 @@ class SerializationTest
     }
 
     @Test
-    void testPUT()
+    void testPutPayload()
     {
         // @formatter:off
         expected =
@@ -45,6 +49,26 @@ class SerializationTest
         sut.sodasPut(obj);
 
         verify(expected);
+    }
+
+    @Test
+    void testJacksonSerialization()
+        throws JsonProcessingException
+    {
+        // @formatter:off
+        expected =
+               "{\n" +
+               "  \"name\": \"Cola\",\n" +
+               "  \"brand\": \"Coca-Cola\",\n" +
+               "  \"quantity\": 100,\n" +
+               "  \"price\": 1.5,\n" +
+               "  \"id\": 0\n" +
+               "}";
+        // @formatter:on
+
+        final SodaWithId obj = new SodaWithId().id(0L).name("Cola").brand("Coca-Cola").quantity(100).price(1.5f);
+
+        assertThat(new ObjectMapper().writeValueAsString(obj)).isEqualToIgnoringWhitespace(expected);
     }
 
     private void verify( String requestBody )

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class NewSoda
    * Get the names of the unrecognizable properties of the {@link NewSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/Soda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -205,6 +206,7 @@ public class Soda
    * Get the names of the unrecognizable properties of the {@link Soda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class UpdateSoda
    * Get the names of the unrecognizable properties of the {@link UpdateSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/model.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/model.mustache
@@ -24,6 +24,7 @@ import java.io.Serializable;
 {{/serializableModel}}
 {{#jackson}}
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 {{#withXml}}

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
@@ -172,6 +172,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
    * Get the names of the unrecognizable properties of the {@link {{classname}}}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class NewSoda
    * Get the names of the unrecognizable properties of the {@link NewSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -205,6 +206,7 @@ public class Soda
    * Get the names of the unrecognizable properties of the {@link Soda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class UpdateSoda
    * Get the names of the unrecognizable properties of the {@link UpdateSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class NewSoda
    * Get the names of the unrecognizable properties of the {@link NewSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -205,6 +206,7 @@ public class Soda
    * Get the names of the unrecognizable properties of the {@link Soda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class UpdateSoda
    * Get the names of the unrecognizable properties of the {@link UpdateSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class NewSoda
    * Get the names of the unrecognizable properties of the {@link NewSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -205,6 +206,7 @@ public class Soda
    * Get the names of the unrecognizable properties of the {@link Soda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 
@@ -174,6 +175,7 @@ public class UpdateSoda
    * Get the names of the unrecognizable properties of the {@link UpdateSoda}.
    * @return The set of properties names
    */
+  @JsonIgnore
   @Nonnull
   public Set<String> getCustomFieldNames() {
     return cloudSdkCustomFields.keySet();


### PR DESCRIPTION
_(low priority)_

We had a customer issue in v4, where the complaint was default `new ObjectMapper()` was serializing a `customFieldNames : []` for every OpenAPI entity. For them it was unexpected and faulty behavior.

While the cause is based on improper _SAP Cloud SDK_ class usage, still we could have a little house-keeping here.