### PR TITLE
Fix DwC-test-app: Made `ScpCfDestinationRetrievalStrategy.ofIdentifier()` public

### DIFF
--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
@@ -66,7 +66,7 @@ public enum ScpCfDestinationRetrievalStrategy
      * @return The strategy enum value.
      */
     @Nullable
-    public static ScpCfDestinationRetrievalStrategy ofIdentifier(@Nullable final String identifier)
+    public static ScpCfDestinationRetrievalStrategy ofIdentifier( @Nullable final String identifier )
     {
         return Stream
             .of(ScpCfDestinationRetrievalStrategy.values())

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
@@ -64,6 +64,7 @@ public enum ScpCfDestinationRetrievalStrategy
      * @param identifier
      *            The string representation of a strategy.
      * @return The strategy enum value.
+     * @since 5.0.0
      */
     @Nullable
     public static ScpCfDestinationRetrievalStrategy ofIdentifier( @Nullable final String identifier )

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
@@ -58,6 +58,13 @@ public enum ScpCfDestinationRetrievalStrategy
         return identifier;
     }
 
+    /**
+     * Get the strategy by its identifier.
+     *
+     * @param identifier
+     *            The string representation of a strategy.
+     * @return The strategy enum value.
+     */
     @Nullable
     public static ScpCfDestinationRetrievalStrategy ofIdentifier(@Nullable final String identifier)
     {

--- a/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
+++ b/cloudplatform/cloudplatform-connectivity-scp-cf/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ScpCfDestinationRetrievalStrategy.java
@@ -59,7 +59,7 @@ public enum ScpCfDestinationRetrievalStrategy
     }
 
     @Nullable
-    static ScpCfDestinationRetrievalStrategy ofIdentifier( @Nullable final String identifier )
+    public static ScpCfDestinationRetrievalStrategy ofIdentifier(@Nullable final String identifier)
     {
         return Stream
             .of(ScpCfDestinationRetrievalStrategy.values())


### PR DESCRIPTION
## Context
The DwC test app previously used `DwcDestinationRetrievalStrategy.ofIdentifier()`.
The app has been changed to use ScpCf.
This new method will be used in [this DwC-test-app pull request.](https://github.wdf.sap.corp/MA/DwC-Test-App/pull/124)