### PR TITLE
fix: Archetype Release

### DIFF
--- a/.pipeline/scripts/generate-release-artifacts.py
+++ b/.pipeline/scripts/generate-release-artifacts.py
@@ -120,8 +120,7 @@ def generate_execution(path_prefix, phase, goal, module, sdk_version):
         file = pom_path
     elif module["packaging"] == "maven-archetype" or module["packaging"] == "maven-plugin":
         file = artifact_path + ".jar"
-        if phase == "install":
-            packaging = "jar"
+        packaging = "jar"
     return f"""
                   <execution>
                       <id>{phase}-{module["artifactId"]}</id>


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#358.


This PR provides **a quick-fix** for our archetype deployment issue.

The fix has been tested as part of [my fork repository](https://github.com/Johannes-Schneider/cloud-sdk-java), where I was able to successfully publish version `0.0.2`.

<details>
<summary>Deployment Difference</summary>

The **old** deployment that contains _spring-boot3-5.0.0.**maven-archetype**_ (incorrect file extension):
![image](https://github.com/SAP/cloud-sdk-java/assets/9248711/676827d8-8aa0-4a9f-84d0-47c8d73e0f17)

---

The **new** deployment that contains _spring-boot3-0.0.2.**jar**_ (correct file extension):
![image](https://github.com/SAP/cloud-sdk-java/assets/9248711/637bc18c-eb53-42a9-b963-709d3df5be85)

</details>

