### PR TITLE
chore: [Destinations] Improve Test for Destination Service Option Combinations

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -9,10 +9,8 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -346,24 +344,6 @@ public final class DefaultHttpDestination implements HttpDestination
     public Option<ProxyType> getProxyType()
     {
         return cachedProxyType;
-    }
-
-    @Nonnull
-    @Override
-    public String toString()
-    {
-        final Map<String, Object> nonSensitiveProperties = new HashMap<>();
-
-        for( final String key : baseProperties.getPropertyNames() ) {
-            Object value = baseProperties.get(key).getOrNull();
-            if( key.toLowerCase(Locale.ENGLISH).contains("password")
-                || key.toLowerCase(Locale.ENGLISH).contains("key") ) {
-                value = "(hidden)";
-            }
-            nonSensitiveProperties.put(key, value);
-        }
-
-        return getClass().getSimpleName() + "(properties=" + nonSensitiveProperties + ")";
     }
 
     /**

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -9,8 +9,10 @@ import java.security.KeyStore;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
@@ -344,6 +346,24 @@ public final class DefaultHttpDestination implements HttpDestination
     public Option<ProxyType> getProxyType()
     {
         return cachedProxyType;
+    }
+
+    @Nonnull
+    @Override
+    public String toString()
+    {
+        final Map<String, Object> nonSensitiveProperties = new HashMap<>();
+
+        for( final String key : baseProperties.getPropertyNames() ) {
+            Object value = baseProperties.get(key).getOrNull();
+            if( key.toLowerCase(Locale.ENGLISH).contains("password")
+                || key.toLowerCase(Locale.ENGLISH).contains("key") ) {
+                value = "(hidden)";
+            }
+            nonSensitiveProperties.put(key, value);
+        }
+
+        return getClass().getSimpleName() + "(properties=" + nonSensitiveProperties + ")";
     }
 
     /**

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -71,16 +71,14 @@ class DefaultHttpDestinationBuilderProxyHandler
         return (DefaultHttpDestination) getServiceBindingDestinationLoader().getDestination(options);
     }
 
-    // Auth type            | retrieval option | tenant   | user      | result
-    // *                    + SUB_ONLY        + NO_TENANT + *        -> (should never happen as it should fail on destination loading)
-    // *                    + SUB_ONLY        + TENANT_PR + *        -> (should never happen as it should fail on destination loading)
-    // BasicAuth            + ALWAYS_PROVIDER + *         + NO_USER  -> TECHNICAL_USER_PROVIDER
-    // BasicAuth            + CURRENT_TENANT  + *         + NO_USER  -> TECHNICAL_USER_CURRENT_TENANT
-    // BasicAuth            + SUB_ONLY        + TENANT_T1 + NO_USER  -> TECHNICAL_USER_CURRENT_TENANT
-    // PrincipalPropagation + *               + *         + NO_USER  -> (fail, on getHeaders())
-    // PrincipalPropagation + ALWAYS_PROVIDER + TENANT_PR + USER_PR  -> TECHNICAL_USER_CURRENT_TENANT (compatibility strategy) or NAME_USER_CURRENT_TENANT (recommended strategy)
-    // PrincipalPropagation + ALWAYS_PROVIDER + TENANT_T1 + *        -> (fail, on getHeaders())
-    // PrincipalPropagation + CURRENT_TENANT  + *         + *        -> TECHNICAL_USER_CURRENT_TENANT
+    // Auth type            | destination tenant | PP mode           | result
+    // *                    + NO_TENANT          + *                -> TECHNICAL_USER_PROVIDER
+    // *                    + TENANT_T1          + *                -> TECHNICAL_USER_CURRENT_TENANT
+    // *                    + TENANT_T1          + *                -> TECHNICAL_USER_CURRENT_TENANT
+    // PrincipalPropagation + NO_TENANT          + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
+    // PrincipalPropagation + NO_TENANT          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
+    // PrincipalPropagation + TENANT_T1          + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
+    // PrincipalPropagation + TENANT_T1          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
     @Nonnull
     private static OnBehalfOf deriveOnBehalfOf( @Nonnull final DefaultHttpDestination.Builder builder )
     {

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -77,7 +77,7 @@ class DefaultHttpDestinationBuilderProxyHandler
     // *                    + TENANT_T1          + *                -> TECHNICAL_USER_CURRENT_TENANT
     // PrincipalPropagation + NO_TENANT          + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
     // PrincipalPropagation + NO_TENANT          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
-    // PrincipalPropagation + TENANT_T1          + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
+    // PrincipalPropagation + TENANT_T1          + TOKEN_FORWARDING -> TECHNICAL_USER_CURRENT_TENANT
     // PrincipalPropagation + TENANT_T1          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
     @Nonnull
     private static OnBehalfOf deriveOnBehalfOf( @Nonnull final DefaultHttpDestination.Builder builder )

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -72,13 +72,13 @@ class DefaultHttpDestinationBuilderProxyHandler
     }
 
     // Auth type            | destination tenant | PP mode           | result
-    // *                    + NO_TENANT          + *                -> TECHNICAL_USER_PROVIDER
-    // *                    + TENANT_T1          + *                -> TECHNICAL_USER_CURRENT_TENANT
-    // *                    + TENANT_T1          + *                -> TECHNICAL_USER_CURRENT_TENANT
-    // PrincipalPropagation + NO_TENANT          + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
-    // PrincipalPropagation + NO_TENANT          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
-    // PrincipalPropagation + TENANT_T1          + TOKEN_FORWARDING -> TECHNICAL_USER_CURRENT_TENANT
-    // PrincipalPropagation + TENANT_T1          + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
+    // *                    + TENANT_PROVIDER    + *                -> TECHNICAL_USER_PROVIDER
+    // *                    + *                  + *                -> TECHNICAL_USER_CURRENT_TENANT
+    // PrincipalPropagation + TENANT_PROVIDER    + TOKEN_FORWARDING -> TECHNICAL_USER_PROVIDER
+    // PrincipalPropagation + *                  + TOKEN_FORWARDING -> TECHNICAL_USER_CURRENT_TENANT
+    // PrincipalPropagation + *                  + TOKEN_EXCHANGE   -> NAMED_USER_CURRENT_TENANT
+    //
+    // note: destination tenant is one of: [undefined, empty, non-empty]. empty is listed here as TENANT_PROVIDER.
     @Nonnull
     private static OnBehalfOf deriveOnBehalfOf( @Nonnull final DefaultHttpDestination.Builder builder )
     {

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -129,7 +129,7 @@ public class DestinationService implements DestinationLoader
         return Cache.getOrComputeDestination(this, destinationName, options, this::loadAndParseDestination);
     }
 
-    private Destination loadAndParseDestination( final String destName, final DestinationOptions options )
+    Destination loadAndParseDestination( final String destName, final DestinationOptions options )
         throws DestinationAccessException,
             DestinationNotFoundException
     {
@@ -147,7 +147,7 @@ public class DestinationService implements DestinationLoader
     }
 
     @Nonnull
-    private DestinationServiceV1Response retrieveDestination( final Strategy strategy, final String servicePath )
+    DestinationServiceV1Response retrieveDestination( final Strategy strategy, final String servicePath )
     {
         final String response =
             strategy.isForwardToken()

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest.java
@@ -209,7 +209,6 @@ class GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest
     {
         destinationCache = Caffeine.newBuilder().build();
         isolationLocks = Caffeine.newBuilder().build();
-        final DestinationServiceAdapter adapter = mock(DestinationServiceAdapter.class);
         destinationService = spy(new DestinationService(mock(DestinationServiceAdapter.class)));
         softly = new SoftAssertions();
     }
@@ -265,7 +264,8 @@ class GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest
         } else if( maybeDestination.isSuccess() && !testCase.isCommandExecutionExpectedToSucceed() ) {
             softly.fail("Expected command execution to fail, but it succeeded.");
         }
-        // softly.assertThat(maybeDestination.get()).isEqualTo(testCase.getExpectedDestination());
+
+        softly.assertThat(maybeDestination.get()).isEqualTo(testCase.getExpectedDestination());
         // sanity checks no cache was hit
         if( testCase.getTokenExchangeStrategy() == DestinationServiceTokenExchangeStrategy.LOOKUP_THEN_EXCHANGE
             && DestinationUtility.requiresUserTokenExchange(testCase.getExpectedDestination()) ) {
@@ -545,7 +545,7 @@ class GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest
                 response.setAuthTokens(List.of(token));
 
                 final Destination expectedDestination =
-                    DefaultDestination
+                    DefaultHttpDestination
                         .fromMap(properties)
                         .property(DestinationProperty.TENANT_ID, tenant == null ? "" : tenant.getTenantId())
                         .property(DestinationProperty.AUTH_TOKENS, List.of(token))


### PR DESCRIPTION
## Context

Follow up to #190 

This PR hardens the `GetOrComputeSingleDestinationCommandWithoutAllDestinationsTest` by mocking the `DestinationServiceV1Reponse` (instead of `HttpDestination`). That way the relevant logic from `DestinationServiceFactory` is now tested (instead of mocked).