### PR TITLE
fix: PrincipalPropagationMode

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -95,12 +95,12 @@ class DefaultHttpDestinationBuilderProxyHandler
             final PrincipalPropagationMode mode =
                 builder
                     .get(DestinationProperty.PRINCIPAL_PROPAGATION_MODE)
-                    .getOrElse(PrincipalPropagationMode.COMPATIBILITY);
+                    .getOrElse(PrincipalPropagationMode.TOKEN_FORWARDING);
 
             switch( mode ) {
-                case RECOMMENDED:
+                case TOKEN_EXCHANGE:
                     return OnBehalfOf.NAMED_USER_CURRENT_TENANT;
-                case COMPATIBILITY: // default
+                case TOKEN_FORWARDING: // default
                     builder.headerProviders(new SapConnectivityAuthenticationHeaderProvider());
                     return OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT;
                 case UNKNOWN:

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/PrincipalPropagationMode.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/PrincipalPropagationMode.java
@@ -31,8 +31,6 @@ public enum PrincipalPropagationMode
      * user.</li>
      * <li>token (principal) with technical credentials of connectivity service binding.</li>
      * </ul>
-     * <p>
-     * <strong>Note:</strong> Despite the name, we're not recommending this mode by default.
      */
     TOKEN_EXCHANGE,
 

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/PrincipalPropagationMode.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/PrincipalPropagationMode.java
@@ -18,31 +18,36 @@ import lombok.RequiredArgsConstructor;
 public enum PrincipalPropagationMode
 {
     /**
-     * Recommended principal propagation strategy.
+     * Principal propagation strategy based on exchanging the user token. <strong>This strategy is generally NOT
+     * recommended</strong>. Please consider switching to {@link #TOKEN_FORWARDING} instead.
      * <p>
-     * <strong>Header:</strong> "Proxy-Authorization" Token exchange (JWT Bearer Token Grant) on behalf of current user
-     * token (principal) with technical credentials of connectivity service binding. The OAuth2 service of target tenant
-     * will be used.
+     * Using the {@code TOKEN_EXCHANGE} strategy produces additional round-trips and increases the load on the XSUAA
+     * service. The XSUAA service is rate limited, so this strategy can lead to on-premise calls being blocked by that
+     * rate limit.
      * <p>
-     * <strong>Note:</strong> The OAuth2 service of target tenant will be used.
+     * Using this strategy the following headers will be populated:
+     * <ul>
+     * <li><strong>Header:</strong> "Proxy-Authorization" Token exchange (JWT Bearer Token Grant) on behalf of current
+     * user.</li>
+     * <li>token (principal) with technical credentials of connectivity service binding.</li>
+     * </ul>
      * <p>
-     * <strong>Note:</strong> Despite the name, we're not recommending this mode by default. Due to token exchanges and
-     * additional round-trips, this leads to an increased load on the XSUAA service instance. The platform rate limiter
-     * could quickly block further OnPremise calls.
+     * <strong>Note:</strong> Despite the name, we're not recommending this mode by default.
      */
-    RECOMMENDED,
+    TOKEN_EXCHANGE,
 
     /**
-     * Compatibility mode for principal propagation.
+     * Principal propagation strategy based on forwarding the user token.
      * <p>
-     * <strong>Header:</strong> "Proxy-Authorization" Token lookup (Client Credentials Grant) on behalf of technical
-     * credentials of connectivity service binding.
-     * <p>
-     * <strong>Header:</strong> "SAP-Connectivity-Authentication" Token forwarding of current user token (principal).
-     * <p>
-     * <strong>Note:</strong> The OAuth2 service of target tenant will be used.
+     * Using this strategy the following headers will be populated:
+     * <ul>
+     * <li><strong>Header:</strong> "Proxy-Authorization" Token lookup (Client Credentials Grant) on behalf of a
+     * technical user for the current tenant using the credentials of connectivity service binding.</li>
+     * <li><strong>Header:</strong> "SAP-Connectivity-Authentication" Token forwarding of current user token
+     * (principal).</li>
+     * </ul>
      */
-    COMPATIBILITY,
+    TOKEN_FORWARDING,
 
     /**
      * Unknown principal propagation mode.

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandlerTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandlerTest.java
@@ -188,7 +188,7 @@ class DefaultHttpDestinationBuilderProxyHandlerTest
                 .builder(uri)
                 .proxyType(ProxyType.ON_PREMISE)
                 .authenticationType(AuthenticationType.PRINCIPAL_PROPAGATION)
-                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.COMPATIBILITY);
+                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.TOKEN_FORWARDING);
 
         // test
         final DefaultHttpDestination result = new DefaultHttpDestinationBuilderProxyHandler().handle(builder);
@@ -216,7 +216,7 @@ class DefaultHttpDestinationBuilderProxyHandlerTest
                 .builder(uri)
                 .proxyType(ProxyType.ON_PREMISE)
                 .authenticationType(AuthenticationType.PRINCIPAL_PROPAGATION)
-                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.RECOMMENDED);
+                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.TOKEN_EXCHANGE);
 
         // test
         final DefaultHttpDestination result = new DefaultHttpDestinationBuilderProxyHandler().handle(builder);

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
@@ -121,7 +121,7 @@ class ConnectivityServiceTest
                 .builder("http://buzz/")
                 .proxyType(ProxyType.ON_PREMISE)
                 .authenticationType(AuthenticationType.PRINCIPAL_PROPAGATION)
-                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.COMPATIBILITY)
+                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.TOKEN_FORWARDING)
                 .property(DestinationProperty.TENANT_ID, providerTenantId);
 
         final DefaultHttpDestination dest = new DefaultHttpDestinationBuilderProxyHandler().handle(builder);
@@ -204,7 +204,7 @@ class ConnectivityServiceTest
                 .builder("http://buzz/")
                 .proxyType(ProxyType.ON_PREMISE)
                 .authenticationType(AuthenticationType.PRINCIPAL_PROPAGATION)
-                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.RECOMMENDED)
+                .property(DestinationProperty.PRINCIPAL_PROPAGATION_MODE, PrincipalPropagationMode.TOKEN_EXCHANGE)
                 .property(DestinationProperty.TENANT_ID, providerTenantId);
 
         final DefaultHttpDestination dest = new DefaultHttpDestinationBuilderProxyHandler().handle(builder);

--- a/release_notes_next_major.md
+++ b/release_notes_next_major.md
@@ -172,6 +172,10 @@ blog: https://blogs.sap.com/?p=xxx
     - The `user(String)` and `password(String)` methods have been replaced with `basicCredentials(String, String)`.
     - Using any overload of `basicCredentials` will now automatically set the `AuthenticationType` to `BASIC_AUTHENTICATION`.
     - Using `proxyConfiguration(ProxyConfiguration)` will now throw an `IllegalArgumentException` in case the contained `Credentials` are not supported. Supported types are `BearerCredentials` and `NoCredentials`.
+  - `PrincipalPropagationStrategy` has been replaced by `PrincipalPropagationMode`.
+    - `PrincipalPropagationStrategy.RECOMMENDED` is now `PrincipalPropagationMode.TOKEN_EXCHANGE`
+    - `PrincipalPropagationStrategy.COMPATIBILITY` is now `PrincipalPropagationMode.TOKEN_FORWARDING`
+    - `PrincipalPropagationStrategy.setDefaultStrategy` has been removed. The strategy can now be configured by setting the `DestinationProperty.PRINCIPAL_PROPAGATION_MODE`.
   - The `BearerCredentials` behavior has been adjusted slightly: The `getToken()` method no longer just returns the value passed in via the constructor but instead is now guaranteed to **NOT** contain the prefix `"Bearer "`. To compensate this change, the `#getHttpHeaderValue()` method has been added, which is guaranteed to contain the `"Bearer "` prefix.
   - Invoking `HttpDestination#getHeaders(...)` may throw a `ResilienceRuntimeException` in case On-Premise Connectivity proxy headers cannot be resolved.
     As usual, the specific error cause is attached to the exception.


### PR DESCRIPTION
## Context

This PR renames the `PrincipalPropagationMode` entries to more expressive terms. Intentionally breaking the API so that any users actively notice the change and switch to the recommended (default) `TOKEN_FORWARDING`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [ ] Documentation updated
- [x] Release notes updated

