### PR TITLE
fix: CAP API Compatibility

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationLoader.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationLoader.java
@@ -42,6 +42,23 @@ public final class DefaultDestinationLoader implements DestinationLoader
         return this;
     }
 
+    /**
+     * Register a {@link HttpDestination} to this destination loader. It must have a non-empty name to be identified by.
+     * If a destination with the same name was registered previously it will be replaced by this one.
+     *
+     * @param destination
+     *            A destination this loader should return when queried.
+     * @return This loader instance.
+     *
+     * @throws IllegalArgumentException
+     *             if the destination name is null or empty.
+     */
+    @Nonnull
+    public DefaultDestinationLoader registerDestination( @Nonnull final HttpDestination destination )
+    {
+        return registerDestination((Destination) destination);
+    }
+
     @Nonnull
     @Override
     public


### PR DESCRIPTION
## Context

This is effectively the same fix that we did to the `HttpClientAccessor`. The API is used by the CAP multi tenancy implementation, both in cds-services and in the DwC Spring Utils.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] ~Tests cover the scope above~
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~
