### PR TITLE
chore: Dependency Cleanup

### DIFF
--- a/bom/pom.xml
+++ b/bom/pom.xml
@@ -104,7 +104,6 @@
 				<artifactId>slf4j-api</artifactId>
 				<version>${slf4j.version}</version>
 			</dependency>
-			<!-- TODO -->
 			<dependency>
 				<groupId>com.google.code.findbugs</groupId>
 				<artifactId>jsr305</artifactId>
@@ -119,12 +118,6 @@
 				<groupId>com.google.guava</groupId>
 				<artifactId>guava</artifactId>
 				<version>${guava.version}</version>
-				<exclusions>
-					<exclusion>
-						<groupId>com.google.code.findbugs</groupId>
-						<artifactId>jsr305</artifactId>
-					</exclusion>
-				</exclusions>
 			</dependency>
 			<dependency>
 				<groupId>com.github.ben-manes.caffeine</groupId>
@@ -146,7 +139,6 @@
 				<artifactId>gson</artifactId>
 				<version>${gson.version}</version>
 			</dependency>
-			<!-- TODO -->
 			<dependency>
 				<groupId>com.fasterxml.jackson.core</groupId>
 				<artifactId>jackson-core</artifactId>

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OnPremTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OnPremTest.java
@@ -1,6 +1,9 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OnPremTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OnPremTest.java
@@ -1,11 +1,6 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.getAllServeEvents;
-import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
-import static com.github.tomakehurst.wiremock.client.WireMock.post;
-import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
-import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
-import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
 import static org.assertj.core.api.Assertions.assertThat;
 

--- a/pom.xml
+++ b/pom.xml
@@ -118,7 +118,6 @@
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->
 		<plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
 		<stax2-api.version>4.2.1</stax2-api.version>
-		<netty.version>4.1.98.Final</netty.version>
 		<bouncycastle.version>1.76</bouncycastle.version>
 		<jakarta-activation.version>2.1.0</jakarta-activation.version>
 		<jakarta-xml-bind.version>4.0.1</jakarta-xml-bind.version>
@@ -127,7 +126,6 @@
 		<checkstyle.version>8.41</checkstyle.version>
 		<kotlin.version>1.9.10</kotlin.version>
 		<byte-buddy.version>1.14.8</byte-buddy.version>
