### PR TITLE
feat: [Destinations] Add toString Implementation for DefaultHttpDestination

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -346,6 +346,7 @@ public final class DefaultHttpDestination implements HttpDestination
         return cachedProxyType;
     }
 
+    @Nonnull
     @Override
     public String toString()
     {

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -346,6 +346,25 @@ public final class DefaultHttpDestination implements HttpDestination
         return cachedProxyType;
     }
 
+    @Override
+    public String toString()
+    {
+        // we don't know which properties exactly may contain sensitive information,
+        // so we are only printing some essential properties known to be safe
+        final StringBuilder sb = new StringBuilder();
+        sb.append("DefaultHttpDestination(");
+        baseProperties.get(DestinationProperty.NAME).peek(name -> sb.append("name=").append(name).append(", "));
+        baseProperties.get(DestinationProperty.URI).peek(uri -> sb.append("uri=").append(uri).append(", "));
+        baseProperties
+            .get(DestinationProperty.PROXY_TYPE)
+            .peek(proxyType -> sb.append("proxyType=").append(proxyType).append(", "));
+        baseProperties
+            .get(DestinationProperty.AUTH_TYPE)
+            .peek(authType -> sb.append("authType=").append(authType).append(", "));
+        sb.append("...)");
+        return sb.toString();
+    }
+
     /**
      * Returns a new {@link Builder} instance that is initialized with this {@code DefaultHttpDestination}.
      * <p>


### PR DESCRIPTION
## Context

This PR adds an implementation for `toString` on `DefaultHttpDestination`. In SDK 4 the `ScpCfHttpDestination` implemented this for cases where the destination was retrieved from the BTP Destination Service.

## Discussion

Which properties to log exactly may be questionable.. Compare the [current state in SDK 4](https://github.wdf.sap.corp/MA/sdk/blob/main/v4/cloudplatform/cloudplatform-connectivity-scp/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractScpDestination.java#L104).

Idea: Log only a few properties which represent enough information and are known to not contain confidential data. Represent that more properties may be present via `, ...)` (otherwise it may be misleading, readers may think the other properties are missing).

Alternatives:

1. print all properties known to be safe
2. print all properties that don't contain certain keywords (e.g. `password`, `key`, `token`, `secret`...)
