### PR TITLE
fix: automatically release once the deployment succeeds

### DIFF
--- a/.github/workflows/perform_release.yml
+++ b/.github/workflows/perform_release.yml
@@ -76,7 +76,7 @@ jobs:
           -DnexusUrl=https://oss.sonatype.org
           -DrepositoryDirectory=./temp_local_repo
           -DstagingProfileId=$MAVEN_CENTRAL_PROFILE_ID
-          -DautoReleaseAfterClose=false
+          -DautoReleaseAfterClose=true
 
         env:
           MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#358.


This PR changed our `perform-release` pipeline to automatically publish our release once the deployment succeeds.
That way, no more manual action is needed to finish the release.