### PR TITLE
fix: Update versions of olingo-v4 and olingo-v2 in pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -105,8 +105,8 @@
 		<arquillian.version>1.5.0.Final</arquillian.version>
 		<junit.jupiter.version>5.10.0</junit.jupiter.version>
 		<codemodel.version>2.6</codemodel.version>
-		<olingo-v4.version>4.9.0</olingo-v4.version>
-		<olingo-v2.version>2.0.12</olingo-v2.version>
+		<olingo-v4.version>4.10.0</olingo-v4.version>
+		<olingo-v2.version>2.0.13</olingo-v2.version>
 		<maven-plugin.version>3.8.1</maven-plugin.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<restassured.version>5.0.1</restassured.version>


### PR DESCRIPTION
# Pull Request Description

This pull request addresses the backlog item [#319 Fix Blackduck v5 findings](https://github.com/SAP/cloud-sdk-java-backlog/issues/319).

The changes in this PR include an update to the versions of `olingo-v4` and `olingo-v2` in the `pom.xml` file. The versions have been updated from `4.9.0` to `4.10.0` and `2.0.12` to `2.0.13` respectively.