### PR TITLE
refactor: use caffeine for caching insetad of regular resilience api

### DIFF
--- a/cloudplatform/connectivity-dwc/pom.xml
+++ b/cloudplatform/connectivity-dwc/pom.xml
@@ -110,6 +110,20 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
+			<artifactId>caching</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>com.github.ben-manes.caffeine</groupId>
+			<artifactId>caffeine</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>checker-qual</artifactId>
+					<groupId>org.checkerframework</groupId>
+				</exclusion>
+			</exclusions>
+		</dependency>
 		<!-- scope "provided" -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>
@@ -119,17 +133,7 @@
 		<!-- scope "test" -->
 		<dependency>
 			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
-			<artifactId>caching</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.sap.cloud.sdk.cloudplatform</groupId>
 			<artifactId>resilience4j</artifactId>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.github.ben-manes.caffeine</groupId>
-			<artifactId>jcache</artifactId>
 			<scope>test</scope>
 		</dependency>
 		<dependency>

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteConnectivityProxyInformationResolverTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteConnectivityProxyInformationResolverTest.java
@@ -7,6 +7,7 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -14,6 +15,9 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 
 import java.net.URI;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Future;
 
 import org.apache.http.HttpHeaders;
 import org.apache.http.HttpResponse;
@@ -24,12 +28,14 @@ import org.apache.http.message.BasicStatusLine;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
 
 import com.google.common.base.Charsets;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceRuntimeException;
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenantFacade;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextExecutors;
 
 import lombok.SneakyThrows;
 
@@ -59,10 +65,7 @@ class MegacliteConnectivityProxyInformationResolverTest
     @BeforeEach
     void setup()
     {
-        final DwcConfiguration dwcConfig = new DwcConfiguration(URI.create("megaclite.com"), "provider-id");
-        final MegacliteDestinationFactory destinationFactory = new MegacliteDestinationFactory(dwcConfig);
-        sut = spy(new MegacliteConnectivityProxyInformationResolver(destinationFactory));
-
+        sut = createSut();
         TenantAccessor.setTenantFacade(new DefaultTenantFacade());
     }
 
@@ -74,20 +77,18 @@ class MegacliteConnectivityProxyInformationResolverTest
 
     @SneakyThrows
     @Test
-    void testProxyUrlIsCachedAcrossTenants()
+    void testProxyUrlIsCachedPerTenants()
     {
         doReturn(successResponse).when(sut).makeHttpRequest(any());
 
         assertThat(sut.getProxyUrl()).isEqualTo(URI.create("http://some.proxy"));
-
-        doReturn(failureResponse).when(sut).makeHttpRequest(any());
 
         final URI proxyUrl = TenantAccessor.executeWithTenant(new DefaultTenant("foo"), sut::getProxyUrl);
         assertThat(proxyUrl)
             .describedAs("The proxy URL should be the same across all tenants")
             .isEqualTo(sut.getProxyUrl());
 
-        verify(sut, times(1)).getProxyInformationFromMegaclite();
+        verify(sut, times(2)).getProxyInformationFromMegaclite();
     }
 
     @SneakyThrows
@@ -122,5 +123,99 @@ class MegacliteConnectivityProxyInformationResolverTest
 
         assertThat(sut.getHeaders(mock(DestinationRequestContext.class)))
             .contains(new Header(HttpHeaders.PROXY_AUTHORIZATION, "Bearer 1234"));
