### PR TITLE
feat: Extend AuthToken Forwarding

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
@@ -123,7 +123,8 @@ class DestinationServiceFactoryTest
     }
 
     @Test
-    void propertyForwardAuthTokenShouldSetAuthenticationType() {
+    void propertyForwardAuthTokenShouldSetAuthenticationType()
+    {
         response.getDestinationConfiguration().put("Type", "HTTP");
         response.getDestinationConfiguration().put("Name", "httpDestination");
         response.getDestinationConfiguration().put("URL", "https://example.com");

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
@@ -121,4 +121,16 @@ class DestinationServiceFactoryTest
             .isInstanceOf(DestinationAccessException.class)
             .hasMessageContaining("some-error-message");
     }
+
+    @Test
+    void propertyForwardAuthTokenShouldSetAuthenticationType() {
+        response.getDestinationConfiguration().put("Type", "HTTP");
+        response.getDestinationConfiguration().put("Name", "httpDestination");
+        response.getDestinationConfiguration().put("URL", "https://example.com");
+        response.getDestinationConfiguration().put("forwardAuthToken", "true");
+
+        final Destination result = DestinationServiceFactory.fromDestinationServiceV1Response(response);
+
+        assertThat(result.asHttp().getAuthenticationType()).isEqualTo(AuthenticationType.TOKEN_FORWARDING);
+    }
 }

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
@@ -1,18 +1,5 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import com.google.common.net.HttpHeaders;
-import com.google.gson.Gson;
-import io.vavr.control.Try;
-import org.junit.jupiter.api.Test;
-
-import java.util.Collection;
-import java.util.HashMap;
-import java.util.Map;
-
-import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
-import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
-import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -20,82 +7,106 @@ import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
 
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import java.util.function.Consumer;
+
+import javax.annotation.Nonnull;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import com.google.common.net.HttpHeaders;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+import com.google.gson.JsonPrimitive;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
+import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration;
+
 public class ForwardAuthTokenTest
 {
-    @Test
-    void localDestinationWithPropertyAndNoAuthenticationShouldForwardIncomingAuthorizationHeader()
+    static Collection<TestCase> createTestCases()
     {
-        final Map<String, Object> properties =
-            Map
-                .of(
-                    DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
-                     "true",
-                    DestinationProperty.AUTH_TYPE.getKeyName(),
-                    AuthenticationType.NO_AUTHENTICATION);
-
-        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
-        final Collection<Header> headers =
-            RequestHeaderAccessor
-                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
-
-        assertThat(headers).containsExactly(new Header(HttpHeaders.AUTHORIZATION, "token"));
-    }
-
-    @Test
-    void localDestinationWithoutPropertyAndNoAuthenticationShouldNotForwardIncomingAuthorizationHeader()
-    {
-        final Map<String, Object> properties =
-            Map
-                .of(
-                    DestinationProperty.AUTH_TYPE.getKeyName(),
-                    AuthenticationType.NO_AUTHENTICATION);
-
-        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
-        final Collection<Header> headers =
-            RequestHeaderAccessor
-                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
-
-        assertThat(headers).isEmpty();
-    }
-
-    @Test
-    void localDestinationWithPropertyAndUnsetAuthenticationShouldForwardIncomingAuthorizationHeader()
-    {
-        final Map<String, Object> properties =
-                Map
+        return List
+            .of(
+                // forwardAuthToken = true && authType = NoAuthentication
+                new TestCase(
+                    Map
                         .of(
-                                DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
-                                "true");
-
-        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
-        final Collection<Header> headers =
-                RequestHeaderAccessor
-                        .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
-
-        assertThat(headers).containsExactly(new Header(HttpHeaders.AUTHORIZATION, "token"));
-    }
-
-    @Test
-    void localDestinationWithFalsePropertyAndUnsetAuthenticationShouldNotForwardIncomingAuthorizationHeader()
-    {
-        final Map<String, Object> properties =
-                Map
+                            DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
+                            "true",
+                            DestinationProperty.AUTH_TYPE.getKeyName(),
+                            AuthenticationType.NO_AUTHENTICATION),
+                    AssertionType.TOKEN_IS_FORWARDED),
+                // forwardAuthToken = true && unset authType
+                new TestCase(
+                    Map.of(DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(), "true"),
+                    AssertionType.TOKEN_IS_FORWARDED),
+                // forwardAuthToken = false && authType = NoAuthentication
+                new TestCase(
+                    Map
                         .of(
-                                DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
-                                "false");
+                            DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
+                            "false",
+                            DestinationProperty.AUTH_TYPE.getKeyName(),
+                            AuthenticationType.NO_AUTHENTICATION),
+                    AssertionType.TOKEN_IS_NOT_FORWARDED),
+                // forwardAuthToken = false && unset authType
+                new TestCase(
+                    Map.of(DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(), "false"),
+                    AssertionType.TOKEN_IS_NOT_FORWARDED),
+                // unset forwardAuthToken && authType = NoAuthentication
+                new TestCase(
+                    Map.of(DestinationProperty.AUTH_TYPE.getKeyName(), AuthenticationType.NO_AUTHENTICATION),
+                    AssertionType.TOKEN_IS_NOT_FORWARDED),
+                // unset forwardAuthToken && unset authType
+                new TestCase(Map.of(), AssertionType.TOKEN_IS_NOT_FORWARDED)
 
-        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
-        final Collection<Header> headers =
-                RequestHeaderAccessor
-                        .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
-
-        assertThat(headers).isEmpty();
+            );
     }
 
