### PR TITLE
fix: BlackDuck Scan

### DIFF
--- a/.github/actions/scan-with-blackduck/action.yaml
+++ b/.github/actions/scan-with-blackduck/action.yaml
@@ -1,11 +1,16 @@
 name: "Scan with BlackDuck"
 description: "Scans the project with BlackDuck"
 
+inputs:
+  token:
+    description: "The token to use for BlackDuck authentication"
+    required: true
+
 runs:
   using: composite
   steps:
     - name: Print Action Start
-      run: echo ">>>>> Starting Scan with BlackDuck Action; inputs = ${{ toJson(inputs) }}"
+      run: echo ">>>>> Starting Scan with BlackDuck Action; Not printing inputs as they might contain sensitive information."
       shell: bash
 
     - name: Get Major Version
@@ -25,7 +30,7 @@ runs:
         flags: \
           --version=$PROJECT_VERSION \
       env:
-        PIPER_token: ${{ secrets.BLACKDUCK_TOKEN }}
+        PIPER_token: ${{ inputs.token }}
         DETECT_MAVEN_EXCLUDED_MODULES: ${{ steps.get-maven-excludes-for-blackduck.outputs.EXCLUDES }}
         DETECT_MAVEN_BUILD_COMMAND: -pl ${{ steps.get-maven-excludes-for-blackduck.outputs.PREFIXED_EXCLUDES }}
         DETECT_TIMEOUT: "7200"

--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -14,6 +14,8 @@ jobs:
       - uses: actions/checkout@v4
       - name: "Scan With Black Duck"
         uses: ./.github/actions/scan-with-blackduck
+        with:
+          token: ${{ secrets.BLACKDUCK_TOKEN }}
 
   notify-job:
     runs-on: ubuntu-latest

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -439,6 +439,8 @@ jobs:
 
       - name: "Scan With Black Duck"
         uses: ./.github/actions/scan-with-blackduck
+        with:
+          token: ${{ secrets.BLACKDUCK_TOKEN }}
 
   security-rating:
     name: "Run Security Rating"


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#318.
Follow-up of #259 

This PR fixes our BlackDuck scan, which is apparently not able to access secrets as it is within a re-usable action.

🟢 [Successful BlackDuck Scan](https://github.com/SAP/cloud-sdk-java/actions/runs/7830330456/job/21364100366)

![image](https://github.com/SAP/cloud-sdk-java/assets/9248711/c66352f9-8f05-4f0a-8603-0d3678632c75)
