### PR TITLE
fix: Update wiremock dependency

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient4/pom.xml
+++ b/cloudplatform/connectivity-apache-httpclient4/pom.xml
@@ -140,8 +140,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-apache-httpclient4/pom.xml
+++ b/cloudplatform/connectivity-apache-httpclient4/pom.xml
@@ -140,8 +140,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-apache-httpclient5/pom.xml
+++ b/cloudplatform/connectivity-apache-httpclient5/pom.xml
@@ -114,8 +114,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-apache-httpclient5/pom.xml
+++ b/cloudplatform/connectivity-apache-httpclient5/pom.xml
@@ -114,8 +114,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-destination-service/pom.xml
+++ b/cloudplatform/connectivity-destination-service/pom.xml
@@ -187,8 +187,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-destination-service/pom.xml
+++ b/cloudplatform/connectivity-destination-service/pom.xml
@@ -187,8 +187,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-oauth/pom.xml
+++ b/cloudplatform/connectivity-oauth/pom.xml
@@ -160,8 +160,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-oauth/pom.xml
+++ b/cloudplatform/connectivity-oauth/pom.xml
@@ -160,8 +160,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/security/pom.xml
+++ b/cloudplatform/security/pom.xml
@@ -107,8 +107,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/security/pom.xml
+++ b/cloudplatform/security/pom.xml
@@ -107,8 +107,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/datamodel-metadata-generator/pom.xml
+++ b/datamodel/datamodel-metadata-generator/pom.xml
@@ -123,8 +123,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/datamodel/datamodel-metadata-generator/pom.xml
+++ b/datamodel/datamodel-metadata-generator/pom.xml
@@ -123,8 +123,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/datamodel/odata-client/pom.xml
+++ b/datamodel/odata-client/pom.xml
@@ -114,8 +114,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata-client/pom.xml
+++ b/datamodel/odata-client/pom.xml
@@ -114,8 +114,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata-v4/odata-v4-api-sample/pom.xml
+++ b/datamodel/odata-v4/odata-v4-api-sample/pom.xml
@@ -99,8 +99,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata-v4/odata-v4-api-sample/pom.xml
+++ b/datamodel/odata-v4/odata-v4-api-sample/pom.xml
@@ -99,8 +99,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata-v4/odata-v4-core/pom.xml
+++ b/datamodel/odata-v4/odata-v4-core/pom.xml
@@ -145,8 +145,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata-v4/odata-v4-core/pom.xml
+++ b/datamodel/odata-v4/odata-v4-core/pom.xml
@@ -145,8 +145,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata/odata-api-sample/pom.xml
+++ b/datamodel/odata/odata-api-sample/pom.xml
@@ -110,8 +110,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata/odata-api-sample/pom.xml
+++ b/datamodel/odata/odata-api-sample/pom.xml
@@ -110,8 +110,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata/odata-core/pom.xml
+++ b/datamodel/odata/odata-core/pom.xml
@@ -139,8 +139,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata/odata-core/pom.xml
+++ b/datamodel/odata/odata-core/pom.xml
@@ -139,8 +139,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/odata/odata-core/pom.xml
+++ b/datamodel/odata/odata-core/pom.xml
@@ -139,8 +139,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>
@@ -151,21 +151,6 @@
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter-params</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-server</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-io</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>org.eclipse.jetty</groupId>
-			<artifactId>jetty-util</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/openapi/openapi-api-sample/pom.xml
+++ b/datamodel/openapi/openapi-api-sample/pom.xml
@@ -74,8 +74,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/openapi/openapi-api-sample/pom.xml
+++ b/datamodel/openapi/openapi-api-sample/pom.xml
@@ -74,8 +74,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/openapi/openapi-core/pom.xml
+++ b/datamodel/openapi/openapi-core/pom.xml
@@ -113,8 +113,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/datamodel/openapi/openapi-core/pom.xml
+++ b/datamodel/openapi/openapi-core/pom.xml
@@ -113,8 +113,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
 		<jakarta-activation.version>2.1.0</jakarta-activation.version>
 		<jakarta-xml-bind.version>4.0.1</jakarta-xml-bind.version>
 		<qdox.version>2.0.3</qdox.version>
-		<wiremock.version>3.3.1</wiremock.version>
+		<wiremock.version>3.0.1</wiremock.version>
 		<checkstyle.version>8.41</checkstyle.version>
 		<kotlin.version>1.9.10</kotlin.version>
 		<byte-buddy.version>1.14.8</byte-buddy.version>
@@ -357,8 +357,8 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>org.wiremock</groupId>
-				<artifactId>wiremock</artifactId>
+				<groupId>com.github.tomakehurst</groupId>
+				<artifactId>wiremock-jre8</artifactId>
 				<version>${wiremock.version}</version>
 				<scope>test</scope>
 			</dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,7 +119,6 @@
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<scp-cf.xs-env.version>1.8.5</scp-cf.xs-env.version>
 		<!--  Dependency convergence dependencies  -->
-		<jetty.version>9.4.53.v20231009</jetty.version>
 		<protobuf-java.version>3.24.3</protobuf-java.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->
 		<plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
@@ -129,7 +128,7 @@
 		<jakarta-activation.version>2.1.0</jakarta-activation.version>
 		<jakarta-xml-bind.version>4.0.1</jakarta-xml-bind.version>
 		<qdox.version>2.0.3</qdox.version>
-		<wiremock.version>2.35.1</wiremock.version>
+		<wiremock.version>3.3.1</wiremock.version>
 		<checkstyle.version>8.41</checkstyle.version>
 		<kotlin.version>1.9.10</kotlin.version>
 		<byte-buddy.version>1.14.8</byte-buddy.version>
@@ -358,8 +357,8 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.github.tomakehurst</groupId>
-				<artifactId>wiremock-jre8</artifactId>
+				<groupId>org.wiremock</groupId>
+				<artifactId>wiremock</artifactId>
 				<version>${wiremock.version}</version>
 				<scope>test</scope>
 			</dependency>
@@ -385,31 +384,6 @@
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-params</artifactId>
 				<version>${junit.jupiter.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<!--Only used in odata-core-->
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-server</artifactId>
-				<version>${jetty.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-http</artifactId>
-				<version>${jetty.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-io</artifactId>
-				<version>${jetty.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-util</artifactId>
-				<version>${jetty.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<!--Used in odata generator and open api generator maven plugins-->
@@ -491,18 +465,6 @@
 				<artifactId>byte-buddy</artifactId>
 				<version>${byte-buddy.version}</version>
 				<scope>test</scope>
-			</dependency>
-			<!-- Added to resolve dependency convergence with wiremock-jre8 -->
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-servlet</artifactId>
-				<version>${jetty.version}</version>
-			</dependency>
-			<!-- Added to resolve dependency convergence with wiremock-jre8 -->
-			<dependency>
-				<groupId>org.eclipse.jetty</groupId>
-				<artifactId>jetty-webapp</artifactId>
-				<version>${jetty.version}</version>
 			</dependency>
 			<!-- Added to resolve dependency convergence between wiremock-jre8 and jetty -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -119,6 +119,7 @@
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<scp-cf.xs-env.version>1.8.5</scp-cf.xs-env.version>
 		<!--  Dependency convergence dependencies  -->
+		<jetty.version>11.0.15</jetty.version>
 		<protobuf-java.version>3.24.3</protobuf-java.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->
 		<plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
@@ -357,8 +358,8 @@
 				<scope>test</scope>
 			</dependency>
 			<dependency>
-				<groupId>com.github.tomakehurst</groupId>
-				<artifactId>wiremock-jre8</artifactId>
+				<groupId>org.wiremock</groupId>
+				<artifactId>wiremock</artifactId>
 				<version>${wiremock.version}</version>
 				<scope>test</scope>
 			</dependency>
@@ -384,6 +385,31 @@
 				<groupId>org.junit.jupiter</groupId>
 				<artifactId>junit-jupiter-params</artifactId>
 				<version>${junit.jupiter.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<!--Only used in odata-core-->
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-server</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-http</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-io</artifactId>
+				<version>${jetty.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<dependency>
+				<groupId>org.eclipse.jetty</groupId>
+				<artifactId>jetty-util</artifactId>
+				<version>${jetty.version}</version>
 				<scope>test</scope>
 			</dependency>
 			<!--Used in odata generator and open api generator maven plugins-->

--- a/s4hana/rfc/pom.xml
+++ b/s4hana/rfc/pom.xml
@@ -102,8 +102,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.github.tomakehurst</groupId>
-			<artifactId>wiremock-jre8</artifactId>
+			<groupId>org.wiremock</groupId>
+			<artifactId>wiremock</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- scope "provided" -->

--- a/s4hana/rfc/pom.xml
+++ b/s4hana/rfc/pom.xml
@@ -102,8 +102,8 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>org.wiremock</groupId>
-			<artifactId>wiremock</artifactId>
+			<groupId>com.github.tomakehurst</groupId>
+			<artifactId>wiremock-jre8</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<!-- scope "provided" -->


### PR DESCRIPTION
# Pull Request Description

This PR addresses the backlog item [#319](https://github.com/SAP/cloud-sdk-java-backlog/issues/319) - Fix Blackduck v5 findings. The changes in this PR are part of the task to apply dependency updates to fix the Blackduck findings.

The changes in this PR include:

- Updated the `com.github.tomakehurst:wiremock-jre8` dependency to `org.wiremock:wiremock` from `2.35.1` to `3.3.1`

- Updated `jetty`, to `11.0.15`