### PR TITLE
`ServiceBindingDestinationLoader` returns `Destination` instead of `HttpDestination`

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultServiceBindingDestinationLoaderChain.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultServiceBindingDestinationLoaderChain.java
@@ -24,13 +24,13 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * This implementation is a utility class that is capable of transforming a given
- * {@link ServiceBindingDestinationOptions} into a {@link HttpDestination}. Internally, this is done by leveraging the
+ * {@link ServiceBindingDestinationOptions} into a {@link Destination}. Internally, this is done by leveraging the
  * {@link ServiceBindingDestinationLoader} API.
  * <p>
  * <u>Usage Example:</u>
  *
  * <pre>
- * private Try<HttpDestination> tryGetDestinationServiceBinding( ServiceBinding serviceBinding )
+ * private Try<Destination> tryGetDestinationServiceBinding( ServiceBinding serviceBinding )
  * {
  *     ServiceBindingDestinationOptions options =
  *         ServiceBindingDestinationOptions.builder(BindableService.DESTINATION, serviceBinding).build();
@@ -75,7 +75,7 @@ class DefaultServiceBindingDestinationLoaderChain implements ServiceBindingDesti
 
     @Override
     @Nonnull
-    public Try<HttpDestination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
+    public Try<Destination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
     {
         if( delegateLoaders.isEmpty() ) {
             log.warn("No delegate loaders. As a consequence, the transformation will not be attempted.");
@@ -85,11 +85,11 @@ class DefaultServiceBindingDestinationLoaderChain implements ServiceBindingDesti
         final ServiceBinding serviceBinding = options.getServiceBinding();
         final List<Throwable> suppressedExceptions = new ArrayList<>();
         for( final ServiceBindingDestinationLoader loader : delegateLoaders ) {
-            final Try<HttpDestination> result = loader.tryGetDestination(options);
+            final Try<Destination> result = loader.tryGetDestination(options);
             if( log.isDebugEnabled() ) {
                 final String msg = "Transformation of service binding ({}) to an {} using an instance of {} {}.";
                 final String state = result.isSuccess() ? "succeeded" : "failed";
-                log.debug(msg, serviceBindingToString(serviceBinding), HttpDestination.class, loader.getClass(), state);
+                log.debug(msg, serviceBindingToString(serviceBinding), Destination.class, loader.getClass(), state);
             }
 
             if( result.isSuccess() ) {
@@ -150,7 +150,7 @@ class DefaultServiceBindingDestinationLoaderChain implements ServiceBindingDesti
     static final class NoDelegateLoadersExceptionHolder
     {
         @Nonnull
-        static final Try<HttpDestination> NO_DELEGATE_LOADERS =
+        static final Try<Destination> NO_DELEGATE_LOADERS =
             Try
                 .failure(
                     new DestinationAccessException(
@@ -158,6 +158,6 @@ class DefaultServiceBindingDestinationLoaderChain implements ServiceBindingDesti
                             .format(
                                 "There are no delegate loaders that could perform the %s to %s transformation. Make sure at least one loader is available on the classpath by, for example, having the 'connectivity-oauth' dependency in your project.",
                                 ServiceBinding.class.getSimpleName(),
-                                HttpDestination.class.getSimpleName())));
+                                Destination.class.getSimpleName())));
     }
 }

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ServiceBindingDestinationLoader.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ServiceBindingDestinationLoader.java
@@ -17,7 +17,7 @@ import io.vavr.control.Try;
 
 /**
  * Represents a class that is capable of transforming a {@link ServiceBinding} and
- * {@link ServiceBindingDestinationOptions} into an {@link HttpDestination}.
+ * {@link ServiceBindingDestinationOptions} into a {@link Destination}.
  *
  * @since 4.16.0
  */
@@ -29,7 +29,7 @@ public interface ServiceBindingDestinationLoader
      * Returns the default <i>loader chain</i> instance. This instance will locate all available
      * {@link ServiceBindingDestinationLoader} implementations (using the <i>service loader pattern</i>) on the
      * classpath. Those instances will be queried <b>in no particular order</b> to try to transform the provided
-     * {@link ServiceBindingDestinationOptions} into an {@link HttpDestination}.
+     * {@link ServiceBindingDestinationOptions} into a {@link Destination}.
      *
      * @return The default <i>loader chain</i> instance.
      */
@@ -41,8 +41,8 @@ public interface ServiceBindingDestinationLoader
 
     /**
      * Returns a new <i>loader chain</i> instance that will query the provided {@code delegateLoaders} <b>in the
-     * provided order</b> to try to transform the provided {@link ServiceBindingDestinationOptions} into an
-     * {@link HttpDestination}.
+     * provided order</b> to try to transform the provided {@link ServiceBindingDestinationOptions} into a
+     * {@link Destination}.
      *
      * @param delegateLoaders
      *            The {@link ServiceBindingDestinationLoader} instances that should be used.
@@ -56,7 +56,7 @@ public interface ServiceBindingDestinationLoader
     }
 
     /**
-     * Tries to transform the given {@code serviceBinding} and {@code options} into an {@link HttpDestination}.
+     * Tries to transform the given {@code serviceBinding} and {@code options} into a {@link Destination}.
      *
      * @param options
      *            The {@link ServiceBindingDestinationOptions} that contain further context information about how the
@@ -70,10 +70,10 @@ public interface ServiceBindingDestinationLoader
      *         </p>
      */
     @Nonnull
-    Try<HttpDestination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options );
+    Try<Destination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options );
 
     /**
-     * Tries to transform the given {@code options} into an {@link HttpDestination}.
+     * Tries to transform the given {@code options} into a {@link Destination}.
      * <p>
      * This method is equivalent to {@code tryGetDestination(options).get();}.
      * </p>
@@ -81,14 +81,14 @@ public interface ServiceBindingDestinationLoader
      * @param options
      *            The {@link ServiceBindingDestinationOptions} that contain further context information (such as the
      *            {@link ServiceBinding} that should be transformed) for the transformation process.
-     * @return An {@link HttpDestination} that can be used to connect to be bound service.
+     * @return A {@link Destination} that can be used to connect to be bound service.
      * @throws DestinationAccessException
-     *             Thrown if the provided {@code options} couldn't be transformed into an {@link HttpDestination}.
+     *             Thrown if the provided {@code options} couldn't be transformed into a {@link Destination}.
      * @throws DestinationNotFoundException
-     *             Thrown if no {@link HttpDestination} could be found for the provided {@code options}.
+     *             Thrown if no {@link Destination} could be found for the provided {@code options}.
      */
     @Nonnull