-    @Test
-    void serviceDestinationWithPropertyAnNoAuthenticationShouldForwardIncomingAuthorizationHeader()
+    private enum AssertionType
     {
-        final String destinationName = "SomeDestinationName";
+        TOKEN_IS_FORWARDED(ForwardAuthTokenTest::assertThatTokenIsForwarded),
+        TOKEN_IS_NOT_FORWARDED(ForwardAuthTokenTest::assertThatTokenIsNotForwarded);
+
+        private final Consumer<HttpDestination> assertion;
+
+        AssertionType( final Consumer<HttpDestination> assertion )
+        {
+            this.assertion = assertion;
+        }
+    }
+
+    private record TestCase( Map<String, Object> properties, AssertionType forwardingAssertion )
+    {
+    }
+
+    @ParameterizedTest
+    @MethodSource( "createTestCases" )
+    void localDestinationShouldFulfillTestCase( @Nonnull final TestCase testCase )
+    {
+        final HttpDestination destination = buildLocalDestination(testCase.properties);
+        testCase.forwardingAssertion.assertion.accept(destination);
+    }
+
+    @ParameterizedTest
+    @MethodSource( "createTestCases" )
+    void destinationServiceDestinationShouldFulfillTestCase( @Nonnull final TestCase testCase )
+    {
+        final HttpDestination destination = buildDestinationServiceDestination(testCase.properties);
+        testCase.forwardingAssertion.assertion.accept(destination);
+    }
+
+    private HttpDestination buildDestinationServiceDestination( final Map<String, Object> properties )
+    {
+        // to circumvent caching in the destination loader we generate a random destination name here
+        final String destinationName = "SomeDestinationName" + UUID.randomUUID();
+        final String serviceResponse = buildServiceResponse(destinationName, properties);
 
         final DestinationServiceAdapter adapter =
             spy(
@@ -109,8 +120,15 @@ public class ForwardAuthTokenTest
                 ResilienceConfiguration.empty("testSingle"),
                 ResilienceConfiguration.empty("testMultiple"));
 
-        doReturn("""
-                {
+        doReturn(serviceResponse).when(adapter).getConfigurationAsJson(eq("/destinations/" + destinationName), any());
+
+        return loader.tryGetDestination(destinationName).get().asHttp();
+    }
+
+    private String buildServiceResponse( final String destinationName, final Map<String, Object> properties )
+    {
+        final JsonElement response = JsonParser.parseString("""
+            {
                 "owner": {
                     "SubaccountId": "someId",
                     "InstanceId": null
@@ -119,18 +137,34 @@ public class ForwardAuthTokenTest
                     "Name": "%s",
                     "Type": "HTTP",
                     "URL": "sap.com",
-                    "Authentication": "NoAuthentication",
                     "ProxyType": "Internet",
-                    "Description": "Test destination",
-                    "forwardAuthToken": "true"
+                    "Description": "Test destination"
                 }
             }
-                """.formatted(destinationName))
-            .when(adapter)
-            .getConfigurationAsJson(eq("/destinations/" + destinationName), any());
+            """.formatted(destinationName));
+        final JsonObject config = response.getAsJsonObject().get("destinationConfiguration").getAsJsonObject();
+        for( final Map.Entry<String, Object> entry : properties.entrySet() ) {
+            config.add(entry.getKey(), new JsonPrimitive(entry.getValue().toString()));
+        }
+        return response.toString();
+    }
 
