### PR TITLE
feat: Add ability to serialize custom fields in OpenAPI generated objects

### DIFF
--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Order.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Order.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -53,6 +54,7 @@ public class Order
     private String nullableProperty;
 
     @JsonAnySetter
+    @JsonAnyGetter
     private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
     /**
@@ -264,6 +266,33 @@ public class Order
             throw new NoSuchElementException("Order has no field with name '" + name + "'.");
         }
         return cloudSdkCustomFields.get(name);
+    }
+
+    /**
+     * Put unrecognizable properties of the {@link Order}.
+     *
+     * @param customFields
+     *            The properties to be stored
+     */
+    @JsonIgnore
+    public void putAllCustomFields( @Nonnull Map<String, Object> customFields )
+    {
+        cloudSdkCustomFields.putAll(customFields);
+    }
+
+    /**
+     * Put an unrecognizable property of the {@link Order}. If the map previously contained a mapping for the key, the
+     * old value is replaced by the specified value.
+     *
+     * @param customFieldName
+     *            The name of the property
+     * @param customFieldValue
+     *            The value of the property
+     */
+    @JsonIgnore
+    public void putCustomField( @Nonnull String customFieldName, @Nonnull Object customFieldValue )
+    {
+        cloudSdkCustomFields.put(customFieldName, customFieldValue);
     }
 
     @Override

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestamp.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OrderWithTimestamp.java
@@ -26,6 +26,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -57,6 +58,7 @@ public class OrderWithTimestamp
     private OffsetDateTime timestamp;
 
     @JsonAnySetter
+    @JsonAnyGetter
     private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
     /**
@@ -304,6 +306,33 @@ public class OrderWithTimestamp
             throw new NoSuchElementException("OrderWithTimestamp has no field with name '" + name + "'.");
         }
         return cloudSdkCustomFields.get(name);
+    }
+
+    /**
+     * Put unrecognizable properties of the {@link OrderWithTimestamp}.
+     *
+     * @param customFields
+     *            The properties to be stored
+     */
+    @JsonIgnore
+    public void putAllCustomFields( @Nonnull Map<String, Object> customFields )
+    {
+        cloudSdkCustomFields.putAll(customFields);
+    }
+
+    /**
+     * Put an unrecognizable property of the {@link OrderWithTimestamp}. If the map previously contained a mapping for
+     * the key, the old value is replaced by the specified value.
+     *
+     * @param customFieldName
+     *            The name of the property
+     * @param customFieldValue
+     *            The value of the property
+     */
+    @JsonIgnore
+    public void putCustomField( @Nonnull String customFieldName, @Nonnull Object customFieldValue )
+    {
+        cloudSdkCustomFields.put(customFieldName, customFieldValue);
     }
 
     @Override

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Soda.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/Soda.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -50,6 +51,7 @@ public class Soda
     private Float price;
 
     @JsonAnySetter
+    @JsonAnyGetter
     private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
     /**
@@ -225,6 +227,33 @@ public class Soda
             throw new NoSuchElementException("Soda has no field with name '" + name + "'.");
         }
         return cloudSdkCustomFields.get(name);
+    }
+
+    /**
+     * Put unrecognizable properties of the {@link Soda}.
+     *
+     * @param customFields
+     *            The properties to be stored
+     */
+    @JsonIgnore
+    public void putAllCustomFields( @Nonnull Map<String, Object> customFields )
+    {
+        cloudSdkCustomFields.putAll(customFields);
+    }
+
+    /**
+     * Put an unrecognizable property of the {@link Soda}. If the map previously contained a mapping for the key, the
+     * old value is replaced by the specified value.
+     *
+     * @param customFieldName
+     *            The name of the property
+     * @param customFieldValue
+     *            The value of the property
+     */
+    @JsonIgnore
+    public void putCustomField( @Nonnull String customFieldName, @Nonnull Object customFieldValue )
+    {
+        cloudSdkCustomFields.put(customFieldName, customFieldValue);
     }
 
     @Override

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithId.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/SodaWithId.java
@@ -25,6 +25,7 @@ import java.util.Set;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -53,6 +54,7 @@ public class SodaWithId
     private Long id;
 
     @JsonAnySetter
