### PR TITLE
fix: XSUAA Usage in Spring Boot Archetype

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/application/pom.xml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/application/pom.xml
@@ -77,12 +77,6 @@
         </dependency>
         -->
 
-        <dependency>
-            <groupId>jakarta.inject</groupId>
-            <artifactId>jakarta.inject-api</artifactId>
-            <version>2.0.1</version>
-        </dependency>
-
         <!-- Dependencies for security setup -->
         <!--
         <dependency>

--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/application/src/main/java/__packageInPathFormat__/Application.java
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/application/src/main/java/__packageInPathFormat__/Application.java
@@ -12,7 +12,7 @@ import org.springframework.context.annotation.ComponentScan;
 
 @SpringBootApplication
 @ComponentScan({"com.sap.cloud.sdk", "${package}"})
-@ServletComponentScan({"com.sap.cloud.sdk.cloudplatform.servletjakarta", "${package}"})
+@ServletComponentScan({"com.sap.cloud.sdk", "${package}"})
 public class Application extends SpringBootServletInitializer
 {
     @Override

--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/HelloWorldControllerTest.java
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/HelloWorldControllerTest.java
@@ -5,17 +5,15 @@ package ${package};
 
 import static java.lang.Thread.currentThread;
 
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-import java.io.InputStream;
-import java.nio.charset.StandardCharsets;
-
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextExecutor;
+// import com.sap.cloud.security.config.Service;
+// import com.sap.cloud.security.test.api.SecurityTestContext;
+// import com.sap.cloud.security.test.extension.SecurityTestExtension;
+// import com.sap.cloud.security.token.TokenClaims;
 import org.apache.commons.io.IOUtils;
-//import org.apache.http.HttpHeaders;
-import org.junit.jupiter.api.AfterAll;
-import org.junit.jupiter.api.BeforeAll;
+// import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.extension.RegisterExtension;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,16 +21,18 @@ import org.springframework.test.context.TestPropertySource;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextExecutor;
-//import com.sap.cloud.security.config.Service;
-//import com.sap.cloud.security.test.SecurityTest;
-//import com.sap.cloud.security.token.TokenClaims;
+import java.io.InputStream;
+import java.nio.charset.StandardCharsets;
+
+import static java.lang.Thread.currentThread;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @SpringBootTest
 @AutoConfigureMockMvc
 @TestPropertySource(
         properties = {
-                "sap.security.services.xsuaa.uaadomain=localhost",
+                "sap.security.services.xsuaa.uaadomain=http://localhost:9001",
                 "sap.security.services.xsuaa.xsappname=xsapp!t0815",
                 "sap.security.services.xsuaa.clientid=sb-clientId!t0815" } )
 class HelloWorldControllerTest
@@ -40,40 +40,33 @@ class HelloWorldControllerTest
     @Autowired
     private MockMvc mvc;
 
-//    private static final SecurityTest rule = new SecurityTest(Service.XSUAA);
-//    private static String jwt;
+    /*
+    @RegisterExtension
+    static SecurityTestExtension extension = SecurityTestExtension.forService(Service.XSUAA) // or Service.IAS
+            .setPort(9001);
 
-    @BeforeAll
-    static void beforeClass()
-            throws Exception
-    {
-//        rule.setup();
-//        jwt =
-//                rule
-//                        .getPreconfiguredJwtGenerator()
-//                        .withLocalScopes("Display")
-//                        .withClaimValue(TokenClaims.XSUAA.ORIGIN, "sap-default") // optional
-//                        .withClaimValue(TokenClaims.USER_NAME, "John") // optional
-//                        .createToken()
-//                        .getTokenValue();
-//        jwt = "Bearer " + jwt;
-    }
-
-    @AfterAll
-    static void afterClass()
-    {
-//        rule.tearDown();
-    }
+    private String jwt;
+    */
 
     @Test
-    void test()
+    void test(/*SecurityTestContext context*/)
     {
+        /*
+        jwt = context.getPreconfiguredJwtGenerator()
+                .withLocalScopes("Display")
+                .withClaimValue(TokenClaims.XSUAA.ORIGIN, "sap-default") // optional
+                .withClaimValue(TokenClaims.USER_NAME, "John") // optional
+                .createToken()
+                .getTokenValue();
+        jwt = "Bearer " + jwt;
+        */
+
         final InputStream inputStream = currentThread().getContextClassLoader().getResourceAsStream("expected.json");
 
         ThreadContextExecutor.fromNewContext().execute(() -> {
             mvc
                     .perform(MockMvcRequestBuilders.get("/hello")
-//                    .header(HttpHeaders.AUTHORIZATION, jwt)
+                            // .header(HttpHeaders.AUTHORIZATION, jwt)
                     )
                     .andExpect(status().isOk())
                     .andExpect(content().json(IOUtils.toString(inputStream, StandardCharsets.UTF_8)));

--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/HelloWorldControllerTest.java
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/src/test/java/__packageInPathFormat__/HelloWorldControllerTest.java
@@ -24,7 +24,6 @@ import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import java.io.InputStream;
 import java.nio.charset.StandardCharsets;
 
-import static java.lang.Thread.currentThread;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 

--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/pom.xml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/pom.xml
@@ -12,10 +12,9 @@
     <packaging>pom</packaging>
 
     <properties>
-        <spring-boot.version>3.1.4</spring-boot.version>
+        <spring-boot.version>3.1.5</spring-boot.version>
 
         <java.version>17</java.version>
-        <security-lib.version>3.2.1</security-lib.version>
         <cloud-sdk.version>5.0.0-alpha-SNAPSHOT</cloud-sdk.version>
 
         <maven.compiler.source>${java.version}</maven.compiler.source>
@@ -30,13 +29,6 @@
 
     <dependencyManagement>
         <dependencies>
-            <dependency>
-                <groupId>com.sap.cloud.security</groupId>
-                <artifactId>java-bom</artifactId>
-                <version>${security-lib.version}</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-dependencies</artifactId>


### PR DESCRIPTION
## Context

Follow-up of #164 and #166

Compare [this](https://github.wdf.sap.corp/MA/sdk/pull/8627) and [this](https://github.wdf.sap.corp/MA/sdk/pull/8664)  change on V4.

[Successful E2E Test Run](https://sdk-v2.cpe.c.eu-de-1.cloud.sap/job/end-to-end-tests/view/Cloud%20SDK%20v5/job/v5-scp-cf-spring-xsuaa/142/)