### PR TITLE
fix: Dependabot Release Notes Generation

### DIFF
--- a/.github/workflows/dependabot-release-notes.yaml
+++ b/.github/workflows/dependabot-release-notes.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   update-release-notes:
     name: "Update Release Notes"
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'app/dependabot') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'apps/dependabot') }}
     permissions:
       pull-requests: read
       contents: write

--- a/.github/workflows/dependabot-release-notes.yaml
+++ b/.github/workflows/dependabot-release-notes.yaml
@@ -14,7 +14,7 @@ on:
 jobs:
   update-release-notes:
     name: "Update Release Notes"
-    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.login == 'apps/dependabot') }}
+    if: ${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'pull_request' && github.event.pull_request.user.html_url == 'https://github.com/apps/dependabot') }}
     permissions:
       pull-requests: read
       contents: write


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

This PR fixes the Dependabot Release Notes automation in two regards:

1. The GH action was incorrectly skipped (e.g. #284) as the initial `if` condition was apparently incorrect.
2. The python script failed if there are multiple updates to the same dependency, even if the updates are for the exact same version.

