### PR TITLE
fix: Blackduck copyright findings

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -36,6 +36,7 @@ jobs:
           command: detectExecuteScan
           flags: \
             --version=$PROJECT_VERSION \
+            --excludedDirectories=src \
         env:
           PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
           DETECT_MAVEN_EXCLUDED_MODULES: ${{ steps.get-maven-excludes-for-blackduck.outputs.EXCLUDES }}


### PR DESCRIPTION
# Pull Request Description 🤖

This PR addresses the backlog item [#319](https://github.com/SAP/cloud-sdk-java-backlog/issues/319) - Fix Blackduck v5 findings.

## Context

Blackduck keeps finding our own java files as violating copyright on previous releases of our own java files. 

## Changes

The change in this PR is a modification to the `.github/workflows/blackduck.yaml` file. Specifically, an additional flag `--excludedDirectories=src` has been added to the `detectExecuteScan` command. This change is intended to exclude our own Java files from the Blackduck scan.

## Reviewer Instructions

Please review the change to ensure that it correctly excludes the `src` directory from the Blackduck scan. Also, please verify that this change does not inadvertently exclude other necessary directories or files from the scan.
[Blackduck action run](https://github.com/SAP/cloud-sdk-java/actions/runs/6689806311/job/18173969852)

## Next steps

This change can be brought over to the v4 scan.