### PR TITLE
[JDK21] Virtual Threads, Convenience ThreadContextExecutors API

### DIFF
--- a/cloudplatform/cloudplatform-core/src/main/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutors.java
+++ b/cloudplatform/cloudplatform-core/src/main/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutors.java
@@ -7,6 +7,7 @@ package com.sap.cloud.sdk.cloudplatform.thread;
 import java.util.concurrent.Callable;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -30,6 +31,7 @@ import com.google.common.util.concurrent.ThreadFactoryBuilder;
 public class ThreadContextExecutors
 {
     private static ThreadContextExecutorService executor = newDefaultThreadContextExecutorService();
+    private static ThreadContextExecutorService executorVirtual = newDefaultThreadContextExecutorServiceVirtual();
 
     private static ThreadContextExecutorService newDefaultThreadContextExecutorService()
     {
@@ -44,6 +46,12 @@ public class ThreadContextExecutors
                             .build()));
     }
 
+    private static ThreadContextExecutorService newDefaultThreadContextExecutorServiceVirtual()
+    {
+        final ThreadFactory factory = Thread.ofVirtual().name("sdk-executor-virtual-", 0).factory();
+        return DefaultThreadContextExecutorService.of(Executors.newThreadPerTaskExecutor(factory));
+    }
+
     /**
      * Get the unique executor of this class.
      *
@@ -53,6 +61,17 @@ public class ThreadContextExecutors
     public static ThreadContextExecutorService getExecutor()
     {
         return executor;
+    }
+
+    /**
+     * Get the unique executor of this class. It serves virtual threads.
+     *
+     * @return The unique customized executor instance.
+     */
+    @Nonnull
+    public static ThreadContextExecutorService getExecutorVirtual()
+    {
+        return executorVirtual;
     }
 
     /**

--- a/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutorTest.java
+++ b/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutorTest.java
@@ -16,7 +16,10 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import javax.annotation.Nonnull;
 
@@ -190,6 +193,22 @@ class ThreadContextExecutorTest
         ThreadContextExecutor.fromNewContext().withListeners(new MyThreadContextListener(property)).execute(() -> {
 
             final ExecutorService executor = ThreadContextExecutors.getExecutor();
+
+            executor.submit(() -> assertCurrentContextContains(softly, property)).get(TIMEOUT, TimeUnit.SECONDS);
+        });
+
+        softly.assertAll();
+    }
+
+    @Test
+    void testExecutorServiceVirtualPropagatedContext()
+    {
+        final SoftAssertions softly = new SoftAssertions();
+        final Property<?> property = Property.of("value");
+
+        ThreadContextExecutor.fromNewContext().withListeners(new MyThreadContextListener(property)).execute(() -> {
+
+            final ExecutorService executor = ThreadContextExecutors.getExecutorVirtual();
 
             executor.submit(() -> assertCurrentContextContains(softly, property)).get(TIMEOUT, TimeUnit.SECONDS);
         });

--- a/pom.xml
+++ b/pom.xml
@@ -46,7 +46,7 @@
 		<!--  do not modify the following line, it is updated by the versioning script  -->
 		<sdk.version>5.4.0-SNAPSHOT</sdk.version>
 		<maven.version>3.5</maven.version>
-		<java.version>17</java.version>
+		<java.version>21</java.version>
 		<java.failOnWarning>true</java.failOnWarning>
 		<java.compilerArgument />
 		<javadoc.opts />


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

BLI https://github.com/SAP/cloud-sdk-java-backlog/issues/369

Add convenience method for default thread-context executor-service.

<details><summary>Load testing virtual threads on local machine with unit test.</summary>

Since the java runtime operates differently in performance for each machine, I'm sharing the load test on my end:

```java
@Test
void testExecutorServicePropagatedContext()
// runs ~20s, spawns 400 threads (according to OS task manager)
{
    final Property<?> property = Property.of("value");

    ThreadContextExecutor.fromNewContext().withListeners(new MyThreadContextListener(property)).execute(() -> {

            final AtomicInteger X = new AtomicInteger();
            try (ExecutorService executor = ThreadContextExecutors.getExecutor()) {
                for (int i = 0; i < 10_000_000; i++) {
                    executor.submit(() -> {
                        assertThat(ThreadContextAccessor.getCurrentContext().getPropertyValue(PROPERTY_NAME)).isEqualTo(property.getValue());
                        X.incrementAndGet();
                    });
                }
            }
            assertThat(X).hasValue(10_000_000);
        });
}

@Test
void testExecutorServiceVirtualPropagatedContext()
// runs ~10s, without additional threads (according to OS task manager)
{
    final Property<?> property = Property.of("value");

    ThreadContextExecutor.fromNewContext().withListeners(new MyThreadContextListener(property)).execute(() -> {

        final AtomicInteger X = new AtomicInteger();
        try (ExecutorService executor = ThreadContextExecutors.getExecutorVirtual()) {
            for (int i = 0; i < 10_000_000; i++) {
                executor.submit(() -> {
                    assertThat(ThreadContextAccessor.getCurrentContext().getPropertyValue(PROPERTY_NAME)).isEqualTo(property.getValue());
                    X.incrementAndGet();
                });
            }
        }
        assertThat(X).hasValue(10_000_000);
    });
}
```
</details>


### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Update to JDK21
- [x] Add convenience method
  - [x] Add test

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [ ] Documentation updated
- [ ] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
