### PR TITLE
feat: OAuth Property Supplier for IAS

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -19,6 +19,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.WorkflowOp
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantWithSubdomain;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 
 import io.vavr.control.Try;
 
@@ -141,7 +142,7 @@ class BtpServicePropertySuppliers
                     .map(TenantWithSubdomain.class::cast)
                     .map(TenantWithSubdomain::getSubdomain)
                     // TODO: this somewhat feels very fragile. Is there a better way?
-                    .map(subdomain -> "https://" + subdomain + "." + domain + "/oauth2/authorize")
+                    .map(subdomain -> "https://" + subdomain + "." + domain)
                     .map(URI::create);
 
             if( maybeTokenUri.isSuccess() ) {
@@ -152,6 +153,13 @@ class BtpServicePropertySuppliers
                 null,
                 "Unable to determine the IAS token URI.",
                 maybeTokenUri.getCause());
+        }
+
+        @Nonnull
+        @Override
+        public OAuth2ServiceEndpointsProvider getTokenEndpoints()
+        {
+            return DefaultTokenEndpoints.fromIasUri(getTokenUri());
         }
     }
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -159,7 +159,7 @@ class BtpServicePropertySuppliers
         @Override
         public OAuth2ServiceEndpointsProvider getTokenEndpoints()
         {
-            return DefaultTokenEndpoints.fromIasUri(getTokenUri());
+            return DefaultTokenEndpoints.forIas(getTokenUri());
         }
     }
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -293,7 +293,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
         }
         if( cls == CredentialType.class ) {
             try {
-                final T result = (T) CredentialType.from((String) value);
+                final T result = (T) SecurityLibWorkarounds.getCredentialType((String) value);
                 if( result == null ) {
                     throw new IllegalArgumentException();
                 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
@@ -68,7 +68,7 @@ public interface OAuth2PropertySupplier
          * @return A new {@link OAuth2ServiceEndpointsProvider}.
          */
         @Nonnull
-        static OAuth2ServiceEndpointsProvider fromXsuaaUri( final URI baseUri )
+        static OAuth2ServiceEndpointsProvider forXsuaa( @Nonnull final URI baseUri )
         {
             final URI tokenEndpoint = expandPath(baseUri, Xsuaa.TOKEN_PATH);
             final URI authorizeEndpoint = expandPath(baseUri, Xsuaa.AUTHORIZE_PATH);
@@ -85,7 +85,7 @@ public interface OAuth2PropertySupplier
          * @return A new {@link OAuth2ServiceEndpointsProvider}.
          */
         @Nonnull
-        static OAuth2ServiceEndpointsProvider fromIasUri( final URI baseUri )
+        static OAuth2ServiceEndpointsProvider forIas( @Nonnull final URI baseUri )
         {
             final URI tokenEndpoint = expandPath(baseUri, Ias.TOKEN_PATH);
             final URI authorizeEndpoint = expandPath(baseUri, Ias.AUTHORIZE_PATH);
@@ -130,7 +130,7 @@ public interface OAuth2PropertySupplier
     @Nonnull
     default OAuth2ServiceEndpointsProvider getTokenEndpoints()
     {
-        return DefaultTokenEndpoints.fromXsuaaUri(getTokenUri());
+        return DefaultTokenEndpoints.forXsuaa(getTokenUri());
     }
 
     /**

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
@@ -4,12 +4,18 @@
 
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
+import static com.sap.cloud.security.xsuaa.util.UriUtil.expandPath;
+
 import java.net.URI;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.Beta;
 import com.sap.cloud.security.config.ClientIdentity;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
+
+import lombok.Value;
 
 /**
  * A supplier of OAuth client information. Implementations should extract the client information out of a
@@ -20,6 +26,74 @@ import com.sap.cloud.security.config.ClientIdentity;
 @Beta
 public interface OAuth2PropertySupplier
 {
+    /**
+     * A default implementation of the {@link OAuth2ServiceEndpointsProvider} interface that provides convenient access
+     * to the default endpoints of either the XSUAA or the IAS service.
+     *
+     * @since 5.2.1
+     */
+    @Value
+    class DefaultTokenEndpoints implements OAuth2ServiceEndpointsProvider
+    {
+        private static class Xsuaa
+        {
+            private static final String TOKEN_PATH = "/oauth/token";
+            private static final String AUTHORIZE_PATH = "/oauth/authorize";
+            private static final String KEYSET_PATH = "/token_keys";
+        }
+
+        private static class Ias
+        {
+            private static final String TOKEN_PATH = "/oauth2/token";
+            private static final String AUTHORIZE_PATH = "/oauth2/authorize";
+            // TODO: is this actually correct?
+            private static final String KEYSET_PATH = "/token_keys";
+        }
+
+        @Nonnull
+        URI tokenEndpoint;
+
+        @Nullable
+        URI authorizeEndpoint;
+
+        @Nullable
+        URI jwksUri;
+
+        /**
+         * Returns a new {@link OAuth2ServiceEndpointsProvider} that points to the default XSUAA endpoints, based on the
+         * provided {@code baseUri}.
+         *
+         * @param baseUri
+         *            The token service uri.
+         * @return A new {@link OAuth2ServiceEndpointsProvider}.
+         */
+        @Nonnull
+        static OAuth2ServiceEndpointsProvider fromXsuaaUri( final URI baseUri )
+        {
+            final URI tokenEndpoint = expandPath(baseUri, Xsuaa.TOKEN_PATH);
+            final URI authorizeEndpoint = expandPath(baseUri, Xsuaa.AUTHORIZE_PATH);
+            final URI jwksUri = expandPath(baseUri, Xsuaa.KEYSET_PATH);
+            return new DefaultTokenEndpoints(tokenEndpoint, authorizeEndpoint, jwksUri);
+        }
+
+        /**
+         * Returns a new {@link OAuth2ServiceEndpointsProvider} that points to the default IAS endpoints, based on the
+         * provided {@code baseUri}.
+         *
+         * @param baseUri
+         *            The token service uri.
+         * @return A new {@link OAuth2ServiceEndpointsProvider}.
+         */
+        @Nonnull
+        static OAuth2ServiceEndpointsProvider fromIasUri( final URI baseUri )
+        {
+            final URI tokenEndpoint = expandPath(baseUri, Ias.TOKEN_PATH);
+            final URI authorizeEndpoint = expandPath(baseUri, Ias.AUTHORIZE_PATH);
+            final URI jwksUri = expandPath(baseUri, Ias.KEYSET_PATH);
+            return new DefaultTokenEndpoints(tokenEndpoint, authorizeEndpoint, jwksUri);
+        }
+    }
+
     /**
      * Indicates if the binding is supported by this supplier.
      *
@@ -42,6 +116,22 @@ public interface OAuth2PropertySupplier
      */
     @Nonnull
     URI getTokenUri();
+
+    /**
+     * {@link OAuth2ServiceEndpointsProvider} for the used token service.
+     * <p>
+     * By default, this method returns endpoints that are specific to the XSUAA service.
+     * <p>
+     * For example, authorization tokens will be retrieved from {@code getTokenServiceUri().resolve("/oauth/token")}.
+     *
+     * @return An instance of {@link OAuth2ServiceEndpointsProvider}.
+     * @since 5.2.1
+     */
+    @Nonnull
+    default OAuth2ServiceEndpointsProvider getTokenEndpoints()
+    {
+        return DefaultTokenEndpoints.fromXsuaaUri(getTokenUri());
+    }
 
     /**
      * OAuth client identity to be used for obtaining a token.

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplier.java
@@ -28,27 +28,16 @@ public interface OAuth2PropertySupplier
 {
     /**
      * A default implementation of the {@link OAuth2ServiceEndpointsProvider} interface that provides convenient access
-     * to the default endpoints of either the XSUAA or the IAS service.
+     * to the default endpoints of the XSUAA service.
      *
      * @since 5.2.1
      */
     @Value
     class DefaultTokenEndpoints implements OAuth2ServiceEndpointsProvider
     {
-        private static class Xsuaa
-        {
-            private static final String TOKEN_PATH = "/oauth/token";
-            private static final String AUTHORIZE_PATH = "/oauth/authorize";
-            private static final String KEYSET_PATH = "/token_keys";
-        }
-
-        private static class Ias
-        {
-            private static final String TOKEN_PATH = "/oauth2/token";
-            private static final String AUTHORIZE_PATH = "/oauth2/authorize";
-            // TODO: is this actually correct?
-            private static final String KEYSET_PATH = "/token_keys";
-        }
+        private static final String TOKEN_PATH = "/oauth/token";
+        private static final String AUTHORIZE_PATH = "/oauth/authorize";
+        private static final String KEYSET_PATH = "/token_keys";
 
         @Nonnull
         URI tokenEndpoint;
@@ -70,26 +59,9 @@ public interface OAuth2PropertySupplier
         @Nonnull
         static OAuth2ServiceEndpointsProvider forXsuaa( @Nonnull final URI baseUri )
         {
-            final URI tokenEndpoint = expandPath(baseUri, Xsuaa.TOKEN_PATH);
-            final URI authorizeEndpoint = expandPath(baseUri, Xsuaa.AUTHORIZE_PATH);
-            final URI jwksUri = expandPath(baseUri, Xsuaa.KEYSET_PATH);
-            return new DefaultTokenEndpoints(tokenEndpoint, authorizeEndpoint, jwksUri);
-        }
-
-        /**
-         * Returns a new {@link OAuth2ServiceEndpointsProvider} that points to the default IAS endpoints, based on the
-         * provided {@code baseUri}.
-         *
-         * @param baseUri
-         *            The token service uri.
-         * @return A new {@link OAuth2ServiceEndpointsProvider}.
-         */
-        @Nonnull
-        static OAuth2ServiceEndpointsProvider forIas( @Nonnull final URI baseUri )
-        {
-            final URI tokenEndpoint = expandPath(baseUri, Ias.TOKEN_PATH);
-            final URI authorizeEndpoint = expandPath(baseUri, Ias.AUTHORIZE_PATH);
-            final URI jwksUri = expandPath(baseUri, Ias.KEYSET_PATH);
+            final URI tokenEndpoint = expandPath(baseUri, TOKEN_PATH);
+            final URI authorizeEndpoint = expandPath(baseUri, AUTHORIZE_PATH);
+            final URI jwksUri = expandPath(baseUri, KEYSET_PATH);
             return new DefaultTokenEndpoints(tokenEndpoint, authorizeEndpoint, jwksUri);
         }
     }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -4,8 +4,6 @@
 
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.sap.cloud.security.xsuaa.util.UriUtil.expandPath;
-
 import java.net.URI;
 import java.time.Duration;
 import java.util.concurrent.TimeUnit;
@@ -41,7 +39,6 @@ import com.sap.cloud.security.xsuaa.tokenflows.XsuaaTokenFlows;
 import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.Getter;
-import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -78,7 +75,15 @@ class OAuth2Service
 
     OAuth2Service( final String uri, final ClientIdentity identity, final OnBehalfOf onBehalfOf )
     {
-        endpoints = Endpoints.fromBaseUri(URI.create(uri));
+        this(OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(URI.create(uri)), identity, onBehalfOf);
+    }
+
+    OAuth2Service(
+        @Nonnull final OAuth2ServiceEndpointsProvider endpoints,
+        @Nonnull final ClientIdentity identity,
+        @Nonnull final OnBehalfOf onBehalfOf )
+    {
+        this.endpoints = endpoints;
         this.identity = identity;
         this.onBehalfOf = onBehalfOf;
         /*
@@ -198,31 +203,5 @@ class OAuth2Service
         return Try
             .of(flow::execute)
             .getOrElseThrow(e -> new TokenRequestFailedException("Failed to resolve access token.", e));
-    }
-
-    @Value
-    static class Endpoints implements OAuth2ServiceEndpointsProvider
-    {
-        private static final String TOKEN_PATH = "/oauth/token";
-        private static final String AUTHORIZE_PATH = "/oauth/authorize";
-        private static final String KEYSET_PATH = "/token_keys";
-
-        @Nonnull
-        URI tokenEndpoint;
-
-        @Nullable
-        URI authorizeEndpoint;
-
-        @Nullable
-        URI jwksUri;
-
-        @Nonnull
-        static Endpoints fromBaseUri( final URI baseUri )
-        {
-            final URI tokenEndpoint = expandPath(baseUri, TOKEN_PATH);
-            final URI authorizeEndpoint = expandPath(baseUri, AUTHORIZE_PATH);
-            final URI jwksUri = expandPath(baseUri, KEYSET_PATH);
-            return new Endpoints(tokenEndpoint, authorizeEndpoint, jwksUri);
-        }
     }
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -75,7 +75,7 @@ class OAuth2Service
 
     OAuth2Service( final String uri, final ClientIdentity identity, final OnBehalfOf onBehalfOf )
     {
-        this(OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(URI.create(uri)), identity, onBehalfOf);
+        this(OAuth2PropertySupplier.DefaultTokenEndpoints.forXsuaa(URI.create(uri)), identity, onBehalfOf);
     }
 
     OAuth2Service(

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
@@ -17,7 +17,7 @@ final class SecurityLibWorkarounds
     @Nullable
     static CredentialType getCredentialType( @Nonnull final String rawType )
     {
-        if( rawType.equalsIgnoreCase(X509_GENERATED) ) {
+        if( rawType.equals(X509_GENERATED) ) {
             // this particular credential type is currently (2024-01-31) NOT supported by the Security Client Lib.
             return CredentialType.X509;
         }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
@@ -1,0 +1,27 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.sap.cloud.security.config.CredentialType;
+
+final class SecurityLibWorkarounds
+{
+    private static final String X509_GENERATED = "X509_GENERATED";
+
+    private SecurityLibWorkarounds()
+    {
+        throw new IllegalStateException("This utility class should never be instantiated.");
+    }
+
+    @Nullable
+    static CredentialType getCredentialType( @Nonnull final String rawType )
+    {
+        if( rawType.equalsIgnoreCase(X509_GENERATED) ) {
+            // this particular credential type is currently (2024-01-31) NOT supported by the Security Client Lib.
+            return CredentialType.X509;
+        }
+
+        return CredentialType.from(rawType);
+    }
+}

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -325,7 +325,7 @@ class BtpServicePropertySuppliersTest
             TenantAccessor.executeWithTenant(new DefaultTenant("a", "tenant-a"), () -> {
                 final URI expectedUri = URI.create("https://tenant-a.ias.domain.com");
                 assertThat(sut.getTokenEndpoints())
-                    .isEqualTo(OAuth2PropertySupplier.DefaultTokenEndpoints.fromIasUri(expectedUri));
+                    .isEqualTo(OAuth2PropertySupplier.DefaultTokenEndpoints.forIas(expectedUri));
             });
         }
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
@@ -1,0 +1,120 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static java.util.Map.entry;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
+import static com.github.tomakehurst.wiremock.client.WireMock.post;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.stubFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
+import static com.github.tomakehurst.wiremock.client.WireMock.verify;
+import static com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingTestUtility.bindingWithCredentials;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+
+import org.apache.http.HttpHeaders;
+import org.apache.http.impl.client.HttpClientBuilder;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
+import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
+import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
+import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
+import com.sap.cloud.security.client.HttpClientFactory;
+
+import io.vavr.control.Try;
+
+@WireMockTest( proxyMode = true )
+class OAuth2IntegrationTest
+{
+    private static final String RESPONSE_TEMPLATE = """
+        {
+          "access_token": "%s",
+          "token_type": "Bearer",
+          "expires_in": 3600,
+          "scope": "uaa.resource",
+          "jti": "abc456"
+        }
+        """;
+
+    private List<HttpClientFactory> oldFactories = List.of();
+
+    @BeforeEach
+    void mockClientFactory()
+    {
+        oldFactories = HttpClientFactory.services;
+        HttpClientFactory.services.clear();
+
+        // `useSystemProperties` is needed for the WireMock proxying
+        HttpClientFactory.services.add(identity -> HttpClientBuilder.create().useSystemProperties().build());
+    }
+
+    @AfterEach
+    void restoreClientFactories()
+    {
+        HttpClientFactory.services.clear();
+        HttpClientFactory.services.addAll(oldFactories);
+    }
+
+    @Test
+    void testIasTokenFlow()
+    {
+        final ServiceBinding binding =
+            bindingWithCredentials(
+                ServiceIdentifier.of("identity"),
+                entry("credential-type", "binding-secret"),
+                entry("clientid", "myClientId"),
+                entry("clientsecret", "myClientSecret"),
+                entry("url", "http://provider.ias.domain"),
+                entry("domain", "ias.domain"));
+        final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();
+
+        final Try<HttpDestination> maybeDestination =
+            new OAuth2ServiceBindingDestinationLoader().tryGetDestination(options);
+        assertThat(maybeDestination.isSuccess()).isTrue();
+        final HttpDestination destination = maybeDestination.get();
+
+        {
+            // provider test
+            final String token = "providerToken";
+
+            stubFor(
+                post("/oauth2/token")
+                    .withHost(equalTo("provider.ias.domain"))
+                    .willReturn(okJson(RESPONSE_TEMPLATE.formatted(token))));
+
+            // no tenant - provider case
+            assertThat(TenantAccessor.tryGetCurrentTenant().isFailure()).isTrue();
+            assertThat(destination.getHeaders()).contains(new Header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+
+            // call the method a second time, so we can be sure the token is cached correctly
+            assertThat(destination.getHeaders()).contains(new Header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+
+            verify(1, postRequestedFor(urlEqualTo("/oauth2/token")).withHost(equalTo("provider.ias.domain")));
+        }
+
+        {
+            // subscriber test
+            final String token = "subscriberToken";
+
+            stubFor(
+                post("/oauth2/token")
+                    .withHost(equalTo("subscriber.ias.domain"))
+                    .willReturn(okJson(RESPONSE_TEMPLATE.formatted(token))));
+
+            TenantAccessor.executeWithTenant(new DefaultTenant("subscriber", "subscriber"), () -> {
+                assertThat(destination.getHeaders()).contains(new Header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+
+                // call the method a second time, so we can be sure the token is cached correctly
+                assertThat(destination.getHeaders()).contains(new Header(HttpHeaders.AUTHORIZATION, "Bearer " + token));
+            });
+
+            verify(1, postRequestedFor(urlEqualTo("/oauth2/token")).withHost(equalTo("subscriber.ias.domain")));
+        }
+    }
+}

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
@@ -21,15 +21,4 @@ class OAuth2PropertySupplierTest
         assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth/authorize");
         assertThat(sut.getJwksUri()).hasToString("https://foo.bar/baz/token_keys");
     }
-
-    @Test
-    void testIasTokenEndpoints()
-    {
-        final OAuth2ServiceEndpointsProvider sut =
-            OAuth2PropertySupplier.DefaultTokenEndpoints.forIas(URI.create("https://foo.bar/baz"));
-
-        assertThat(sut.getTokenEndpoint()).hasToString("https://foo.bar/baz/oauth2/token");
-        assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth2/authorize");
-        assertThat(sut.getJwksUri()).hasToString("https://foo.bar/baz/token_keys");
-    }
 }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
@@ -15,7 +15,7 @@ class OAuth2PropertySupplierTest
     void testXsuaaTokenEndpoints()
     {
         final OAuth2ServiceEndpointsProvider sut =
-            OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(URI.create("https://foo.bar/baz"));
+            OAuth2PropertySupplier.DefaultTokenEndpoints.forXsuaa(URI.create("https://foo.bar/baz"));
 
         assertThat(sut.getTokenEndpoint()).hasToString("https://foo.bar/baz/oauth/token");
         assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth/authorize");
@@ -26,7 +26,7 @@ class OAuth2PropertySupplierTest
     void testIasTokenEndpoints()
     {
         final OAuth2ServiceEndpointsProvider sut =
-            OAuth2PropertySupplier.DefaultTokenEndpoints.fromIasUri(URI.create("https://foo.bar/baz"));
+            OAuth2PropertySupplier.DefaultTokenEndpoints.forIas(URI.create("https://foo.bar/baz"));
 
         assertThat(sut.getTokenEndpoint()).hasToString("https://foo.bar/baz/oauth2/token");
         assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth2/authorize");

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2PropertySupplierTest.java
@@ -1,0 +1,35 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
+
+class OAuth2PropertySupplierTest
+{
+
+    @Test
+    void testXsuaaTokenEndpoints()
+    {
+        final OAuth2ServiceEndpointsProvider sut =
+            OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(URI.create("https://foo.bar/baz"));
+
+        assertThat(sut.getTokenEndpoint()).hasToString("https://foo.bar/baz/oauth/token");
+        assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth/authorize");
+        assertThat(sut.getJwksUri()).hasToString("https://foo.bar/baz/token_keys");
+    }
+
+    @Test
+    void testIasTokenEndpoints()
+    {
+        final OAuth2ServiceEndpointsProvider sut =
+            OAuth2PropertySupplier.DefaultTokenEndpoints.fromIasUri(URI.create("https://foo.bar/baz"));
+
+        assertThat(sut.getTokenEndpoint()).hasToString("https://foo.bar/baz/oauth2/token");
+        assertThat(sut.getAuthorizeEndpoint()).hasToString("https://foo.bar/baz/oauth2/authorize");
+        assertThat(sut.getJwksUri()).hasToString("https://foo.bar/baz/token_keys");
+    }
+}

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
@@ -47,7 +47,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
     private static final URI baseUrl = URI.create("baseUrl");
     private static final URI tokenUrl = URI.create("tokenUrl");
     private static final OAuth2ServiceEndpointsProvider xsuaaTokenEndpoints =
-        OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(tokenUrl);
+        OAuth2PropertySupplier.DefaultTokenEndpoints.forXsuaa(tokenUrl);
     public static final ClientIdentity credentials = new ClientCredentials("id", "sec");
 
     private static final ServiceIdentifier TEST_SERVICE = ServiceIdentifier.of("TEST_SERVICE_IDENTIFIER");

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
@@ -38,6 +38,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationNotFoun
 import com.sap.cloud.security.config.ClientCertificate;
 import com.sap.cloud.security.config.ClientCredentials;
 import com.sap.cloud.security.config.ClientIdentity;
+import com.sap.cloud.security.xsuaa.client.OAuth2ServiceEndpointsProvider;
 
 import io.vavr.control.Try;
 
@@ -45,6 +46,8 @@ class OAuth2ServiceBindingDestinationLoaderTest
 {
     private static final URI baseUrl = URI.create("baseUrl");
     private static final URI tokenUrl = URI.create("tokenUrl");
+    private static final OAuth2ServiceEndpointsProvider xsuaaTokenEndpoints =
+        OAuth2PropertySupplier.DefaultTokenEndpoints.fromXsuaaUri(tokenUrl);
     public static final ClientIdentity credentials = new ClientCredentials("id", "sec");
 
     private static final ServiceIdentifier TEST_SERVICE = ServiceIdentifier.of("TEST_SERVICE_IDENTIFIER");
@@ -193,6 +196,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
         when(mock.isOAuth2Binding()).thenReturn(true);
         when(mock.getServiceUri()).thenReturn(baseUrl);
         when(mock.getTokenUri()).thenReturn(tokenUrl);
+        when(mock.getTokenEndpoints()).thenReturn(xsuaaTokenEndpoints);
         when(mock.getClientIdentity()).thenReturn(credentials);
 
         sut = mockLoader(mock);
@@ -213,7 +217,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
         verify(sut, times(3))
             .toDestination(
                 eq(baseUrl),
-                eq(tokenUrl),
+                eq(xsuaaTokenEndpoints),
                 eq(credentials),
                 eq(OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT),
                 eq(TEST_SERVICE));
@@ -228,6 +232,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
         when(mock.isOAuth2Binding()).thenReturn(true);
         when(mock.getServiceUri()).thenReturn(baseUrl);
         when(mock.getTokenUri()).thenReturn(tokenUrl);
+        when(mock.getTokenEndpoints()).thenReturn(xsuaaTokenEndpoints);
         when(mock.getClientIdentity()).thenReturn(certificate);
 
         sut = mockLoader(mock);
@@ -361,7 +366,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
                 .toProxiedDestination(
                     baseDestination,
                     proxyUrl,
-                    tokenUrl,
+                    xsuaaTokenEndpoints,
                     credentials,
                     OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT);
 
@@ -377,7 +382,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
                 .toProxiedDestination(
                     baseDestination,
                     proxyUrl,
-                    tokenUrl,
+                    xsuaaTokenEndpoints,
                     credentials,
                     OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT);
 
@@ -390,7 +395,7 @@ class OAuth2ServiceBindingDestinationLoaderTest
 
         verify(sut, times(2))
             .createHeaderProvider(
-                eq(tokenUrl),
+                eq(xsuaaTokenEndpoints),
                 eq(credentials),
                 eq(OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT),
                 eq(HttpHeaders.PROXY_AUTHORIZATION));


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#391.


This PR adds a new `OAuth2PropertySupplier` implementation that is capable of reading IAS service bindings.
With that, it should - in theory - be possible to fetch tokens for [App-to-Service communication scenarios](https://github.wdf.sap.corp/CPSecurity/Knowledge-Base/blob/master/03_ApplicationSecurity/ProofOfPossession.md#reuse-service-token).

<details>
<summary>Manual E2E Test</summary>

The implementation has been manually E2E tested by extending our [scp-cf-spring-ias-java-17](https://canary.cockpit.btp.int.sap/cockpit/#/globalaccount/s4HanaCloud/subaccount/a89ea924-d9c2-4eab-84fb-3ffcaadf5d24/org/2145ac4f-0ce2-4ecc-aabe-7ef53d1ee1db/space/a140b93a-f555-4538-87eb-ef58ac26edd1/app/5e2f3620-3a25-4da1-b565-12e9b455e3eb/overview) test with the following service:

```java
@RestController
@RequestMapping("/ias")
public class IasSpringController {
    private static final Logger logger = LoggerFactory.getLogger(IasSpringController.class);

    @RequestMapping( method = RequestMethod.GET, path = "/token" )
    public ResponseEntity<?> getToken()
    {
        try {
            logger.info("Requesting IAS token on behalf of '{}'", TenantAccessor.getCurrentTenant());

            final ServiceBindingDestinationOptions options =
                    ServiceBindingDestinationOptions.forService(ServiceIdentifier.of("identity")).build();
            final HttpDestination destination =
                    ServiceBindingDestinationLoader.defaultLoaderChain().getDestination(options);

            final String authorizationHeaderValue =
                    destination
                            .getHeaders()
                            .stream()
                            .filter(h -> HttpHeaders.AUTHORIZATION.equalsIgnoreCase(h.getName()))
                            .map(Header::getValue)
                            .findFirst()
                            .get();

            return ResponseEntity
                    .ok(authorizationHeaderValue.substring(0, Math.min(8, authorizationHeaderValue.length() - 8)) + "****");
        }
        catch( final Exception e ) {
            logger.error("Exception while fetching IAS token.", e);
            return ResponseEntity.internalServerError().build();
        }
    }
}
```

[cf.logs.zip](https://github.com/SAP/cloud-sdk-java/files/14113389/cf.logs.zip)

</details>

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Implement new `OAuth2PropertySupplier` for IAS
- [x] Refactor logic of how the `OAuth2TokenEndpointsProvider` is created
  - This was needed as the IAS token endpoints are slightly different from the XSUAA ones 


## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~ (not meant for the public audience just yet)
- [x] ~Release notes updated~ (not meant for the public audience just yet)

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