-		<hamcrest-core.version>2.2</hamcrest-core.version>
 		<jsr305.optional>true</jsr305.optional>
 	</properties>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,6 @@
 		<codeAnalysisExclusions>**/odata/namespaces/**,**/odata/services/**,**/odatav4/namespaces/**,**/odatav4/services/**,**/soap/client/**,**/testclasses/**</codeAnalysisExclusions>
 		<!--  Non-essential dependencies  -->
 		<jco-api.version>4.57.7.1</jco-api.version>
-		<jsonschema2pojo.version>1.1.2</jsonschema2pojo.version>
 		<jackson.version>2.15.2</jackson.version>
 		<commons-configuration.version>1.10</commons-configuration.version>
 		<!--  WordUtils used twice in OData generator  -->
@@ -107,16 +106,13 @@
 		<olingo-v2.version>2.0.13</olingo-v2.version>
 		<maven-plugin.version>3.8.1</maven-plugin.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
-		<restassured.version>5.0.1</restassured.version>
 		<caffeine.version>3.1.8</caffeine.version>
 		<openapi-generator.version>7.0.1</openapi-generator.version>
 		<io-swagger-core-v3.version>2.1.13</io-swagger-core-v3.version>
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<!--  Dependency convergence dependencies  -->
 		<jetty.version>11.0.18</jetty.version>
-		<protobuf-java.version>3.24.3</protobuf-java.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->
-		<plexus-component-annotations.version>2.1.1</plexus-component-annotations.version>
 		<stax2-api.version>4.2.1</stax2-api.version>
 		<bouncycastle.version>1.76</bouncycastle.version>
 		<jakarta-activation.version>2.1.0</jakarta-activation.version>
@@ -197,7 +193,7 @@
 				<artifactId>commons-configuration</artifactId>
 				<version>${commons-configuration.version}</version>
 			</dependency>
-			<!--Used in mdi-generator and odata-generator-->
+			<!--Used in odata-generator-->
 			<dependency>
 				<groupId>com.sun.codemodel</groupId>
 				<artifactId>codemodel</artifactId>
@@ -209,13 +205,11 @@
 				<artifactId>odata-commons-core</artifactId>
 				<version>${olingo-v4.version}</version>
 			</dependency>
-			<!--Used in Odata v4 generator and Mdo distribution client-->
 			<dependency>
 				<groupId>org.apache.olingo</groupId>
 				<artifactId>odata-commons-api</artifactId>
 				<version>${olingo-v4.version}</version>
 			</dependency>
-			<!--Used in Odata v4 generator-->
 			<dependency>
 				<groupId>org.apache.olingo</groupId>
 				<artifactId>odata-client-core</artifactId>
@@ -261,25 +255,12 @@
 				<artifactId>jackson-dataformat-yaml</artifactId>
 				<version>${jackson.version}</version>
 			</dependency>
-			<!--Dependencies used in services-->
-			<!-- Added to avoid vulnerability CVE-2022-42889 that comes from the openapi generator  -->
-			<dependency>
-				<groupId>org.apache.commons</groupId>
-				<artifactId>commons-text</artifactId>
-				<version>1.10.0</version>
-			</dependency>
 			<!--Rest of SDK Dependencies-->
 			<!--Used only in RFC module as a compile dependency, everywhere else in test scope -->
 			<dependency>
 				<groupId>org.json</groupId>
 				<artifactId>json</artifactId>
 				<version>${json.version}</version>
-			</dependency>
-			<!--  avoid class loading issues with Spring and WireMock-->
-			<dependency>
-				<groupId>org.skyscreamer</groupId>
-				<artifactId>jsonassert</artifactId>
-				<version>${jsonassert.version}</version>
 			</dependency>
 			<!-- Used in connectivity-apache-httpclient4 and connectivity-apache-httpclient5 -->
 			<dependency>
@@ -291,18 +272,6 @@
 				<groupId>org.bouncycastle</groupId>
 				<artifactId>bcprov-jdk18on</artifactId>
 				<version>${bouncycastle.version}</version>
-			</dependency>
-			<!--Used in end-to-end tests-->
-			<!--Used only in unit-tests-->
-			<dependency>
-				<groupId>jakarta.activation</groupId>
-				<artifactId>jakarta.activation-api</artifactId>
-				<version>${jakarta-activation.version}</version>
-			</dependency>
-			<dependency>
-				<groupId>jakarta.xml.bind</groupId>
-				<artifactId>jakarta.xml.bind-api</artifactId>
-				<version>${jakarta-xml-bind.version}</version>
 			</dependency>
 			<!--Dependencies with test scope-->
 			<dependency>
@@ -353,6 +322,12 @@
 				<version>${junit.jupiter.version}</version>
 				<scope>test</scope>
 			</dependency>
+			<dependency>
+				<groupId>org.skyscreamer</groupId>
+				<artifactId>jsonassert</artifactId>
+				<version>${jsonassert.version}</version>
+				<scope>test</scope>
+			</dependency>
 			<!--Only used in odata-core-->
 			<dependency>
 				<groupId>org.eclipse.jetty</groupId>
@@ -394,17 +369,17 @@
 				<scope>test</scope>
 			</dependency>
 			<!--Dependencies managed for conflict resolution-->
-			<!--Used for dependency convergence in odata-generator-maven-plugin -->
-			<dependency>
-				<groupId>org.codehaus.plexus</groupId>
-				<artifactId>plexus-component-annotations</artifactId>
-				<version>${plexus-component-annotations.version}</version>
-			</dependency>
 			<!--Used for dependency convergence in odata-v4-generator-->
 			<dependency>
 				<groupId>org.codehaus.woodstox</groupId>
 				<artifactId>stax2-api</artifactId>
 				<version>${stax2-api.version}</version>
+			</dependency>
+			<!--Used to resolve conflicts inside org.openapitools:openapi-generator -->
+			<dependency>
+				<groupId>jakarta.xml.bind</groupId>
+				<artifactId>jakarta.xml.bind-api</artifactId>
+				<version>${jakarta-xml-bind.version}</version>
 			</dependency>
 			<!--Used to override version 1.7.36 coming from openapi-generator -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -99,9 +99,8 @@
 		<slf4j.version>2.0.9</slf4j.version>
 		<assertj-core.version>3.24.2</assertj-core.version>
 		<assertj-vavr.version>0.4.3</assertj-vavr.version>
-		<mockito.version>5.5.0</mockito.version>
+		<mockito.version>5.7.0</mockito.version>
 		<jsonassert.version>1.5.1</jsonassert.version>
-		<arquillian.version>1.5.0.Final</arquillian.version>
 		<junit.jupiter.version>5.10.0</junit.jupiter.version>
 		<codemodel.version>2.6</codemodel.version>
 		<olingo-v4.version>4.10.0</olingo-v4.version>
@@ -138,14 +137,6 @@
 				<groupId>com.sap.cloud.sdk</groupId>
 				<artifactId>sdk-bom</artifactId>
 				<version>${sdk.version}</version>
-				<type>pom</type>
-				<scope>import</scope>
-			</dependency>
-			<!-- Imported to resolve dependency convergences with org.apache.tomee:arquillian-tomee-embedded -->
-			<dependency>
-				<groupId>org.jboss.arquillian</groupId>
-				<artifactId>arquillian-bom</artifactId>
-				<version>${arquillian.version}</version>
 				<type>pom</type>
 				<scope>import</scope>
 			</dependency>
@@ -417,6 +408,12 @@
 				<artifactId>stax2-api</artifactId>
 				<version>${stax2-api.version}</version>
 			</dependency>
+			<!--Used to override version 1.7.36 coming from openapi-generator -->
+			<dependency>
+				<groupId>org.slf4j</groupId>
+				<artifactId>slf4j-ext</artifactId>
+				<version>${slf4j.version}</version>
+			</dependency>
 			<!--Used for dependency convergence in datamodel-metadata-generator-->
 			<dependency>
 				<groupId>org.jetbrains.kotlin</groupId>
@@ -433,25 +430,11 @@
 				<artifactId>kotlin-stdlib</artifactId>
 				<version>${kotlin.version}</version>
 			</dependency>
-			<!--For dependency convergence error between wiremock-jre8 and junit-->
-			<dependency>
-				<groupId>org.hamcrest</groupId>
-				<artifactId>hamcrest-core</artifactId>
-				<version>${hamcrest-core.version}</version>
-				<scope>test</scope>
-			</dependency>
 			<!--For dependency convergence error between assertj-core and mockito-core-->
 			<dependency>
 				<groupId>net.bytebuddy</groupId>
 				<artifactId>byte-buddy</artifactId>
 				<version>${byte-buddy.version}</version>
-				<scope>test</scope>
-			</dependency>
-			<!-- Added to resolve dependency convergence between wiremock-jre8 and jetty -->
-			<dependency>
-				<groupId>org.ow2.asm</groupId>
-				<artifactId>asm</artifactId>
-				<version>9.5</version>
 				<scope>test</scope>
 			</dependency>
 			<!-- Added to resolve dependency convergence between httpclient5, httpclient, and olingo-odata2-core -->


### PR DESCRIPTION
## Context

This PR cleans up obsolete dependency convergence entries, increases outdated dependencies and more.

### Feature scope:
 
- [x] Remove Wiremock JRE8 related dependency management
- [x] Override outdated SLF4J version coming in transitively
- [x] Remove obsolete properties
- [x] Remove obsolete dependency management entries 


## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

