### PR TITLE
Rollback artifact workarounds

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/application/src/main/java/__packageInPathFormat__/Application.java
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/application/src/main/java/__packageInPathFormat__/Application.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @ComponentScan({"com.sap.cloud.sdk", "${package}"})
-@ServletComponentScan({"com.sap.cloud.sdk.cloudplatform.servletjakarta", "${package}"})
+@ServletComponentScan({"com.sap.cloud.sdk", "${package}"})
 public class Application extends SpringBootServletInitializer
 {
     @Override

--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/pom.xml
@@ -31,6 +31,13 @@
     <dependencyManagement>
         <dependencies>
             <dependency>
+                <groupId>com.sap.cloud.sdk</groupId>
+                <artifactId>sdk-bom</artifactId>
+                <version>${cloud-sdk.version}</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+            <dependency>
                 <groupId>com.sap.cloud.security</groupId>
                 <artifactId>java-bom</artifactId>
                 <version>${security-lib.version}</version>
@@ -41,13 +48,6 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>
                 <version>${spring-boot.version}</version>
-                <type>pom</type>
-                <scope>import</scope>
-            </dependency>
-            <dependency>
-                <groupId>com.sap.cloud.sdk</groupId>
-                <artifactId>sdk-bom</artifactId>
-                <version>${cloud-sdk.version}</version>
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>


### PR DESCRIPTION
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#307

Workarounds were needed for an SDK application to use Java 17. Now that the SDK only supports Java 17, these workarounds can be removed in Spring applications
🟢[Successful test run](https://sdk-v2.cpe.c.eu-de-1.cloud.sap/job/end-to-end-tests/view/Cloud%20SDK%20v5/job/v5-scp-cf-spring-java17-jakarta/154/)

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Placed Spring dependencies after the sdk-bom
- [x] The servlet scan can now be on the whole SDK as there is only one servlet module anymore (servlet-jakarta)

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] [Removed mentions of Java 8](https://github.com/SAP/cloud-sdk/pull/1614/files#top)
- [x] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
