### PR TITLE
Remove jetty bom from archetype

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/pom.xml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/integration-tests/pom.xml
@@ -40,17 +40,6 @@
         <jacoco.excludes>org.apache.*</jacoco.excludes>
     </properties>
 
-    <dependencyManagement>
-        <dependencies>
-            <dependency>
-                <groupId>org.eclipse.jetty</groupId>
-                <artifactId>jetty-bom</artifactId>
-                <version>11.0.18</version>
-                <scope>import</scope>
-                <type>pom</type>
-            </dependency>
-        </dependencies>
-    </dependencyManagement>
     <dependencies>
         <dependency>
             <groupId>${groupId}</groupId>


### PR DESCRIPTION
Is this even necessary?

Current "Jetty 11" is not natively compatible with current "Spring Boot", without [adjustments](https://github.com/spring-projects/spring-boot/issues/33044).