### PR TITLE
Change ScpCf modules behaviour with DwC bindings

### DIFF
--- a/cloudplatform/cloudplatform-connectivity-scp-cf/pom.xml
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/pom.xml
@@ -175,6 +175,11 @@
 		<!-- scope "test" -->
 		<dependency>
 			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+			<artifactId>connectivity-dwc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
 			<artifactId>servlet</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationServiceAdapter.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationServiceAdapter.java
@@ -86,13 +86,19 @@ class ScpCfDestinationServiceAdapter
         try {
             final ServiceBinding binding = serviceBindingSupplier.get();
 
-            return TypedMapView.ofCredentials(binding).getString("tenantid");
+            final TypedMapView credentials = TypedMapView.ofCredentials(binding);
+            if( credentials.containsKey("tenantid") ) {
+                return credentials.getString("tenantid");
+            }
         }
         catch( final Exception e ) {
             throw new DestinationAccessException(
                 "Could not resolve destination to Destination Service on behalf of provider.",
                 e);
         }
+        throw new DestinationAccessException(
+            "The provider tenant id is not defined in the service binding."
+                + " Please verify that the service binding contains the field 'tenantid' in the credentials list.");
     }
 
     private Function<OnBehalfOf, HttpDestination> prepareServiceDestinationComputation()

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationServiceAdapterTest.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationServiceAdapterTest.java
@@ -312,6 +312,24 @@ public class ScpCfDestinationServiceAdapterTest
             .isExactlyInstanceOf(MultipleServiceBindingsException.class);
     }
 
+    @Test
+    public void getDestinationServiceProviderTenantShouldThrowForDwcServiceBindings()
+    {
+        final MegacliteServiceBinding serviceBinding =
+            MegacliteServiceBinding
+                .forService(ServiceIdentifier.DESTINATION)
+                .providerConfiguration()
+                .name("destination-paas")
+                .version("v1")
+                .build();
+        final ScpCfDestinationServiceAdapter adapterToTest = createSut(serviceBinding);
+        assertThatThrownBy(adapterToTest::getProviderTenantId)
+            .isInstanceOf(DestinationAccessException.class)
+            .hasMessage(
+                "The provider tenant id is not defined in the service binding."
+                    + " Please verify that the service binding contains the field 'tenantid' in the credentials list.");
+    }
+
     private static ScpCfDestinationServiceAdapter createSut( @Nonnull final ServiceBinding... serviceBindings )
     {
         return new ScpCfDestinationServiceAdapter(null, () -> {

--- a/cloudplatform/cloudplatform-core-scp-cf/pom.xml
+++ b/cloudplatform/cloudplatform-core-scp-cf/pom.xml
@@ -90,6 +90,11 @@
 		</dependency>
 		<!-- scope "test" -->
 		<dependency>
+			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+			<artifactId>connectivity-dwc</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>com.sap.cloud.environment.servicebinding</groupId>
 			<artifactId>java-sap-service-operator</artifactId>
 			<scope>test</scope>

--- a/cloudplatform/cloudplatform-core-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/ScpCfCloudPlatform.java
+++ b/cloudplatform/cloudplatform-core-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/ScpCfCloudPlatform.java
@@ -307,6 +307,8 @@ public class ScpCfCloudPlatform implements CloudPlatform
             .accept(
                 "tags",
                 () -> serviceBinding.getTags().stream().collect(JsonArray::new, JsonArray::add, JsonArray::addAll));
+        // DwC: The binding doesn't have credentials, MegacliteServiceBinding either reads the DWC_APPLICATION env var
+        // and returns the map {tenantid: <ProviderTenantId>}, or, returns an empty map if DWC_APPLICATION is not found.
         converter.accept("credentials", () -> convert(TypedMapView.ofCredentials(serviceBinding)));
 
         return convertedServiceBinding;

--- a/cloudplatform/cloudplatform-core-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/ScpCfCloudPlatformTest.java
+++ b/cloudplatform/cloudplatform-core-scp-cf/src/test/java/com/sap/cloud/sdk/cloudplatform/ScpCfCloudPlatformTest.java
@@ -663,7 +663,7 @@ public class ScpCfCloudPlatformTest
 
         // sanity check
         assertThat(serviceBinding.getName()).isEmpty();
-        assertThat(serviceBinding.getServiceName()).hasValue(String.valueOf(ServiceIdentifier.DESTINATION));
+        assertThat(serviceBinding.getServiceName()).hasValue(ServiceIdentifier.DESTINATION.toString());
         assertThat(serviceBinding.getServicePlan()).isEmpty();
         assertThat(serviceBinding.getTags()).isEmpty();
         // The dwcConfiguration cannot find the DWC_APPLICATION env var, so the credentials are empty
@@ -678,6 +678,6 @@ public class ScpCfCloudPlatformTest
         final Map<String, JsonArray> parsedVcapServices = sut.getVcapServices();
 
         // assert
-        assertThat(parsedVcapServices).containsOnlyKeys(String.valueOf(ServiceIdentifier.DESTINATION));
+        assertThat(parsedVcapServices).containsOnlyKeys(ServiceIdentifier.DESTINATION.toString());
     }
 }

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -15,8 +15,8 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.Beta;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
+import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
-import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -124,11 +124,13 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Override
     public Map<String, Object> getCredentials()
     {
-        final Try<String> tenantId = Try.of(dwcConfiguration::providerTenant);
-        if( tenantId.isSuccess() ) {
-            return Collections.singletonMap("tenantid", tenantId.get());
+        try {
+            final String tenantId = dwcConfiguration.providerTenant();
+            return Collections.singletonMap("tenantid", tenantId);
         }
-        return Collections.emptyMap();
+        catch( final CloudPlatformException | IllegalArgumentException e ) {
+            return Collections.emptyMap();
+        }
     }
 
     /**

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -24,6 +24,7 @@ import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import lombok.ToString;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Represents a (remote) service that is bound to Megaclite. Therefore, the application may reach the bound service by
@@ -58,6 +59,7 @@ import lombok.ToString;
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
 @EqualsAndHashCode
 @ToString
+@Slf4j
 public final class MegacliteServiceBinding implements ServiceBinding
 {
     @Nonnull
@@ -125,10 +127,10 @@ public final class MegacliteServiceBinding implements ServiceBinding
     public Map<String, Object> getCredentials()
     {
         try {
-            final String tenantId = dwcConfiguration.providerTenant();
-            return Collections.singletonMap("tenantid", tenantId);
+            return Collections.singletonMap("tenantid", dwcConfiguration.providerTenant());
         }
         catch( final CloudPlatformException | IllegalArgumentException e ) {
+            log.debug("Failed to get the provider tenant ID from the DWC configuration.", e);
             return Collections.emptyMap();
         }
     }

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBinding.java
@@ -15,8 +15,8 @@ import javax.annotation.Nullable;
 import com.google.common.annotations.Beta;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
-import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
+import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
@@ -123,10 +123,12 @@ public final class MegacliteServiceBinding implements ServiceBinding
     @Nonnull
     @Override
     public Map<String, Object> getCredentials()
-        throws CloudPlatformException,
-            IllegalArgumentException
     {
-        return Collections.singletonMap("tenantid", dwcConfiguration.providerTenant());
+        final Try<String> tenantId = Try.of(dwcConfiguration::providerTenant);
+        if( tenantId.isSuccess() ) {
+            return Collections.singletonMap("tenantid", tenantId.get());
+        }
+        return Collections.emptyMap();
     }
 
     /**

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingTest.java
@@ -8,11 +8,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
+import java.util.Collections;
 
 import org.junit.Test;
 
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
-import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
 public class MegacliteServiceBindingTest
 {
@@ -51,7 +51,7 @@ public class MegacliteServiceBindingTest
     }
 
     @Test
-    public void testGetCredentialsThrowsExceptionWithoutProviderTenantId()
+    public void testGetCredentialsWithoutProviderTenantIdReturnsEmptyMap()
     {
         final MegacliteServiceBinding binding =
             MegacliteServiceBinding
@@ -62,8 +62,6 @@ public class MegacliteServiceBindingTest
                 .build();
         binding.setDwcConfiguration(DwcConfiguration.getInstance());
 
-        assertThatThrownBy(binding::getCredentials)
-            .isExactlyInstanceOf(CloudPlatformException.class)
-            .hasMessage("No DWC_APPLICATION environment variable found. Cannot determine provider account id.");
+        assertThat(binding.getCredentials()).isEqualTo(Collections.emptyMap());
     }
 }


### PR DESCRIPTION
## Context
DwC apps cannot call `ScpCfCloudPlatform` without the `DWC_APPLICATION` env var. This was introduced in #98.

## Solution
Here is the intended stacktrace from top to bottom
- `DwcConfiguration` throws
- then `MegacliteServiceBinding` catches and returns an empty map
- then `ScpCfCloudPlatform` works normally
-  then `ScpCfDestinationServiceAdapter` throws if the map is empty.

## Questions for the Reviewer
- What should the message thrown by `ScpCfDestinationServiceAdapter` be?
  - _Maybe it should be `"No DWC_APPLICATION environment variable defined. Cannot determine the provider account id."`. Not sure if there is a scenario in which the Adapter doesn't find `tenantid` while the binding is not DwC_
- Do the new test dependencies cause a problem?
- Is there still a need for `DwcConfiguration` to be public to help customer test their app locally without setting an env var?
- Can the Exception hidden  by `MegacliteServiceBinding.getCredentials()` cause problem for customers with broken configs?