+    }
+
+    @Test
+    @Timeout( value = 300_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS )
+    @SneakyThrows
+    void testAuthTokenCanBeRetrievedInParallelForDifferentTenants()
+    {
+        final CountDownLatch firstInvocationLatch = new CountDownLatch(1);
+        final CountDownLatch secondInvocationLatch = new CountDownLatch(2);
+        final CountDownLatch resumeInvocationsLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            firstInvocationLatch.countDown();
+            secondInvocationLatch.countDown();
+            resumeInvocationsLatch.await();
+            return successResponse;
+        }).when(sut).makeHttpRequest(any());
+
+        final Future<String> firstTask =
+            TenantAccessor
+                .executeWithTenant(
+                    new DefaultTenant("Tenant1"),
+                    () -> ThreadContextExecutors.submit(sut::getAuthorizationToken));
+        firstInvocationLatch.await(); // make sure the first invocation is in progress
+
+        final Future<String> secondTask =
+            TenantAccessor
+                .executeWithTenant(
+                    new DefaultTenant("Tenant2"),
+                    () -> ThreadContextExecutors.submit(sut::getAuthorizationToken));
+        secondInvocationLatch.await(); // make sure the second invocation is in progress
+
+        // both tasks are running in parallel
+        assertThat(firstTask).isNotNull();
+        assertThat(secondTask).isNotNull();
+        assertThat(firstTask.isDone()).isFalse();
+        assertThat(secondTask.isDone()).isFalse();
+
+        resumeInvocationsLatch.countDown();
+
+        assertThat(firstTask.get()).isEqualTo("Bearer 1234");
+        assertThat(secondTask.get()).isEqualTo("Bearer 1234");
+
+        verify(sut, times(2)).makeHttpRequest(any());
+    }
+
+    @Test
+    @Timeout( value = 300_000, unit = java.util.concurrent.TimeUnit.MILLISECONDS )
+    @SneakyThrows
+    void testInstancesUseSeparateResilienceStates()
+    {
+        final MegacliteConnectivityProxyInformationResolver firstSut = createSut();
+        final MegacliteConnectivityProxyInformationResolver secondSut = createSut();
+
+        final CountDownLatch firstInvocationLatch = new CountDownLatch(1);
+        final CountDownLatch secondInvocationLatch = new CountDownLatch(1);
+        final CountDownLatch resumeInvocationLatch = new CountDownLatch(1);
+
+        doAnswer(invocation -> {
+            firstInvocationLatch.countDown();
+            resumeInvocationLatch.await();
+            return successResponse;
+        }).when(firstSut).makeHttpRequest(any());
+
+        doAnswer(invocation -> {
+            secondInvocationLatch.countDown();
+            resumeInvocationLatch.await();
+            return successResponse;
+        }).when(secondSut).makeHttpRequest(any());
+
+        final CompletableFuture<String> firstTask = CompletableFuture.supplyAsync(firstSut::getAuthorizationToken);
+        firstInvocationLatch.await();
+
+        final CompletableFuture<String> secondTask = CompletableFuture.supplyAsync(secondSut::getAuthorizationToken);
+        secondInvocationLatch.await();
+
+        // both requests are running FOR THE SAME TENANT in parallel
+        assertThat(firstTask.isDone()).isFalse();
+        assertThat(secondTask.isDone()).isFalse();
+
+        resumeInvocationLatch.countDown();
+
+        assertThat(firstTask.get()).isEqualTo("Bearer 1234");
+        assertThat(secondTask.get()).isEqualTo("Bearer 1234");
+
+        verify(firstSut, times(1)).makeHttpRequest(any());
+        verify(secondSut, times(1)).makeHttpRequest(any());
+    }
+
+    private static MegacliteConnectivityProxyInformationResolver createSut()
+    {
+        final DwcConfiguration dwcConfig = new DwcConfiguration(URI.create("megaclite.com"), "provider-id");
+        final MegacliteDestinationFactory destinationFactory = new MegacliteDestinationFactory(dwcConfig);
+        return spy(new MegacliteConnectivityProxyInformationResolver(destinationFactory));
     }
 }


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
SAP/cloud-sdk-java-backlog/issues/359

This PR refactors our `MegacliteConnectivityProxyInformationResolver` to use a `Caffeine` cache instead of our regular resilience cache.
The reason for this change is that our resilience caching is not working in case the application doesn't provide a proper JCache implementation.
With this change, our caching behavior no longer depends on the actually used dependencies in the customer application.

Additionally, this PR changes the caching behavior:
Instead of having two separates caches (one for the auth token and another one for the proxy URL), we are now using a single cache for the entire megaclite response (which contains both the token as well as the proxy URL).
As a consequence, the proxy URL will also be cached PER TENANT and has a short caching duration (15 minutes instead of 1 day).
This change fixes an issue where the proxy URL might have been changed (e.g. service binding on Megaclite has been rotated) but it would take (in the worst case) one entire day for the change to be reflected in the application, which is too long.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
