### PR TITLE
fix: error handling in OAuth2ServiceBindingDestinationLoader

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -148,6 +148,10 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
         catch( final DestinationAccessException e ) {
             return Try.failure(e);
         }
+        catch( final Exception e ) {
+            final String msg = "Failed to retrieve OAuth2 properties for service binding of service '%s'.";
+            return Try.failure(new DestinationAccessException(String.format(msg, identifier), e));
+        }
 
         final Option<HttpDestination> destinationToBeProxied = options.getOption(Options.ProxyOptions.class);
 


### PR DESCRIPTION
This PR fixes the error handling in our `OAuth2ServiceBindingDestinationLoader` in cases where a (customer-provided) `OAuth2PropertySupplier` throws an Exception in any of the getters.