### PR TITLE
Revert "chore: update caffeine major version"

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -68,7 +68,7 @@
 		<commons-lang3.version>3.13.0</commons-lang3.version>
 		<!-- Soap requests -->
 		<!-- Resilience & Caching -->
-		<caffeine.version>3.1.8</caffeine.version>
+		<caffeine.version>2.9.3</caffeine.version>
 		<jcache.version>1.1.1</jcache.version>
 		<resilience4j.version>1.7.1</resilience4j.version>
 		<!-- JSON & XML stuff -->

--- a/pom.xml
+++ b/pom.xml
@@ -110,7 +110,7 @@
 		<maven-plugin.version>3.8.1</maven-plugin.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<restassured.version>5.0.1</restassured.version>
-		<caffeine.version>3.1.8</caffeine.version>
+		<caffeine.version>2.9.3</caffeine.version>
 		<javax-javaee.version>8.0.1</javax-javaee.version>
 		<!-- Keep TomEE version in sync with com.sap.cloud.sjb.cf:cf-tomee7-bom -->
 		<arquillian-tomee.version>7.0.7</arquillian-tomee.version>

--- a/release_notes_next_major.md
+++ b/release_notes_next_major.md
@@ -220,11 +220,6 @@ blog: https://blogs.sap.com/?p=xxx
 - `Destination#asHttp()` no longer throws an exception in case the `Destination` originates from the Destination service and the attached auth token contains an error.
   Instead, an exception will be thrown upon invoking the `getHeaders()` method, for example, during request execution.
 
-- Dependency Updates:
-  - Other dependency updates:
-    - Major version updates:
-      - Update `com.github.ben-manes.caffeine:caffeine` from `2.9.3` to `3.1.8`
-
 ## fixedIssues
 
 - Fixed a bug where an `Authorization` header was attached multiple times to outgoing HTTP requests under some circumstances


### PR DESCRIPTION
Reverts SAP/cloud-sdk-java#131

Revert this dependency update since it broke out Java 8 compatibility.