### PR TITLE
fix: DwC Connectivity Service Auto Configuration

### DIFF
--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessor.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessor.java
@@ -34,23 +34,22 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class MegacliteServiceBindingAccessor implements ServiceBindingAccessor
 {
-    // this binding just exists so we can use ServiceIdentifier.CONNECTIVITY in our
-    // service binding -> destination APIs
-    // its content is currently not used -- see https://github.com/SAP/cloud-sdk-java-backlog/issues/209
-    static final MegacliteServiceBinding CONNECTIVITY_BINDING =
+    /**
+     * The {@link MegacliteServiceBinding} for the connectivity service. In case you want to access on-premise systems
+     * via Megaclite, you need to register this service binding manually using
+     * {@link #registerServiceBinding(MegacliteServiceBinding)}.
+     */
+    @Nonnull
+    public static final MegacliteServiceBinding CONNECTIVITY_BINDING =
         MegacliteServiceBinding
             .forService(ServiceIdentifier.CONNECTIVITY)
             .subscriberConfiguration()
-            .name("foo")
-            .version("bar")
+            .name("connectivity")
+            .version("v1")
             .build();
 
     @Nonnull
     private static final Set<MegacliteServiceBinding> serviceBindings = new HashSet<>();
-
-    static {
-        registerServiceBinding(CONNECTIVITY_BINDING);
-    }
 
     /**
      * Adds the provided {@code serviceBinding} to the <b>statically</b> stored list of all tracked

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessor.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessor.java
@@ -68,7 +68,6 @@ public class MegacliteServiceBindingAccessor implements ServiceBindingAccessor
     {
         log.warn("Clearing the registered Dwc Service Bindings. This should never happen outside of testing!");
         serviceBindings.clear();
-        registerServiceBinding(CONNECTIVITY_BINDING);
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessorTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingAccessorTest.java
@@ -4,7 +4,6 @@
 
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.sap.cloud.sdk.cloudplatform.connectivity.MegacliteServiceBindingAccessor.CONNECTIVITY_BINDING;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.util.List;
@@ -33,17 +32,16 @@ class MegacliteServiceBindingAccessorTest
     }
 
     @Test
-    void testGetServiceBindingsIsNotEmptyByDefault()
+    void testGetServiceBindingsIsEmptyByDefault()
     {
         final MegacliteServiceBindingAccessor sut = new MegacliteServiceBindingAccessor();
-        assertThat(sut.getServiceBindings()).hasSize(1).containsExactly(CONNECTIVITY_BINDING);
+        assertThat(sut.getServiceBindings()).isEmpty();
     }
 
     @Test
     void testGetServiceBindingsReturnsStaticServiceBindings()
     {
         final MegacliteServiceBindingAccessor sut = new MegacliteServiceBindingAccessor();
-        assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(CONNECTIVITY_BINDING);
 
         final MegacliteServiceBinding serviceBinding =
             MegacliteServiceBinding
@@ -54,6 +52,6 @@ class MegacliteServiceBindingAccessorTest
                 .build();
         MegacliteServiceBindingAccessor.registerServiceBinding(serviceBinding);
 
-        assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(serviceBinding, CONNECTIVITY_BINDING);
+        assertThat(sut.getServiceBindings()).containsExactlyInAnyOrder(serviceBinding);
     }
 }

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
@@ -271,6 +271,8 @@ class MegacliteServiceBindingDestinationLoaderTest
         sut.setConnectivityResolver(mock);
 
         DefaultHttpDestinationBuilderProxyHandler.setServiceBindingDestinationLoader(sut);
+        DefaultHttpDestinationBuilderProxyHandler
+            .setServiceBindingConnectivity(MegacliteServiceBindingAccessor.CONNECTIVITY_BINDING);
 
         final DefaultHttpDestination result =
             DefaultHttpDestination
@@ -296,7 +298,7 @@ class MegacliteServiceBindingDestinationLoaderTest
     void testMissingDestinationToBeProxied()
     {
         final ServiceBindingDestinationOptions options =
-            ServiceBindingDestinationOptions.forService(ServiceIdentifier.CONNECTIVITY).build();
+            ServiceBindingDestinationOptions.forService(MegacliteServiceBindingAccessor.CONNECTIVITY_BINDING).build();
 
         assertThatThrownBy(() -> sut.getDestination(options)).isInstanceOf(DestinationAccessException.class);
     }
@@ -306,7 +308,7 @@ class MegacliteServiceBindingDestinationLoaderTest
     {
         final ServiceBindingDestinationOptions options =
             ServiceBindingDestinationOptions
-                .forService(ServiceIdentifier.CONNECTIVITY)
+                .forService(MegacliteServiceBindingAccessor.CONNECTIVITY_BINDING)
                 .onBehalfOf(OnBehalfOf.TECHNICAL_USER_PROVIDER)
                 .withOption(ProxyOptions.destinationToBeProxied(mock(HttpDestination.class)))
                 .build();


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#209

This PR changes the connectivity service binding for megaclite to no longer be registered by default. This is necessary as otherwise there would be two bindings available in case shared orbits are used.

Users will have to register the connectivity binding explicitly, similar to the destination service binding.

### Feature scope:
 
- [x] Make `CONNECTIVITY_BINDING` public
- [ ] E2E Test update
- [x] Update DwC Documentation & Migration Guide

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] Documentation updated
- [x] ~Release notes updated~
