### PR TITLE
Fix compatibility v4 / v5 with CAP

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestination.java
@@ -77,7 +77,15 @@ public final class DefaultDestination implements Destination
         return getClass().getSimpleName() + "(properties=" + nonSensitiveProperties + ")";
     }
 
-    private DefaultDestination( @Nonnull final Map<String, ?> properties )
+    /**
+     * Creates a new {@code DefaultDestination} with the given properties.
+     *
+     * @deprecated Please use static {@link #fromMap()} instead.
+     * @param properties
+     *            the properties to be used for the destination builder.
+     */
+    @Deprecated
+    public DefaultDestination( @Nonnull final Map<String, ?> properties )
     {
         this.properties.putAll(properties);
     }


### PR DESCRIPTION
Currently CAP has to make the following code change in their productive code (non-test) for migrating to SDK v5:

```diff
- httpDestination = new DefaultDestination(destination.getProperties()).asHttp();
+ httpDestination = DefaultHttpDestination.fromMap(destination.getProperties()).build();
```

Implication:
* There's a chance for users of SDK v5 + CAP v2 to experience runtime exception about constructor visibility.

We could solve it by making the constructor public again.


Uses in current CAP here:
* https://github.wdf.sap.corp/cds-java/cds-services/blob/main/cds-feature-remote-odata/src/main/java/com/sap/cds/services/impl/odata/RemoteODataClient.java#L88
* https://github.wdf.sap.corp/cds-java/cds-services/blob/main/cds-feature-remote-hcql/src/main/java/com/sap/cds/services/impl/hcql/RemoteHcqlClient.java#L95