### PR TITLE
fix: Improve BlackDuck Scan

### DIFF
--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -7,6 +7,8 @@ steps:
     mavenExcludedScopes: ["provided", "test"]
     failOn: ['BLOCKER', 'CRITICAL', 'MAJOR']
     versioningModel: "major"
+    # detectTools: ['DETECTOR', 'BINARY_SCAN']
+    scanProperties: ['--detect.maven.excluded.modules=com.sap.cloud.sdk.*']
 
 stages:
   test:

--- a/.pipeline/config.yml
+++ b/.pipeline/config.yml
@@ -7,8 +7,7 @@ steps:
     mavenExcludedScopes: ["provided", "test"]
     failOn: ['BLOCKER', 'CRITICAL', 'MAJOR']
     versioningModel: "major"
-    # detectTools: ['DETECTOR', 'BINARY_SCAN']
-    scanProperties: ['--detect.maven.excluded.modules=com.sap.cloud.sdk.*']
+    detectTools: ['DETECTOR', 'BINARY_SCAN']
 
 stages:
   test:


### PR DESCRIPTION
## Context

This PR adjusts the BlackDuck scan to no longer produce false positives based on older versions of our own modules.

[Successful run](https://github.com/SAP/cloud-sdk-java/actions/runs/7086109307)

There is a follow-up BLI to check out if Mend can perform better: SAP/cloud-sdk-java-backlog#365

