### PR TITLE
fix: Improve exception handling in ODataRequestResultMultipartGeneric class

### DIFF
--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -94,17 +94,17 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
         }
 
         log.debug("Looking for request {} in batch response at position {}", request, responsePosition);
-        final List<List<HttpResponse>> batchedResponse = getBatchedResponses();
-        if( batchedResponse.size() <= responsePosition._1() ) {
+        final List<List<HttpResponse>> batchResponseItems = getBatchedResponses();
+        if( responsePosition._1() >= batchResponseItems.size() ) {
             final String msg =
                 "Illegal OData response: at least "
                     + (responsePosition._1() + 1)
                     + " batch requests were executed, but the OData server returned only "
-                    + batchedResponse.size()
+                    + batchResponseItems.size()
                     + " batch responses.";
             throw new ODataResponseException(batchRequest, httpResponse, msg, null);
         }
-        final List<HttpResponse> subResponses = batchedResponse.get(responsePosition._1());
+        final List<HttpResponse> subResponses = batchResponseItems.get(responsePosition._1());
 
         final boolean isSingleResponse = responsePosition._2() == null || responsePosition._2() >= subResponses.size();
         final HttpResponse response = subResponses.get(isSingleResponse ? 0 : responsePosition._2());

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -96,12 +96,8 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
         log.debug("Looking for request {} in batch response at position {}", request, responsePosition);
         final List<List<HttpResponse>> batchResponseItems = getBatchedResponses();
         if( responsePosition._1() >= batchResponseItems.size() ) {
-            final String msg =
-                "Illegal OData response: at least "
-                    + (responsePosition._1() + 1)
-                    + " batch requests were executed, but the OData server returned only "
-                    + batchResponseItems.size()
-                    + " batch responses.";
+            String msg = "Unable to extract batch response item at position %s. The response contains only %s items.";
+            msg = String.format(msg, responsePosition._1() + 1, batchResponseItems.size());
             throw new ODataResponseException(batchRequest, httpResponse, msg, null);
         }
         final List<HttpResponse> subResponses = batchResponseItems.get(responsePosition._1());

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -97,10 +97,10 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
         final List<List<HttpResponse>> batchedResponse = getBatchedResponses();
         if( batchedResponse.size() <= responsePosition._1() ) {
             final String msg =
-                "Illegal batch response item size: "
+                "Illegal batch response size: "
                     + batchedResponse.size()
-                    + ". Lower than requested size: "
-                    + responsePosition._1();
+                    + ". Lower than "
+                    + (responsePosition._1() + 1);
             throw new ODataResponseException(batchRequest, httpResponse, msg, null);
         }
         final List<HttpResponse> subResponses = batchedResponse.get(responsePosition._1());

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -95,10 +95,11 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
 
         log.debug("Looking for request {} in batch response at position {}", request, responsePosition);
         final List<List<HttpResponse>> batchedResponse = getBatchedResponses();
-        if( batchRequest.getRequests().size() != batchedResponse.size() ) {
-            final String msg = "Unexpected OData response: "
-                    + batchRequest.getRequests().size()
-                    + " batch requests were executed, but the OData server returned "
+        if( batchedResponse.size() <= responsePosition._1() ) {
+            final String msg =
+                "Illegal OData response: at least "
+                    + (responsePosition._1() + 1)
+                    + " batch requests were executed, but the OData server returned only "
                     + batchedResponse.size()
                     + " batch responses.";
             throw new ODataResponseException(batchRequest, httpResponse, msg, null);

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -94,7 +94,16 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
         }
 
         log.debug("Looking for request {} in batch response at position {}", request, responsePosition);
-        final List<HttpResponse> subResponses = getBatchedResponses().get(responsePosition._1());
+        final List<List<HttpResponse>> batchedResponse = getBatchedResponses();
+        if( batchedResponse.size() <= responsePosition._1() ) {
+            final String msg =
+                "Illegal batch response item size: "
+                    + batchedResponse.size()
+                    + ". Lower than requested size: "
+                    + responsePosition._1();
+            throw new ODataResponseException(batchRequest, httpResponse, msg, null);
+        }
+        final List<HttpResponse> subResponses = batchedResponse.get(responsePosition._1());
 
         final boolean isSingleResponse = responsePosition._2() == null || responsePosition._2() >= subResponses.size();
         final HttpResponse response = subResponses.get(isSingleResponse ? 0 : responsePosition._2());

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -95,12 +95,12 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
 
         log.debug("Looking for request {} in batch response at position {}", request, responsePosition);
         final List<List<HttpResponse>> batchedResponse = getBatchedResponses();
-        if( batchedResponse.size() <= responsePosition._1() ) {
-            final String msg =
-                "Illegal batch response size: "
+        if( batchRequest.getRequests().size() != batchedResponse.size() ) {
+            final String msg = "Unexpected OData response: "
+                    + batchRequest.getRequests().size()
+                    + " batch requests were executed, but the OData server returned "
                     + batchedResponse.size()
-                    + ". Lower than "
-                    + (responsePosition._1() + 1);
+                    + " batch responses.";
             throw new ODataResponseException(batchRequest, httpResponse, msg, null);
         }
         final List<HttpResponse> subResponses = batchedResponse.get(responsePosition._1());

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
@@ -121,12 +121,17 @@ public class ODataClientBatchResponseParsingUnitTest
         final String responseBody = readResourceFileCrlf("BatchOnlyReadsMissingResponse.txt");
 
         // Prepare test objects
-        final ODataEntityKey entityKey1 = new ODataEntityKey(V4).addKeyProperty("key", "klauskinski");
+        final ODataEntityKey entityKey1 = new ODataEntityKey(V4).addKeyProperty("key", "one");
         final ODataRequestReadByKey readByKey1 = new ODataRequestReadByKey("/", "People", entityKey1, "", V4);
-        final ODataEntityKey entityKey2 = new ODataEntityKey(V4).addKeyProperty("key", "DanielBruehl");
+        final ODataEntityKey entityKey2 = new ODataEntityKey(V4).addKeyProperty("key", "two");
         final ODataRequestReadByKey readByKey2 = new ODataRequestReadByKey("/", "People", entityKey2, "", V4);
+        final ODataEntityKey entityKey3 = new ODataEntityKey(V4).addKeyProperty("key", "three");
+        final ODataRequestReadByKey readByKey3 = new ODataRequestReadByKey("/", "People", entityKey3, "", V4);
         final ODataRequestBatch batchRequest =
-            new ODataRequestBatch("/", V4, uuidProvider).addReadByKey(readByKey1).addReadByKey(readByKey2);
+            new ODataRequestBatch("/", V4, uuidProvider)
+                .addReadByKey(readByKey1)
+                .addReadByKey(readByKey2)
+                .addReadByKey(readByKey3);
 
         final HttpClient httpClient = MockedHttpClient.of(requestBody, responseBody);
         final ODataRequestResultMultipartGeneric batchResponse = batchRequest.execute(httpClient);
@@ -136,15 +141,18 @@ public class ODataClientBatchResponseParsingUnitTest
         assertThat(batchResponse.getHttpResponse().getStatusLine().getStatusCode()).isEqualTo(200);
 
         // Test assertion:
-        // response payload is 404
+        // response payload1 is 200
+        assertThat(batchResponse.getResult(readByKey1)).isNotNull();
+
+        // response payload2 is 404
         assertThatExceptionOfType(ODataServiceErrorException.class)
-            .isThrownBy(() -> batchResponse.getResult(readByKey1))
-            .satisfies(e -> assertThat(e.getHttpCode()).isEqualTo(404));
-        // response payload cannot be extracted, response is missing
-        assertThatExceptionOfType(ODataResponseException.class)
             .isThrownBy(() -> batchResponse.getResult(readByKey2))
-            .withMessage(
-                "Illegal OData response: at least 2 batch requests were executed, but the OData server returned only 1 batch responses.");
+            .satisfies(e -> assertThat(e.getHttpCode()).isEqualTo(404));
+
+        // response payload3 cannot be extracted, response is missing
+        assertThatExceptionOfType(ODataResponseException.class)
+            .isThrownBy(() -> batchResponse.getResult(readByKey3))
+            .withMessage("Unable to extract batch response item at position 3. The response contains only 2 items.");
     }
 
     @Test

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
@@ -137,11 +137,12 @@ public class ODataClientBatchResponseParsingUnitTest
         assertThat(batchResponse.getHttpResponse().getStatusLine().getStatusCode()).isEqualTo(200);
 
         // Test assertion: response payload cannot be extracted, DanielBruehl is missing
-        final List<Person> resultRead1 = batchResponse.getResult(readByKey1).asList(Person.class);
-        assertThat(resultRead1).isNotNull().hasSize(1).doesNotContainNull();
+        assertThatThrownBy(() -> batchResponse.getResult(readByKey1))
+                .isExactlyInstanceOf(ODataResponseException.class)
+                .hasMessage("Unexpected OData response: 2 batch requests were executed, but the OData server returned 1 batch responses.");
         assertThatThrownBy(() -> batchResponse.getResult(readByKey2))
             .isExactlyInstanceOf(ODataResponseException.class)
-            .hasMessage("Illegal batch response size: 1. Lower than 2");
+            .hasMessage("Unexpected OData response: 2 batch requests were executed, but the OData server returned 1 batch responses.");
     }
 
     @Test

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingRequest.txt
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingRequest.txt
@@ -3,7 +3,7 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 1
 
-GET People(%27klauskinski%27) HTTP/1.1
+GET People(%27one%27) HTTP/1.1
 Accept: application/json
 
 
@@ -12,7 +12,16 @@ Content-Type: application/http
 Content-Transfer-Encoding: binary
 Content-ID: 2
 
-GET People(%27DanielBruehl%27) HTTP/1.1
+GET People(%27two%27) HTTP/1.1
+Accept: application/json
+
+
+--batch_00000000-0000-0000-0000-000000000001
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 3
+
+GET People(%27three%27) HTTP/1.1
 Accept: application/json
 
 

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingRequest.txt
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingRequest.txt
@@ -1,0 +1,19 @@
+--batch_00000000-0000-0000-0000-000000000001
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 1
+
+GET People(%27klauskinski%27) HTTP/1.1
+Accept: application/json
+
+
+--batch_00000000-0000-0000-0000-000000000001
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+Content-ID: 2
+
+GET People(%27DanielBruehl%27) HTTP/1.1
+Accept: application/json
+
+
+--batch_00000000-0000-0000-0000-000000000001--

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
@@ -2,11 +2,11 @@
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-HTTP/1.1 200 OK
+HTTP/1.1 404 Not Found
 Content-Type: application/json; odata.metadata=minimal; odata.streaming=true
 OData-Version: 4.0
 
 
-{"@odata.context":"https://services.odata.org/TripPinRESTierService/(S(w3zgpoiit3rigb4hkixmletd))/$metadata#People","value":[{"UserName":"klauskinski","FirstName":"Klaus","LastName":"Kinski"}]}
+{"error":{"code":"","message":"The request resource is not found."}}
 --batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef--
 

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
@@ -1,0 +1,12 @@
+--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 200 OK
+Content-Type: application/json; odata.metadata=minimal; odata.streaming=true
+OData-Version: 4.0
+
+
+{"@odata.context":"https://services.odata.org/TripPinRESTierService/(S(w3zgpoiit3rigb4hkixmletd))/$metadata#People","value":[{"UserName":"klauskinski","FirstName":"Klaus","LastName":"Kinski"}]}
+--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef--
+

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/ODataClientBatchResponseParsingUnitTest/BatchOnlyReadsMissingResponse.txt
@@ -2,10 +2,18 @@
 Content-Type: application/http
 Content-Transfer-Encoding: binary
 
-HTTP/1.1 404 Not Found
+HTTP/1.1 200 OK
 Content-Type: application/json; odata.metadata=minimal; odata.streaming=true
 OData-Version: 4.0
 
+{"@odata.context":"https://services.odata.org/TripPinRESTierService/(S(w3zgpoiit3rigb4hkixmletd))/$metadata#People","value":[{"UserName":"one"}]}
+--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef
+Content-Type: application/http
+Content-Transfer-Encoding: binary
+
+HTTP/1.1 404 Not Found
+Content-Type: application/json; odata.metadata=minimal; odata.streaming=true
+OData-Version: 4.0
 
 {"error":{"code":"","message":"The request resource is not found."}}
 --batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef--


### PR DESCRIPTION
# Pull Request Description 🤖

## Summary
**This PR is a cherry-pick of a [v4 PR](https://github.wdf.sap.corp/MA/sdk/pull/8636#top).** It addresses the issue raised in the backlog item [#342](https://github.com/SAP/cloud-sdk-java-backlog/issues/342). It improves the exception handling in the `ODataRequestResultMultipartGeneric` class by providing a more informative error message when an `IndexOutOfBoundsException` is encountered.

## Changes
The main change is in the `ODataRequestResultMultipartGeneric` class. Previously, if a subrequest in a batch returned a status code such as 400, an `IndexOutOfBoundsException` would be thrown. This has been replaced with an `ODataResponseException` that provides a more informative error message. The error message indicates the position of the missing batch response item and the total number of items in the response.

In addition, a new unit test has been added to the `ODataClientBatchResponseParsingUnitTest` class to verify the new behavior. This test checks that the correct exception is thrown when a batch response item is missing.

## Testing
The new behavior has been verified with a unit test. The test checks that an `ODataResponseException` is thrown when a batch response item is missing, and that the error message is as expected.

## Reviewer Notes
Please verify that the new error message provides sufficient information to diagnose the issue. Also, please check that the new unit test covers all relevant cases.

## Stakeholder
The changes in this PR address the issue raised by the stakeholder in this [issue](https://github.wdf.sap.corp/MA/sdk/issues/8635).