-    default HttpDestination getDestination( @Nonnull final ServiceBindingDestinationOptions options )
+    default Destination getDestination( @Nonnull final ServiceBindingDestinationOptions options )
         throws DestinationAccessException,
             DestinationNotFoundException
     {

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandlerTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandlerTest.java
@@ -51,7 +51,7 @@ class DefaultHttpDestinationBuilderProxyHandlerTest
     {
         @Nonnull
         @Override
-        public Try<HttpDestination> tryGetDestination( @Nonnull ServiceBindingDestinationOptions options )
+        public Try<Destination> tryGetDestination( @Nonnull ServiceBindingDestinationOptions options )
         {
             return Try.success(mock(DefaultHttpDestination.class));
         }

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultServiceBindingDestinationLoaderChainTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultServiceBindingDestinationLoaderChainTest.java
@@ -40,7 +40,7 @@ class DefaultServiceBindingDestinationLoaderChainTest
         final DefaultServiceBindingDestinationLoaderChain sut =
             new DefaultServiceBindingDestinationLoaderChain(Collections.emptyList());
 
-        final Try<HttpDestination> result = sut.tryGetDestination(TEST_OPTIONS);
+        final Try<Destination> result = sut.tryGetDestination(TEST_OPTIONS);
         assertThat(result.isFailure()).isTrue();
         assertThat(result)
             .isSameAs(DefaultServiceBindingDestinationLoaderChain.NoDelegateLoadersExceptionHolder.NO_DELEGATE_LOADERS);
@@ -57,7 +57,7 @@ class DefaultServiceBindingDestinationLoaderChainTest
         final DefaultServiceBindingDestinationLoaderChain sut =
             new DefaultServiceBindingDestinationLoaderChain(Collections.singletonList(loader));
 
-        final Try<HttpDestination> result = sut.tryGetDestination(TEST_OPTIONS);
+        final Try<Destination> result = sut.tryGetDestination(TEST_OPTIONS);
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isExactlyInstanceOf(DestinationNotFoundException.class);
     }
@@ -73,7 +73,7 @@ class DefaultServiceBindingDestinationLoaderChainTest
         final DefaultServiceBindingDestinationLoaderChain sut =
             new DefaultServiceBindingDestinationLoaderChain(Collections.singletonList(loader));
 
-        final Try<HttpDestination> result = sut.tryGetDestination(TEST_OPTIONS);
+        final Try<Destination> result = sut.tryGetDestination(TEST_OPTIONS);
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isSameAs(expectedCause);
     }
