### PR TITLE
Migrate OData header deduplication

### DIFF
--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.java
@@ -162,6 +162,20 @@ public abstract class ODataRequestGeneric implements ODataRequestExecutable
     }
 
     /**
+     * Replace a header with multiple values in the OData HTTP request.
+     *
+     * @param key
+     *            The header name.
+     * @param values
+     *            The header values.
+     * @since 4.27.0
+     */
+    public void setHeader( @Nonnull final String key, @Nonnull final Collection<String> values )
+    {
+        headers.put(key, new ArrayList<>(values));
+    }
+
+    /**
      * Add a header to the OData HTTP request.
      *
      * @param key

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
@@ -713,7 +713,7 @@ public class ODataRequestResultGeneric
                 request.getProtocol());
 
         // populate headers
-        request.getHeaders().forEach(( k, values ) -> values.forEach(v -> nextReadRequest.addHeader(k, v)));
+        request.getHeaders().forEach(nextReadRequest::setHeader);
 
         // execute request
         return Try.of(() -> nextReadRequest.execute(httpClient));

--- a/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGenericTest.java
+++ b/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGenericTest.java
@@ -7,6 +7,7 @@ package com.sap.cloud.sdk.datamodel.odata.client.request;
 import static org.apache.http.HttpVersion.HTTP_1_1;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.assertj.core.api.Assertions.entry;
 import static org.assertj.core.api.SoftAssertions.assertSoftly;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
@@ -15,10 +16,15 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.net.SocketException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Map;
 
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
+import org.apache.http.client.HttpClient;
+import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
 import org.apache.http.message.BasicHttpResponse;
 import org.junit.jupiter.api.Test;
@@ -131,5 +137,33 @@ class ODataRequestResultGenericTest
 
         assertThat(result.getHeaderValues("someOtherKey")).containsExactly("someOtherValue");
         assertThat(result.getHeaderValues("SOMEotherKEY")).containsExactly("someOtherValue");
+    }
+
+    @Test
+    @SneakyThrows
+    public void ensureNoRedundantHeadersForPaginatedRequests()
+    {
+        final ODataRequestGeneric oDataRequest =
+            new ODataRequestRead("generic/service/path", "entity(123)", null, ODataProtocol.V4);
+
+        final BasicHttpResponse httpResponse = new BasicHttpResponse(HTTP_1_1, 200, "OK");
+        final String json = "{\"value\":[],\"@odata.nextLink\": \"Foo?$count=true&$select=BarID&$skiptoken='ABCD'\"}";
+        httpResponse.setEntity(new StringEntity(json));
+
+        final HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.execute(any())).thenReturn(httpResponse);
+
+        final ODataRequestResultGeneric testResult =
+            new ODataRequestResultGeneric(oDataRequest, httpResponse, httpClient);
+
+        ODataRequestResultGeneric nextResult = testResult.tryGetNextPage().get();
+        nextResult = nextResult.tryGetNextPage().get();
+        nextResult = nextResult.tryGetNextPage().get();
+        nextResult = nextResult.tryGetNextPage().get();
+        nextResult = nextResult.tryGetNextPage().get();
+        nextResult = nextResult.tryGetNextPage().get();
+
+        final Map<String, Collection<String>> lastRequestHeaders = nextResult.getODataRequest().getHeaders();
+        assertThat(lastRequestHeaders).containsExactly(entry("Accept", Collections.singletonList("application/json")));
     }
 }


### PR DESCRIPTION
This ports the change done in https://github.wdf.sap.corp/MA/sdk/pull/8631 from v4 to v5.