### PR TITLE
chore: Add script to re-bind ias e2e services

### DIFF
--- a/.pipeline/scripts/refresh-ias-certificates.py
+++ b/.pipeline/scripts/refresh-ias-certificates.py
@@ -1,0 +1,34 @@
+#!/usr/bin/env python3
+
+import subprocess
+
+
+class Binding:
+    def __init__(self, app_name, service_name, app_identifier):
+        self.app_name = app_name
+        self.service_name = service_name
+        self.app_identifier = app_identifier
+
+# This script is used to refresh the IAS certificates for the following service bindings:
+bindings = [
+    Binding("scp-cf-spring-sms-provider-test-java17", "cf-sprias-ias", "sms-17-app"),
+    Binding("scp-cf-spring-sms-provider-test-java17-approuter", "cf-sprias-ias", "sms-17-router"),
+
+    Binding("scp-cf-spring-sms-provider-test", "cf-sprias-ias", "sms-app"),
+    Binding("scp-cf-spring-sms-provider-test-approuter", "cf-sprias-ias", "sms-router"),
+
+    Binding("scp-cf-spring-ias-test-java17", "cf-spring-ias", "ias-17-app"),
+    Binding("scp-cf-spring-ias-test-java17-approuter", "cf-spring-ias", "ias-17-router"),
+
+    Binding("scp-cf-spring-ias-test", "cf-spring-ias", "ias-app"),
+    Binding("scp-cf-spring-ias-test-approuter", "cf-spring-ias", "ias-router"),
+]
+
+for binding in bindings:
+    # Information on the parameter can be found here:
+    # https://github.wdf.sap.corp/CPSecurity/Knowledge-Base/blob/master/08_Tutorials/iasbroker/README.md#service-binding-creation
+    binding_parameter = (f'{{"credential-type": "X509_GENERATED", "app-identifier": "{binding.app_identifier}", '
+                         f'"validity": 1, "validity-type": "YEARS"}}')
+    subprocess.run(["cf", "unbind-service", binding.app_name, binding.service_name])
+    subprocess.run(["cf", "bind-service", binding.app_name, binding.service_name, "-c", binding_parameter])
+

--- a/.pipeline/scripts/refresh-ias-certificates.py
+++ b/.pipeline/scripts/refresh-ias-certificates.py
@@ -1,13 +1,13 @@
 #!/usr/bin/env python3
 
 import subprocess
+from dataclasses import dataclass
 
-
+@dataclass
 class Binding:
-    def __init__(self, app_name, service_name, app_identifier):
-        self.app_name = app_name
-        self.service_name = service_name
-        self.app_identifier = app_identifier
+    app_name: str
+    service_name: str
+    app_identifier: str
 
 # This script is used to refresh the IAS certificates for the following service bindings:
 bindings = [


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#404.


This PR adds a script to refresh the service bindings of our E2E Apps to the IAS service.
This is necessary to be done once a year, but can be done more often, if wanted.

Once this is merged I will setup a Slack reminder to run this script beginning of 2025.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] ~Tests cover the scope above~
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~
