### PR TITLE
[Fix] Invalid Destination Domain Throws

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriBuilder.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriBuilder.java
@@ -20,12 +20,8 @@ public class UriBuilder
      *
      * @param scheme
      *            The connection scheme of the URI.
-     * @param userInfo
-     *            The user information for the URI.
-     * @param host
-     *            The connection host of the URI.
-     * @param port
-     *            The port to connect on. Use -1 to ignore the port.
+     * @param authority
+     *            The authority of the URI.
      * @param path
      *            The path to the resource on the host (if the host is given).
      * @param query
@@ -41,9 +37,7 @@ public class UriBuilder
     @Nonnull
     public URI build(
         @Nullable final String scheme,
-        @Nullable final String userInfo,
-        @Nullable final String host,
-        final int port,
+        @Nullable final String authority,
         @Nullable final String path,
         @Nullable final String query,
         @Nullable final String fragment )
@@ -56,24 +50,9 @@ public class UriBuilder
             sb.append(':');
         }
 
-        if( host != null ) {
+        if( authority != null ) {
             sb.append("//");
-            if( userInfo != null ) {
-                sb.append(userInfo);
-                sb.append('@');
-            }
-            final boolean needBrackets = host.indexOf(':') >= 0 && !host.startsWith("[") && !host.endsWith("]");
-            if( needBrackets ) {
-                sb.append('[');
-            }
-            sb.append(host);
-            if( needBrackets ) {
-                sb.append(']');
-            }
-            if( port != -1 ) {
-                sb.append(':');
-                sb.append(port);
-            }
+            sb.append(authority);
         }
 
         if( path != null ) {

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMerger.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMerger.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
-import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationPathsNotMergeableException;
 import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
 
@@ -60,11 +59,6 @@ public class UriPathMerger
             throw new DestinationPathsNotMergeableException("The destination URI must be absolute OR empty.");
         }
 
-        if( primaryUri.getHost() == null ) {
-            throw new DestinationAccessException(
-                "Invalid destination domain name. Please follow the format https://www.ietf.org/rfc/rfc2396.txt Page 14.");
-        }
-
         if( secondaryUri == null ) {
             return primaryUri.getRawPath().isEmpty() ? primaryUri.resolve("/") : primaryUri;
         }
@@ -84,9 +78,7 @@ public class UriPathMerger
                 new UriBuilder()
                     .build(
                         primaryUri.getScheme(),
-                        primaryUri.getRawUserInfo(),
-                        primaryUri.getHost(),
-                        primaryUri.getPort(),
+                        primaryUri.getRawAuthority(),
                         mergeRootPath,
                         StringUtils.trimToNull(mergeQuery),
                         Option.of(secondaryUri.getRawFragment()).getOrElse(primaryUri::getRawFragment));
@@ -102,12 +94,8 @@ public class UriPathMerger
     private void assertSecondaryHostMatchesPrimaryHost( @Nonnull final URI primaryUri, @Nonnull final URI secondaryUri )
         throws DestinationPathsNotMergeableException
     {
-        if( secondaryUri.getHost() != null ) {
-            final boolean isSchemeEqual = primaryUri.getScheme().equalsIgnoreCase(secondaryUri.getScheme());
-            final boolean isHostEqual = primaryUri.getHost().equalsIgnoreCase(secondaryUri.getHost());
-            final boolean isPortEqual = primaryUri.getPort() == secondaryUri.getPort();
-
-            if( !(isSchemeEqual && isHostEqual && isPortEqual) ) {
+        if( secondaryUri.getRawAuthority() != null ) {
+            if( !primaryUri.getRawAuthority().equals(secondaryUri.getRawAuthority()) ) {
                 throw new DestinationPathsNotMergeableException(
                     String
                         .format(

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMerger.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMerger.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 
 import org.apache.commons.lang3.StringUtils;
 
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationPathsNotMergeableException;
 import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
 
@@ -57,6 +58,11 @@ public class UriPathMerger
 
         if( !primaryUri.isAbsolute() ) {
             throw new DestinationPathsNotMergeableException("The destination URI must be absolute OR empty.");
+        }
+
+        if( primaryUri.getHost() == null ) {
+            throw new DestinationAccessException(
+                "Invalid destination domain name. Please follow the format https://www.ietf.org/rfc/rfc2396.txt Page 14.");
         }
 
         if( secondaryUri == null ) {

--- a/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
@@ -14,6 +14,7 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationPathsNotMergeableException;
 
 class UriPathMergerTest
@@ -173,5 +174,12 @@ class UriPathMergerTest
     {
         assertThatThrownBy(() -> merge("/relative/path", "https://some.url/with?parameter=foo"))
             .isExactlyInstanceOf(DestinationPathsNotMergeableException.class);
+    }
+
+    @Test
+    void testInvalidDestinationDomainThrows()
+    {
+        assertThatThrownBy(() -> merge("https://test_1.com/", "https://some.url/with?parameter=foo"))
+                .isExactlyInstanceOf(DestinationAccessException.class);
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
@@ -180,6 +180,6 @@ class UriPathMergerTest
     void testInvalidDestinationDomainThrows()
     {
         assertThatThrownBy(() -> merge("https://test_1.com/", "https://some.url/with?parameter=foo"))
-                .isExactlyInstanceOf(DestinationAccessException.class);
+            .isExactlyInstanceOf(DestinationAccessException.class);
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriPathMergerTest.java
@@ -14,7 +14,6 @@ import javax.annotation.Nullable;
 
 import org.junit.jupiter.api.Test;
 
-import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationPathsNotMergeableException;
 
 class UriPathMergerTest
@@ -177,9 +176,11 @@ class UriPathMergerTest
     }
 
     @Test
-    void testInvalidDestinationDomainThrows()
+    void testInvalidDestinationDomain()
     {
-        assertThatThrownBy(() -> merge("https://test_1.com/", "https://some.url/with?parameter=foo"))
-            .isExactlyInstanceOf(DestinationAccessException.class);
+        testMerge(
+            "https://test_1.com/",
+            "https://test_1.com/with?parameter=foo",
+            URI.create("https://test_1.com/with?parameter=foo"));
     }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,6 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 
 ## 🐛 Fixed Issues
 
-- Fix an issue where an invalid URL in a destination would lead to an empty hostname.
+- Fix an issue where an invalid hostname in a destination would lead to an empty hostname. The hostname is now accepted.
 
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,7 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 
 ## 🐛 Fixed Issues
 
-- Invalid destination domain names now throw a DestinationAccessException when executing a request.
+- Fix an issue where an invalid URL in a destination would lead to an empty hostname.
+  Now a `DestinationAccessException` will be thrown upon executing a request, if the URL domain contains a hostname that violates [RFC 2396](https://www.ietf.org/rfc/rfc2396.txt).
 
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,6 +25,6 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 
 ## 🐛 Fixed Issues
 
-- 
+- Invalid destination domain names now throw a DestinationAccessException when executing a request.
 
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -26,6 +26,5 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 ## 🐛 Fixed Issues
 
 - Fix an issue where an invalid URL in a destination would lead to an empty hostname.
-  Now a `DestinationAccessException` will be thrown upon executing a request, if the URL domain contains a hostname that violates [RFC 2396](https://www.ietf.org/rfc/rfc2396.txt).
 
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Closes SAP/cloud-sdk-java-backlog#382.


Invalid domain names break our `UriPathMerger`, which sends a broken URI to the HttpClient.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Add a meaningful exception message if `UriPathMerger` if `getHost` is null

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
