### PR TITLE
feat: [Destinations] Warn on Expired Auth Token Usage

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AuthTokenHeaderProvider.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AuthTokenHeaderProvider.java
@@ -5,9 +5,11 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import static com.sap.cloud.sdk.cloudplatform.connectivity.DestinationServiceV1Response.DestinationAuthToken;
 
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -54,6 +56,18 @@ class AuthTokenHeaderProvider implements DestinationHeaderProvider
         } else if( isAuthTokenExpected(authenticationType) ) {
             log.warn("The destination service did not include an auth token in the response.");
         }
+
+        tokens
+            .stream()
+            .map(DestinationAuthToken::getExpiryTimestamp)
+            .filter(Objects::nonNull)
+            .filter(expiry -> expiry.isBefore(LocalDateTime.now()))
+            .forEach(
+                expiry -> log
+                    .warn(
+                        "An authorization token of destination {} has expired. "
+                            + "Please ensure that you don't reuse destination objects in your code for longer periods of time.",
+                        destination.get(DestinationProperty.NAME).getOrElse(destination::toString)));
 
         return result;
     }

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,6 +20,7 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 
 ## 📈 Improvements
 
+- A warning is now logged when destinations with expired authentication tokens are used for requests.
 - SAP dependency updates:
   - Update the [SAP Security Library](https://github.com/SAP/cloud-security-services-integration-library) from `3.3.0` to `3.3.1`
 


### PR DESCRIPTION
## Context

This PR adds a warning which is logged when headers for an expired auth token are accessed.

We could also consider throwing an exception, but for now I didn't do that for two reasons:

* The destination service could send incorrect expiry information, or there may be a grace period
* Headers may be accessed also outside of actually executing requests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] ~Tests cover the scope above~
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated

