### PR TITLE
fix: XSUAA Test Code in Archetype for Spring Boot 3.2.0

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/pom.xml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/pom.xml
@@ -40,6 +40,17 @@
         <jacoco.excludes>org.apache.*</jacoco.excludes>
     </properties>
 
+    <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.eclipse.jetty</groupId>
+                <artifactId>jetty-bom</artifactId>
+                <version>11.0.18</version>
+                <scope>import</scope>
+                <type>pom</type>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>${groupId}</groupId>


### PR DESCRIPTION
## Context

Fixes a dependency conflict between XSUAA testing lib and Spring Boot.