+    @JsonAnyGetter
     private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
     /**
@@ -264,6 +266,33 @@ public class SodaWithId
             throw new NoSuchElementException("SodaWithId has no field with name '" + name + "'.");
         }
         return cloudSdkCustomFields.get(name);
+    }
+
+    /**
+     * Put unrecognizable properties of the {@link SodaWithId}.
+     *
+     * @param customFields
+     *            The properties to be stored
+     */
+    @JsonIgnore
+    public void putAllCustomFields( @Nonnull Map<String, Object> customFields )
+    {
+        cloudSdkCustomFields.putAll(customFields);
+    }
+
+    /**
+     * Put an unrecognizable property of the {@link SodaWithId}. If the map previously contained a mapping for the key,
+     * the old value is replaced by the specified value.
+     *
+     * @param customFieldName
+     *            The name of the property
+     * @param customFieldValue
+     *            The value of the property
+     */
+    @JsonIgnore
+    public void putCustomField( @Nonnull String customFieldName, @Nonnull Object customFieldValue )
+    {
+        cloudSdkCustomFields.put(customFieldName, customFieldValue);
     }
 
     @Override

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/model.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/model.mustache
@@ -24,6 +24,7 @@ import java.io.Serializable;
 {{/serializableModel}}
 {{#jackson}}
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
@@ -59,6 +59,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
 
   {{/vars}}
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
   {{#parcelableModel}}
   public {{classname}}() {
@@ -185,6 +186,27 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link {{classname}}}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link {{classname}}}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   {{#parent}}
   {{#allVars}}

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class NewSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class NewSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link NewSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link NewSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -60,6 +61,7 @@ public class Soda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -225,6 +227,27 @@ public class Soda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link Soda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link Soda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class UpdateSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class UpdateSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link UpdateSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link UpdateSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class NewSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class NewSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link NewSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link NewSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -60,6 +61,7 @@ public class Soda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -225,6 +227,27 @@ public class Soda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link Soda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link Soda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class UpdateSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class UpdateSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link UpdateSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link UpdateSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class NewSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class NewSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link NewSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link NewSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -60,6 +61,7 @@ public class Soda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -225,6 +227,27 @@ public class Soda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link Soda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link Soda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class UpdateSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -194,6 +196,27 @@ public class UpdateSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Put unrecognizable properties of the {@link UpdateSoda}.
+   * @param customFields The properties to be stored
+   */
+  @JsonIgnore
+  public void putAllCustomFields( @Nonnull Map<String, Object> customFields ) {
+      cloudSdkCustomFields.putAll(customFields);
+  }
+
+  /**
+   * Put an unrecognizable property of the {@link UpdateSoda}.
+   * If the map previously contained a mapping for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void putCustomField(@Nonnull String customFieldName, @Nonnull Object customFieldValue) {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/release_notes.md
+++ b/release_notes.md
@@ -32,7 +32,9 @@
 
 ### ✨ New Functionality
 
-- 
+- `OpenAPI` generated objects can now write custom fields which are not part of the object's schema:
+  - `putAllCustomFields(Map.of("nameOfField", "valueOfField", ...))`
+  - `putCustomField("nameOfField", "valueOfField")`
 
 ### 📈 Improvements
 


### PR DESCRIPTION
# 🤖
## Overview

This pull request addresses the backlog item [#228](https://github.com/SAP/cloud-sdk-java-backlog/issues/228) and introduces the ability to serialize custom fields in OpenAPI generated objects. Previously, we only supported deserializing these custom fields.

## Changes

The changes in this PR are as follows:

- Added the `@JsonAnyGetter` annotation to the `cloudSdkCustomFields` map in the OpenAPI generated classes. This allows the custom fields to be serialized when sending requests to an OpenAPI service.
- Introduced two new methods `putAllCustomFields(Map<String, Object> customFields)` and `putCustomField(String customFieldName, Object customFieldValue)` in the OpenAPI generated classes. These methods allow users to add custom fields to the objects.

## Usage

Users can now add custom fields to their OpenAPI generated objects using the following methods:

```java
putAllCustomFields(Map.of("nameOfField", "valueOfField", ...));
putCustomField("nameOfField", "valueOfField");
```

## Reviewer Notes

Please ensure that the changes align with the requirements of the backlog item. Should tests be added?