-        final HttpDestination destination = loader.tryGetDestination(destinationName).get().asHttp();
+    private HttpDestination buildLocalDestination( Map<String, Object> properties )
+    {
+        return DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
+    }
 
+    private static void assertThatTokenIsNotForwarded( final HttpDestination destination )
+    {
+        final Collection<Header> headers =
+            RequestHeaderAccessor
+                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).isEmpty();
+    }
+
+    private static void assertThatTokenIsForwarded( final HttpDestination destination )
+    {
         final Collection<Header> headers =
             RequestHeaderAccessor
                 .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
@@ -14,14 +14,10 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.net.HttpHeaders;
-import com.google.gson.Gson;
-import com.google.gson.JsonElement;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonPrimitive;
+
 import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
 
-public class ForwardAuthTokenTest
+class ForwardAuthTokenTest
 {
     static Collection<TestCase> createTestCases()
     {
@@ -66,8 +62,7 @@ public class ForwardAuthTokenTest
         }
     }
 
-    private record TestCase( Map<String, Object> properties, AssertionType forwardingAssertion )
-    {
+    private record TestCase(Map<String, Object> properties, AssertionType forwardingAssertion) {
     }
 
     private static class TestCaseBuilder
@@ -118,47 +113,6 @@ public class ForwardAuthTokenTest
     {
         final HttpDestination destination = buildLocalDestination(testCase.properties);
         testCase.forwardingAssertion.assertion.accept(destination);
-    }
-
-    @ParameterizedTest
-    @MethodSource( "createTestCases" )
-    void destinationServiceDestinationShouldFulfillTestCase( @Nonnull final TestCase testCase )
-    {
-        final HttpDestination destination = buildDestinationServiceDestination(testCase.properties);
-        testCase.forwardingAssertion.assertion.accept(destination);
-    }
-
-    private HttpDestination buildDestinationServiceDestination( final Map<String, Object> properties )
-    {
-        final String serviceResponse = buildServiceResponse(properties);
-        final DestinationServiceV1Response parsedResponse =
-            new Gson().fromJson(serviceResponse, DestinationServiceV1Response.class);
-        final Destination destination = DestinationServiceFactory.fromDestinationServiceV1Response(parsedResponse);
-        return destination.asHttp();
-    }
-
-    private String buildServiceResponse( final Map<String, Object> properties )
-    {
-        final JsonElement response = JsonParser.parseString("""
-            {
-                "owner": {
-                    "SubaccountId": "someId",
-                    "InstanceId": null
-                },
-                "destinationConfiguration": {
-                    "Name": "SomeDestination",
-                    "Type": "HTTP",
-                    "URL": "sap.com",
-                    "ProxyType": "Internet",
-                    "Description": "Test destination"
-                }
-            }
-            """);
-        final JsonObject config = response.getAsJsonObject().get("destinationConfiguration").getAsJsonObject();
-        for( final Map.Entry<String, Object> entry : properties.entrySet() ) {
-            config.add(entry.getKey(), new JsonPrimitive(entry.getValue().toString()));
-        }
-        return response.toString();
     }
 
     private HttpDestination buildLocalDestination( Map<String, Object> properties )

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
@@ -1,0 +1,140 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import com.google.common.net.HttpHeaders;
+import com.google.gson.Gson;
+import io.vavr.control.Try;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
+import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
+
+public class ForwardAuthTokenTest
+{
+    @Test
+    void localDestinationWithPropertyAndNoAuthenticationShouldForwardIncomingAuthorizationHeader()
+    {
+        final Map<String, Object> properties =
+            Map
+                .of(
+                    DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
+                     "true",
+                    DestinationProperty.AUTH_TYPE.getKeyName(),
+                    AuthenticationType.NO_AUTHENTICATION);
+
+        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
+        final Collection<Header> headers =
+            RequestHeaderAccessor
+                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).containsExactly(new Header(HttpHeaders.AUTHORIZATION, "token"));
+    }
+
+    @Test
+    void localDestinationWithoutPropertyAndNoAuthenticationShouldNotForwardIncomingAuthorizationHeader()
+    {
+        final Map<String, Object> properties =
+            Map
+                .of(
+                    DestinationProperty.AUTH_TYPE.getKeyName(),
+                    AuthenticationType.NO_AUTHENTICATION);
+
+        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
+        final Collection<Header> headers =
+            RequestHeaderAccessor
+                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
+    void localDestinationWithPropertyAndUnsetAuthenticationShouldForwardIncomingAuthorizationHeader()
+    {
+        final Map<String, Object> properties =
+                Map
+                        .of(
+                                DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
+                                "true");
+
+        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
+        final Collection<Header> headers =
+                RequestHeaderAccessor
+                        .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).containsExactly(new Header(HttpHeaders.AUTHORIZATION, "token"));
+    }
+
+    @Test
+    void localDestinationWithFalsePropertyAndUnsetAuthenticationShouldNotForwardIncomingAuthorizationHeader()
+    {
+        final Map<String, Object> properties =
+                Map
+                        .of(
+                                DestinationProperty.FORWARD_AUTH_TOKEN.getKeyName(),
+                                "false");
+
+        final HttpDestination destination = DefaultDestination.fromMap(properties).uri("sap.com").build().asHttp();
+        final Collection<Header> headers =
+                RequestHeaderAccessor
+                        .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).isEmpty();
+    }
+
+    @Test
+    void serviceDestinationWithPropertyAnNoAuthenticationShouldForwardIncomingAuthorizationHeader()
+    {
+        final String destinationName = "SomeDestinationName";
+
+        final DestinationServiceAdapter adapter =
+            spy(
+                new DestinationServiceAdapter(
+                    behalf -> DefaultHttpDestination.builder("").build(),
+                    () -> mock(ServiceBinding.class),
+                    "providerTenantId"));
+        final DestinationLoader loader =
+            new DestinationService(
+                adapter,
+                ResilienceConfiguration.empty("testSingle"),
+                ResilienceConfiguration.empty("testMultiple"));
+
+        doReturn("""
+                {
+                "owner": {
+                    "SubaccountId": "someId",
+                    "InstanceId": null
+                },
+                "destinationConfiguration": {
+                    "Name": "%s",
+                    "Type": "HTTP",
+                    "URL": "sap.com",
+                    "Authentication": "NoAuthentication",
+                    "ProxyType": "Internet",
+                    "Description": "Test destination",
+                    "forwardAuthToken": "true"
+                }
+            }
+                """.formatted(destinationName))
+            .when(adapter)
+            .getConfigurationAsJson(eq("/destinations/" + destinationName), any());
+
+        final HttpDestination destination = loader.tryGetDestination(destinationName).get().asHttp();
+
+        final Collection<Header> headers =
+            RequestHeaderAccessor
+                .executeWithHeaderContainer(Map.of(HttpHeaders.AUTHORIZATION, "token"), () -> destination.getHeaders());
+
+        assertThat(headers).containsExactly(new Header(HttpHeaders.AUTHORIZATION, "token"));
+    }
+}

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ForwardAuthTokenTest.java
@@ -14,7 +14,6 @@ import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 
 import com.google.common.net.HttpHeaders;
