### PR TITLE
fix: Modify build workflow to prevent failures from forked repositories

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -191,8 +191,10 @@ jobs:
       - name: Test
         run: |
           mvn $MVN_CLI_ARGS_SINGLE_THREAD org.jacoco:jacoco-maven-plugin:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:report
+      # Do not run this step on a forked repository
+      # Fixed in https://github.com/ScaCap/action-surefire-report/issues/31
       - name: Test Report
-        if: success() || failure() && github.repository == 'SAP/cloud-sdk-java' # Do not run this step on a forked repository
+        if: github.repository == 'SAP/cloud-sdk-java' && (success() || failure())
         uses: scacap/action-surefire-report@v1
       - name: Coverage Report
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -192,7 +192,7 @@ jobs:
         run: |
           mvn $MVN_CLI_ARGS_SINGLE_THREAD org.jacoco:jacoco-maven-plugin:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:report
       - name: Test Report
-        if: success() || failure()
+        if: success() || failure() && github.repository == 'SAP/cloud-sdk-java' # Do not run this step on a forked repository
         uses: scacap/action-surefire-report@v1
       - name: Coverage Report
         run: |


### PR DESCRIPTION
## Summary

This PR addresses the issue of PR build failures when the PR is created via a fork instead of a branch. The root cause of this issue was identified to be related to a specific step in the build workflow. This PR modifies the condition for running the 'Test Report' step in the build workflow to ensure it does not run on a forked repository. This change is expected to enable successful PR builds from forked repositories.

## Changes

The following changes have been made in this PR:

- Modified the condition for running the 'Test Report' step in the build workflow. The step will now only run if the repository is not a forked one.

## Link to Backlog Item

The backlog item associated with this PR can be found [here](https://github.com/SAP/cloud-sdk-java-backlog/issues/400).

## Instructions for Reviewers

Please review the changes made in the build workflow file and ensure that they align with the proposed solution in the backlog item. Also, please verify if the 'Test Report' step is not run when the PR is created from a forked repository.

## Next Steps

Upon successful review and merging of this PR, a PR should be created from a non-SAP account fork to verify if the PR build is successful.