### PR TITLE
Re-Added `UriBuilder.build` but deprecated

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriBuilder.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/UriBuilder.java
@@ -20,6 +20,65 @@ public class UriBuilder
      *
      * @param scheme
      *            The connection scheme of the URI.
+     * @param userInfo
+     *            The user information for the URI.
+     * @param host
+     *            The connection host of the URI.
+     * @param port
+     *            The port to connect on. Use -1 to ignore the port.
+     * @param path
+     *            The path to the resource on the host (if the host is given).
+     * @param query
+     *            The query to append to the URI.
+     * @param fragment
+     *            Any remaining fragments that should be appended to the URI.
+     *
+     * @return A valid URI bases on the components given.
+     *
+     * @throws URISyntaxException
+     *             If the given parameter cannot be combined into a valid {@link URI}, see {@link URI#URI(String)}
+     * @deprecated Please use {@link #build(String , String, String, String, String)} instead.
+     */
+    @Nonnull
+    @Deprecated
+    public URI build(
+        @Nullable final String scheme,
+        @Nullable final String userInfo,
+        @Nullable final String host,
+        final int port,
+        @Nullable final String path,
+        @Nullable final String query,
+        @Nullable final String fragment )
+        throws URISyntaxException
+    {
+        final StringBuilder sb = new StringBuilder();
+
+        if( host != null ) {
+            if( userInfo != null ) {
+                sb.append(userInfo);
+                sb.append('@');
+            }
+            final boolean needBrackets = host.indexOf(':') >= 0 && !host.startsWith("[") && !host.endsWith("]");
+            if( needBrackets ) {
+                sb.append('[');
+            }
+            sb.append(host);
+            if( needBrackets ) {
+                sb.append(']');
+            }
+            if( port != -1 ) {
+                sb.append(':');
+                sb.append(port);
+            }
+        }
+        return build(scheme, sb.toString(), path, query, fragment);
+    }
+
+    /**
+     * Builds an {@link URI} based on the given parameter.
+     *
+     * @param scheme
+     *            The connection scheme of the URI.
      * @param authority
      *            The authority of the URI.
      * @param path

--- a/release_notes.md
+++ b/release_notes.md
@@ -10,7 +10,8 @@ docs: https://sap.github.io/cloud-sdk/docs/java/release-notes
 
 ## 🔧 Compatibility Notes
 
-- 
+- `UriBuilder.build(scheme, userInfo, host, port, path, query, fragment)` has been deprecated in favor of
+ `UriBuilder.build(scheme, authority, path, query, fragment)`.
 
 
 ## ✨ New Functionality


### PR DESCRIPTION
## Context
[[Fix] Invalid Destination Domain Throws](https://github.com/SAP/cloud-sdk-java/pull/189#top) removed a public method by accident. This PR re-adds the deleted method but deprecated.
I manually edited UriPathMerger to use the deprecated method and manually ran the UriPathMergerTest👍

### Feature scope:

- [x] Remove the breaking change

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above (manually tested)
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated