### PR TITLE
fix: Default Tenant must not throw on euqlas, hashcode and toString

### DIFF
--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -96,35 +96,6 @@ public class DwcHeaderUtils
         return logonName;
     }
 
-    /**
-     * This method fetches the value of the {@link #DWC_CLIENT_HEADER} header or throws an
-     * {@link DwcHeaderNotFoundException} if the header was not found.
-     *
-     * @return The value of the {@link #DWC_CLIENT_HEADER} header.
-     * @throws DwcHeaderNotFoundException
-     *             if the header was not found.
-     */
-    @Nonnull
-    public static String getDwcClientOrThrow()
-    {
-        return getNonEmptyDwcHeaderValue(DWC_CLIENT_HEADER);
-    }
-
-    /**
-     * This method fetches the values of the {@link #DWC_SCOPES_HEADER} header throws an
-     * {@link DwcHeaderNotFoundException} if the header was not found.
-     *
-     * @return The values of the {@link #DWC_SCOPES_HEADER} header.
-     * @throws DwcHeaderNotFoundException
-     *             if the header was not found.
-     */
-    @Nonnull
-    public static Set<String> getDwcScopesOrThrow()
-    {
-        final String scopes = getNonEmptyDwcHeaderValue(DWC_SCOPES_HEADER);
-        return Arrays.stream(scopes.split(" ")).collect(Collectors.toSet());
-    }
-
     @Nonnull
     private static String getNonEmptyDwcHeaderValue( @Nonnull final String key )
         throws DwcHeaderNotFoundException

--- a/cloudplatform/tenant/src/main/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenant.java
+++ b/cloudplatform/tenant/src/main/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenant.java
@@ -17,8 +17,8 @@ import lombok.ToString;
 /**
  * Implementation of {@link Tenant} which can be used on SAP Business Technology Platform Cloud Foundry.
  */
-@EqualsAndHashCode
-@ToString
+@EqualsAndHashCode( doNotUseGetters = true )
+@ToString( doNotUseGetters = true )
 @RequiredArgsConstructor
 public class DefaultTenant implements TenantWithSubdomain
 {

--- a/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantTest.java
+++ b/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantTest.java
@@ -5,6 +5,7 @@
 package com.sap.cloud.sdk.cloudplatform.tenant;
 
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
 
 import org.junit.jupiter.api.Test;
 
@@ -14,5 +15,10 @@ class DefaultTenantTest
     void testNullParameters()
     {
         assertThatThrownBy(() -> new DefaultTenant(null, null)).isExactlyInstanceOf(NullPointerException.class);
+
+        DefaultTenant tenant = new DefaultTenant("foo", null);
+        assertDoesNotThrow(tenant::toString);
+        assertDoesNotThrow(tenant::hashCode);
+        assertDoesNotThrow(() -> tenant.equals(tenant));
     }
 }


### PR DESCRIPTION
## Context

Rather nasty bug. Questionable if we want to stick to the "throw inside getter" approach. This still might happen e.g. during JSON serialization, depending on how the serialiser works.

But otherwise we would have to make changes to the API which may again break stuff...
