### PR TITLE
feat: Improve OAuthDestinationBuilder

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
@@ -5,8 +5,6 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import java.time.Duration;
-import java.util.Collections;
-import java.util.Map;
 import java.util.UUID;
 
 import javax.annotation.Nonnull;
@@ -73,9 +71,9 @@ public class OAuth2DestinationBuilder
          * @since 4.10.0
          */
         @Nonnull
-        DefaultHttpDestination.Builder withClient( @Nonnull final ClientIdentity clientIdentity, @Nonnull final OnBehalfOf behalf );
+        DefaultHttpDestination.Builder
+            withClient( @Nonnull final ClientIdentity clientIdentity, @Nonnull final OnBehalfOf behalf );
     }
-
 
     /**
      * Static factory method to initialize a fluent API builder.

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
@@ -73,60 +73,9 @@ public class OAuth2DestinationBuilder
          * @since 4.10.0
          */
         @Nonnull
-        BuilderWithClient withClient( @Nonnull final ClientIdentity clientIdentity, @Nonnull final OnBehalfOf behalf );
+        DefaultHttpDestination.Builder withClient( @Nonnull final ClientIdentity clientIdentity, @Nonnull final OnBehalfOf behalf );
     }
 
-    /**
-     * Helper interface to serve optional properties.
-     *
-     * @since 4.10.0
-     */
-    @FunctionalInterface
-    @Beta
-    public interface BuilderWithClient
-    {
-        /**
-         * Apply destination properties.
-         *
-         * @param properties
-         *            The destination properties.
-         * @return The same builder instance.
-         * @since 4.10.0
-         */
-        @Nonnull
-        BuilderWithProperties withProperties( @Nonnull final Map<String, String> properties );
-
-        /**
-         * Finalize build process.
-         *
-         * @return A new {@link HttpDestination} instance.
-         * @since 4.10.0
-         */
-        @Nonnull
-        default HttpDestination build()
-        {
-            return withProperties(Collections.emptyMap()).build();
-        }
-    }
-
-    /**
-     * Helper interface to serve build method.
-     *
-     * @since 4.10.0
-     */
-    @FunctionalInterface
-    @Beta
-    public interface BuilderWithProperties
-    {
-        /**
-         * Finalize build process.
-         *
-         * @return A new {@link HttpDestination} instance.
-         * @since 4.10.0
-         */
-        @Nonnull
-        HttpDestination build();
-    }
 
     /**
      * Static factory method to initialize a fluent API builder.
@@ -139,7 +88,7 @@ public class OAuth2DestinationBuilder
     @Nonnull
     public static BuilderWithTargetUrl forTargetUrl( @Nonnull final String targetUrl )
     {
-        return ( tokenUrl ) -> ( client, behalf ) -> ( properties ) -> () -> {
+        return ( tokenUrl ) -> ( client, behalf ) -> {
             final OAuth2ServiceImpl oauth2service = new OAuth2ServiceImpl(tokenUrl, client, behalf);
             final DefaultHttpDestination.Builder destinationBuilder = DefaultHttpDestination.builder(targetUrl);
 
@@ -147,16 +96,13 @@ public class OAuth2DestinationBuilder
             final String destinationName = UUID.randomUUID().toString();
             destinationBuilder.name(destinationName);
 
-            properties.forEach(destinationBuilder::property);
-
             destinationBuilder
                 .property(
                     OAuthHeaderProvider.PROPERTY_OAUTH2_RESILIENCE_CONFIG,
                     createTokenRetrievalResilienceConfiguration(destinationName));
 
             return destinationBuilder
-                .headerProviders(new OAuthHeaderProvider(oauth2service, HttpHeaders.AUTHORIZATION))
-                .build();
+                .headerProviders(new OAuthHeaderProvider(oauth2service, HttpHeaders.AUTHORIZATION));
         };
     }
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilderTest.java
@@ -20,7 +20,6 @@ import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMoc
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.Collection;
-import java.util.Collections;
 
 import org.apache.http.HttpResponse;
 import org.apache.http.client.methods.HttpGet;
@@ -120,16 +119,17 @@ public class OAuth2DestinationBuilderTest
     }
 
     @Test
-    public void testOtherBuilderMethodsCanBeUsed() {
+    public void testOtherBuilderMethodsCanBeUsed()
+    {
         final DefaultHttpDestination destination =
-                OAuth2DestinationBuilder
-                    .forTargetUrl(mockServer.baseUrl())
-                    .withTokenEndpoint(mockServer.baseUrl())
-                    .withClient(new ClientCredentials("clientid", "clientsecret"), OnBehalfOf.NAMED_USER_CURRENT_TENANT)
-                    .name("my-destination")
-                    .header("my-header", "my-value")
-                    .property("foo", "bar")
-                    .build();
+            OAuth2DestinationBuilder
+                .forTargetUrl(mockServer.baseUrl())
+                .withTokenEndpoint(mockServer.baseUrl())
+                .withClient(new ClientCredentials("clientid", "clientsecret"), OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                .name("my-destination")
+                .header("my-header", "my-value")
+                .property("foo", "bar")
+                .build();
         assertThat(destination.get(DestinationProperty.NAME)).contains("my-destination");
         assertThat(destination.get("foo")).contains("bar");
         assertThat(destination.customHeaders).containsExactly(new Header("my-header", "my-value"));

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilderTest.java
@@ -70,7 +70,6 @@ public class OAuth2DestinationBuilderTest
                 .forTargetUrl(mockServer.baseUrl())
                 .withTokenEndpoint(mockServer.baseUrl())
                 .withClient(new ClientCredentials("clientid", "clientsecret"), OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT)
-                .withProperties(Collections.singletonMap("foo", "bar"))
                 .build();
 
         // direct invocation test assertion
@@ -98,7 +97,6 @@ public class OAuth2DestinationBuilderTest
                 .forTargetUrl(mockServer.baseUrl())
                 .withTokenEndpoint(mockServer.baseUrl())
                 .withClient(new ClientCredentials("clientid", "clientsecret"), OnBehalfOf.NAMED_USER_CURRENT_TENANT)
-                .withProperties(Collections.singletonMap("foo", "bar"))
                 .build();
 
         final String token = JwtGenerator.getInstance(Service.XSUAA, "client-id").createToken().getTokenValue();
@@ -119,5 +117,22 @@ public class OAuth2DestinationBuilderTest
         mockServer.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing(token)));
         mockServer.verify(1, getRequestedFor(urlEqualTo("/")).withHeader("Authorization", equalTo("Bearer PERSONAL")));
         AuthTokenAccessor.setAuthTokenFacade(null);
+    }
+
+    @Test
+    public void testOtherBuilderMethodsCanBeUsed() {
+        final DefaultHttpDestination destination =
+                OAuth2DestinationBuilder
+                    .forTargetUrl(mockServer.baseUrl())
+                    .withTokenEndpoint(mockServer.baseUrl())
+                    .withClient(new ClientCredentials("clientid", "clientsecret"), OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                    .name("my-destination")
+                    .header("my-header", "my-value")
+                    .property("foo", "bar")
+                    .build();
+        assertThat(destination.get(DestinationProperty.NAME)).contains("my-destination");
+        assertThat(destination.get("foo")).contains("bar");
+        assertThat(destination.customHeaders).containsExactly(new Header("my-header", "my-value"));
+
     }
 }

--- a/release_notes_next_major.md
+++ b/release_notes_next_major.md
@@ -167,6 +167,9 @@ blog: https://blogs.sap.com/?p=xxx
   - The `BearerCredentials` behavior has been adjusted slightly: The `getToken()` method no longer just returns the value passed in via the constructor but instead is now guaranteed to **NOT** contain the prefix `"Bearer "`. To compensate this change, the `#getHttpHeaderValue()` method has been added, which is guaranteed to contain the `"Bearer "` prefix.
   - Invoking `HttpDestination#getHeaders(...)` may throw a `ResilienceRuntimeException` in case On-Premise Connectivity proxy headers cannot be resolved.
     As usual, the specific error cause is attached to the exception.
+  - The deprecated `ClientCredentialsHttpDestination` has been removed in favor of the improved `OAuth2DestinationBuilder`.
+  - The `OAuth2DestinationBuilder` has been changed to allow for setting arbitrary destination properties after the OAuth2 configuration has been set.
+    - The `.withProperties(..)` aspect of the builder has been replaced with `.withProperty(..)`.
 - The following classes have been moved or their modules have been renamed:
   - All classes related to the Apache Http Client 4 have been moved from `com.sap.cloud.sdk.cloudplatform:cloudplatform-connectivity` to a new module `com.sap.cloud.sdk.cloudplatform:connectivity-apache-httpclient4`
   - All classes related to the Apache Http Client 5 have been moved from `com.sap.cloud.sdk.frameworks:apache-httpclient5` to `com.sap.cloud.sdk.cloudplatform:connectivity-apache-httpclient5`


### PR DESCRIPTION
## Context

Small improvement inspired by the requirement to set a custom name [here](https://github.com/cap-js/docs/pull/534/files#diff-81ee32ad88239ef1cf29d9f9cc1553192e5ec7e6d480c4be3868979f20db7416L284).

This is enabled by the recent improvements we did to the destination and its builder 🥳

