### PR TITLE
Fix: Silently Ignore Resilience for multiple `ResilienceDecorationStrategies`

### DIFF
--- a/cloudplatform/resilience/pom.xml
+++ b/cloudplatform/resilience/pom.xml
@@ -87,5 +87,10 @@
 			<artifactId>junit-jupiter-api</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-core</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 </project>

--- a/cloudplatform/resilience/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceDecorator.java
+++ b/cloudplatform/resilience/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceDecorator.java
@@ -404,9 +404,9 @@ public final class ResilienceDecorator
         @Nonnull
         @Override
         public <T> Supplier<T> decorateSupplier(
-            @Nonnull Supplier<T> supplier,
-            @Nonnull ResilienceConfiguration configuration,
-            @Nullable Function<? super Throwable, T> fallbackFunction )
+            @Nonnull final Supplier<T> supplier,
+            @Nonnull final ResilienceConfiguration configuration,
+            @Nullable final Function<? super Throwable, T> fallbackFunction )
         {
             throw exception;
         }
@@ -414,9 +414,9 @@ public final class ResilienceDecorator
         @Nonnull
         @Override
         public <T> Callable<T> decorateCallable(
-            @Nonnull Callable<T> callable,
-            @Nonnull ResilienceConfiguration configuration,
-            @Nullable Function<? super Throwable, T> fallbackFunction )
+            @Nonnull final Callable<T> callable,
+            @Nonnull final ResilienceConfiguration configuration,
+            @Nullable final Function<? super Throwable, T> fallbackFunction )
         {
             throw exception;
         }

--- a/cloudplatform/resilience/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceDecoratorTest.java
+++ b/cloudplatform/resilience/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceDecoratorTest.java
@@ -1,0 +1,81 @@
+package com.sap.cloud.sdk.cloudplatform.resilience;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import java.util.stream.Collectors;
+
+import javax.annotation.Nonnull;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+
+import com.sap.cloud.sdk.cloudplatform.exception.ObjectLookupFailedException;
+import com.sap.cloud.sdk.cloudplatform.util.FacadeLocator;
+
+public class ResilienceDecoratorTest
+{
+    @Before
+    @After
+    public void resetFacadeLocator()
+    {
+        FacadeLocator.setMockableInstance(new FacadeLocator.MockableInstance());
+    }
+
+    @Test
+    public void testGetDefaultDecorationStrategyReturnsSingleInstance()
+    {
+        final ResilienceDecorationStrategy singleStrategy = mock(ResilienceDecorationStrategy.class);
+        mockDecorationStrategies(singleStrategy);
+
+        assertThat(ResilienceDecorator.getDefaultDecorationStrategy()).isSameAs(singleStrategy);
+    }
+
+    @Test
+    public void testGetDefaultDecorationStrategyReturnsNoResilience()
+    {
+        mockDecorationStrategies();
+
+        assertThat(ResilienceDecorator.getDefaultDecorationStrategy())
+            .isExactlyInstanceOf(NoResilienceDecorationStrategy.class);
+    }
+
+    @Test
+    public void testGetDefaultDecorationStrategyReturnsThrowingStrategy()
+    {
+        final ResilienceDecorationStrategy firstStrategy = mock(ResilienceDecorationStrategy.class);
+        final ResilienceDecorationStrategy secondInstance = mock(ResilienceDecorationStrategy.class);
+        mockDecorationStrategies(firstStrategy, secondInstance);
+
+        assertThat(ResilienceDecorator.getDefaultDecorationStrategy())
+            .isExactlyInstanceOf(ResilienceDecorator.ThrowingResilienceDecorationStrategy.class);
+    }
+
+    @Test
+    public void testThrowingStrategyThrowsTheSameInstance()
+    {
+        final ObjectLookupFailedException expected = new ObjectLookupFailedException("test exception");
+        final ResilienceConfiguration configuration = ResilienceConfiguration.empty("test configuration");
+
+        final ResilienceDecorationStrategy sut = new ResilienceDecorator.ThrowingResilienceDecorationStrategy(expected);
+
+        assertThatThrownBy(() -> sut.decorateCallable(() -> null, configuration)).isSameAs(expected);
+        assertThatThrownBy(() -> sut.decorateCallable(() -> null, configuration)).isSameAs(expected);
+        assertThatThrownBy(() -> sut.decorateSupplier(() -> null, configuration)).isSameAs(expected);
+        assertThatThrownBy(() -> sut.decorateSupplier(() -> null, configuration)).isSameAs(expected);
+    }
+
+    private static void mockDecorationStrategies( @Nonnull final ResilienceDecorationStrategy... strategies )
+    {
+        final FacadeLocator.MockableInstance facadeLocator = mock(FacadeLocator.MockableInstance.class);
+        when(facadeLocator.getFacades(eq(ResilienceDecorationStrategy.class)))
+            .thenReturn(Arrays.stream(strategies).collect(Collectors.toList()));
+
+        FacadeLocator.setMockableInstance(facadeLocator);
+    }
+}


### PR DESCRIPTION
## Context

BLI: https://github.com/SAP/cloud-sdk-java-backlog/issues/337

This change is ported over from our `main/v4` fix: https://github.wdf.sap.corp/MA/sdk/pull/8633

**Note:** No release notes needed as the issue will also be fixed in V4 and, therefore, nothing has changed in our V5 release from the consumers' perspective.