### PR TITLE
fix: Snapshot Deployment

### DIFF
--- a/.github/actions/deploy-snapshot/action.yaml
+++ b/.github/actions/deploy-snapshot/action.yaml
@@ -32,8 +32,8 @@ runs:
         distribution: "temurin"
         java-version: "17"
         server-id: artifactory-snapshots
-        server-username: ${{ inputs.repository-username }}
-        server-password: ${{ inputs.repository-password }}
+        server-username: DEPLOYMENT_USER
+        server-password: DEPLOYMENT_PASS
 
     - name: "Download Release Artifacts"
       uses: actions/download-artifact@v4
@@ -57,6 +57,9 @@ runs:
         -Dhttp.keepAlive=false
         deploy
       shell: bash
+      env:
+        DEPLOYMENT_USER: ${{ inputs.repository-username }}
+        DEPLOYMENT_PASS: ${{ inputs.repository-password }}
 
     - name: "Print Action End"
       if: always()


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#318.
Follow-up of #259 


This PR fixes an issue with our snapshot deployment.
As per [actions/setup-java documentation](https://github.com/actions/setup-java):
> * `server-username`: Environment variable name for the username for authentication to the Apache Maven repository. Default is GITHUB_ACTOR.
> * `server-password`: Environment variable name for password or token for authentication to the Apache Maven repository. Default is GITHUB_TOKEN.

So when using the `setup-java` action, it is expected to pass the environment variable names instead of their content, which is now fixed with this PR.