@@ -89,7 +89,7 @@ class DefaultServiceBindingDestinationLoaderChainTest
         final DefaultServiceBindingDestinationLoaderChain sut =
             new DefaultServiceBindingDestinationLoaderChain(Collections.singletonList(loader));
 
-        final Try<HttpDestination> result = sut.tryGetDestination(TEST_OPTIONS);
+        final Try<Destination> result = sut.tryGetDestination(TEST_OPTIONS);
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause())
             .isExactlyInstanceOf(DestinationAccessException.class)
@@ -101,17 +101,17 @@ class DefaultServiceBindingDestinationLoaderChainTest
     void testTryGetDestinationReturnsFirstMatchingResult()
     {
         final ServiceBindingDestinationLoader firstLoader = mock(ServiceBindingDestinationLoader.class);
-        final Try<HttpDestination> firstSuccess = Try.success(mock(HttpDestination.class));
+        final Try<Destination> firstSuccess = Try.success(mock(Destination.class));
         when(firstLoader.tryGetDestination(any())).thenReturn(firstSuccess);
 
         final ServiceBindingDestinationLoader secondLoader = mock(ServiceBindingDestinationLoader.class);
-        final Try<HttpDestination> secondSuccess = Try.success(mock(HttpDestination.class));
+        final Try<Destination> secondSuccess = Try.success(mock(Destination.class));
         when(secondLoader.tryGetDestination(any())).thenReturn(secondSuccess);
 
         final DefaultServiceBindingDestinationLoaderChain sut =
             new DefaultServiceBindingDestinationLoaderChain(Arrays.asList(firstLoader, secondLoader));
 
-        final Try<HttpDestination> result = sut.tryGetDestination(TEST_OPTIONS);
+        final Try<Destination> result = sut.tryGetDestination(TEST_OPTIONS);
         assertThat(result.isSuccess()).isTrue();
         assertThat(result).isSameAs(firstSuccess);
         assertThat(result).isNotSameAs(secondSuccess);

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoader.java
@@ -22,8 +22,8 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * Representation of the <i>Megaclite</i> service as provided in <i>Deploy with Confidence</i> landscapes. This class
- * can be used to convert {@link MegacliteServiceBinding} instances into {@link HttpDestination} that use Megaclite as
- * an egress proxy.
+ * can be used to convert {@link MegacliteServiceBinding} instances into {@link Destination} that use Megaclite as an
+ * egress proxy.
  *
  * @see MegacliteServiceBinding
  * @see MegacliteServiceBindingAccessor
@@ -43,7 +43,7 @@ public final class MegacliteServiceBindingDestinationLoader implements ServiceBi
 
     @Nonnull
     @Override
-    public Try<HttpDestination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
+    public Try<Destination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
     {
         final MegacliteServiceBinding megacliteServiceBinding;
 
@@ -68,7 +68,7 @@ public final class MegacliteServiceBindingDestinationLoader implements ServiceBi
     }
 
     @Nonnull
-    private Try<HttpDestination> tryGetConnectivityDestination(
+    private Try<Destination> tryGetConnectivityDestination(
         @Nonnull final OnBehalfOf onBehalfOf,
         @Nonnull final ServiceBindingDestinationOptions options )
     {

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
@@ -122,7 +122,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         final ServiceBindingDestinationOptions options =
             ServiceBindingDestinationOptions.forService(BINDING_PAAS_AND_SAAS).build();
 
-        final HttpDestination result = sut.getDestination(options);
+        final HttpDestination result = sut.getDestination(options).asHttp();
 
         assertThat(result.getUri())
             .isEqualTo(megacliteUrl.resolve("/megaclite-version-saas/destination-saas/version-saas/"));
@@ -141,7 +141,7 @@ class MegacliteServiceBindingDestinationLoaderTest
                 .onBehalfOf(OnBehalfOf.TECHNICAL_USER_PROVIDER)
                 .build();
 
-        final HttpDestination result = sut.getDestination(options);
+        final HttpDestination result = sut.getDestination(options).asHttp();
 
         assertThat(result.getUri())
             .isEqualTo(megacliteUrl.resolve("/megaclite-version-paas/destination-paas/version-paas/"));
@@ -162,7 +162,7 @@ class MegacliteServiceBindingDestinationLoaderTest
                 .onBehalfOf(OnBehalfOf.NAMED_USER_CURRENT_TENANT)
                 .build();
 
-        final HttpDestination result = sut.getDestination(options);
+        final HttpDestination result = sut.getDestination(options).asHttp();
 
         assertThat(result.getUri())
             .describedAs("Named user should behave the same as current tenant")
@@ -180,7 +180,7 @@ class MegacliteServiceBindingDestinationLoaderTest
                 .build();
         final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();
 
-        final Try<HttpDestination> result = sut.tryGetDestination(options);
+        final Try<Destination> result = sut.tryGetDestination(options);
 
         assertThatThrownBy(result::get).isExactlyInstanceOf(DestinationNotFoundException.class);
     }
@@ -196,7 +196,7 @@ class MegacliteServiceBindingDestinationLoaderTest
 
         // create a loader without mocked DwC config
         sut = new MegacliteServiceBindingDestinationLoader();
-        final Try<HttpDestination> result = sut.tryGetDestination(options);
+        final Try<Destination> result = sut.tryGetDestination(options);
 
         assertThatThrownBy(result::get)
             .isExactlyInstanceOf(DestinationAccessException.class)
@@ -212,7 +212,7 @@ class MegacliteServiceBindingDestinationLoaderTest
                 .onBehalfOf(OnBehalfOf.TECHNICAL_USER_PROVIDER)
                 .build();
 
-        final Try<HttpDestination> result = sut.tryGetDestination(options);
+        final Try<Destination> result = sut.tryGetDestination(options);
 
         assertThatThrownBy(result::get)
             .describedAs("A SaaS binding should not be accessible on behalf of the provider.")
@@ -229,7 +229,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         final ServiceBindingDestinationOptions options =
             ServiceBindingDestinationOptions.forService(BINDING_PAAS).build();
 
-        final Try<HttpDestination> result = sut.tryGetDestination(options);
+        final Try<Destination> result = sut.tryGetDestination(options);
 
         assertThatThrownBy(result::get)
             .describedAs("A PaaS binding should not be accessible on behalf of a subscriber tenant.")
@@ -242,7 +242,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         final ServiceBindingDestinationOptions options =
             ServiceBindingDestinationOptions.forService(BINDING_SAAS).build();
 
-        final Try<HttpDestination> result = sut.tryGetDestination(options);
+        final Try<Destination> result = sut.tryGetDestination(options);
 
         assertThatThrownBy(result::get)
             .describedAs("A SaaS binding needs the current tenant to be present.")
@@ -258,7 +258,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         final ServiceBindingDestinationOptions options =
             ServiceBindingDestinationOptions.forService(BINDING_PAAS_AND_SAAS).build();
 
-        final HttpDestination result = sut.getDestination(options);
+        final HttpDestination result = sut.getDestination(options).asHttp();
 
         assertThat(result.getUri())
             .isEqualTo(megacliteUrl.resolve("/megaclite-version-paas/destination-paas/version-paas/"));

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -31,7 +31,7 @@ import lombok.extern.slf4j.Slf4j;
 
 /**
  * An implementation of the {@link ServiceBindingDestinationLoader} interface that is capable of producing OAuth2 based
- * {@link HttpDestination} instances.
+ * {@link Destination} instances.
  * <p>
  * This class will automatically be picked up by the <i>service loader pattern</i>.
  *
@@ -125,7 +125,7 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
 
     @Nonnull
     @Override
-    public Try<HttpDestination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
+    public Try<Destination> tryGetDestination( @Nonnull final ServiceBindingDestinationOptions options )
     {
         final ServiceIdentifier identifier = options.getServiceBinding().getServiceIdentifier().orElse(null);
         log.debug("Creating an OAuth2 destination for service {}.", identifier);

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2OnPremiseIntegrationTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2OnPremiseIntegrationTest.java
@@ -50,8 +50,8 @@ class OAuth2OnPremiseIntegrationTest
 
         final OAuth2ServiceBindingDestinationLoader loader = new OAuth2ServiceBindingDestinationLoader();
 
-        final HttpDestination destination1 = loader.getDestination(connectivityOptions);
-        final HttpDestination destination2 = loader.getDestination(connectivityOptions);
+        final HttpDestination destination1 = loader.getDestination(connectivityOptions).asHttp();
+        final HttpDestination destination2 = loader.getDestination(connectivityOptions).asHttp();
 
         // No caching of destinations
         assertThat(destination1).isNotSameAs(destination2);

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
@@ -144,7 +144,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
     @Test
     void testUnknownService()
     {
-        final Try<HttpDestination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
+        final Try<Destination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isExactlyInstanceOf(DestinationNotFoundException.class);
     }
@@ -156,7 +156,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
 
         sut = mockLoader(mock);
 
-        final Try<HttpDestination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
+        final Try<Destination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
 
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isExactlyInstanceOf(DestinationNotFoundException.class);
@@ -170,7 +170,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
 
         sut = mockLoader(mock);
 
-        final Try<HttpDestination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
+        final Try<Destination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
 
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isExactlyInstanceOf(DestinationAccessException.class);
@@ -189,10 +189,10 @@ class OAuth2ServiceBindingDestinationLoaderTest
 
         sut = mockLoader(mock);
 
-        final Try<HttpDestination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
+        final Try<Destination> result = sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING);
 
         assertThat(result.isSuccess()).isTrue();
-        assertThat(result.get().getUri()).isEqualTo(baseUrl);
+        assertThat(result.get().get(DestinationProperty.URI).get()).isEqualTo(baseUrl.toString());
 
         verify(sut, times(1))
             .toDestination(
@@ -217,7 +217,10 @@ class OAuth2ServiceBindingDestinationLoaderTest
         sut = mockLoader(mock);
 
         final Try<Collection<Header>> result =
-            sut.tryGetDestination(OPTIONS_WITH_EMPTY_BINDING).map(HttpDestinationProperties::getHeaders);
+            sut
+                .tryGetDestination(OPTIONS_WITH_EMPTY_BINDING)
+                .map(Destination::asHttp)
+                .map(HttpDestinationProperties::getHeaders);
 
         assertThat(result.isFailure()).isTrue();
         assertThat(result.getCause()).isInstanceOf(IllegalArgumentException.class);
@@ -355,7 +358,8 @@ class OAuth2ServiceBindingDestinationLoaderTest
                     URI.create("proxyUrl"),
                     tokenUrl,
                     credentials,
-                    OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT);
+                    OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT)
+                .asHttp();
 
         assertThat(result.getUri()).isEqualTo(baseUrl);
         assertThat(result.getHeaders(baseUrl))
@@ -380,7 +384,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
 
         sut = new OAuth2ServiceBindingDestinationLoader();
 
-        HttpDestination result =
+        Destination result =
             sut.toDestination(baseUrl, tokenUrl, credentials, OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT, TEST_SERVICE);
 
         assertThat(result.get(OAuth2HeaderProvider.PROPERTY_OAUTH2_RESILIENCE_CONFIG)).isNotEmpty();


### PR DESCRIPTION
## Context
This aligns the API with `DestinationLoader`

SAP/cloud-sdk-java-backlog#ISSUENUMBER.


Please provide a short description of what your change does and why it is needed.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [ ] Task1 
- [ ] Task2 
  - [ ] SubTask1 

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