-
 import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
 
 class ForwardAuthTokenTest
@@ -62,7 +61,8 @@ class ForwardAuthTokenTest
         }
     }
 
-    private record TestCase(Map<String, Object> properties, AssertionType forwardingAssertion) {
+    private record TestCase( Map<String, Object> properties, AssertionType forwardingAssertion )
+    {
     }
 
     private static class TestCaseBuilder

--- a/release_notes.md
+++ b/release_notes.md
@@ -54,6 +54,7 @@
       - Update [Guava](https://central.sonatype.com/artifact/com.google.guava/guava/33.0.0-jre) from `32.1.3-jre` to `33.0.0-jre`
       - Update [Jackson](https://central.sonatype.com/artifact/com.fasterxml.jackson.core/jackson-core/2.16.1) from `2.15.3` to `2.16.1`
       - Update [Commons Lang](https://central.sonatype.com/artifact/org.apache.commons/commons-lang3/3.14.0) from `3.13.0` to `3.14.0`
+- Destinations retrieved from the BTP Destination Service now correctly evaluate the `forwardAuthToken` property if it has the authentication type `NoAuthentication`.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#401


This PR allows destinations retrieved from the Destination Service with Authentication Type `NO_AUTHENTICATION` to evaluate the `forwardAuthToken` parameter.

This means any incoming JWT will be forwarded to the target of the destination if the `forwardAuthToken` is set to true and the Authentication Type is either unset or set to `NO_AUTHENTICATION`.


## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated