### PR TITLE
chore: [DevOps] Enable Dependabot

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,0 +1,28 @@
+# configuration docu: https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
+version: 2
+updates:
+  - package-ecosystem: maven
+    target-branch: main
+    directory: '/'
+    schedule:
+      interval: daily
+      time: '08:00'
+      timezone: 'Europe/Berlin'
+    open-pull-requests-limit: 5
+    groups:
+      production-dependencies:
+        dependency-type: "production"
+        update-types: ["minor", "patch"]
+      production-major-dependencies:
+        dependency-type: "production"
+        update-types: [ "major" ]
+      development-dependencies:
+        dependency-type: "development"
+    ignore:
+      # leads to unintended formatting of POM files
+      - dependency-name: 'com.github.ekryd.sortpom:sortpom-maven-plugin'
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: monthly

--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -10,13 +10,21 @@ updates:
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 5
     groups:
-      production-dependencies:
+      production-minor-patch:
         dependency-type: "production"
         update-types: ["minor", "patch"]
-      production-major-dependencies:
+        exclude-patterns:
+          - "*-plugin"
+      production-major:
         dependency-type: "production"
         update-types: [ "major" ]
-      development-dependencies:
+        exclude-patterns:
+          - "*-plugin"
+      plugins:
+        dependency-type: "production"
+        patterns:
+          - "*-plugin"
+      development:
         dependency-type: "development"
     ignore:
       # leads to unintended formatting of POM files


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#311.

Configures dependabot to create PRs for updating dependencies. This will probably require further tuning, but it is easier to do that once an initial state has been merged to main.