### PR TITLE
feat:Allow manipulation of Urls read from service binding

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -55,7 +55,7 @@ class BtpServicePropertySuppliers
                     .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice")
                     .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice")
                     .withUrlKey(BusinessLoggingOptions.READ_API, "readservice")
-                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice")
+                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice","buslogs/log")
                     .factory());
 
     private static final List<OAuth2PropertySupplierResolver> DEFAULT_SERVICE_RESOLVERS = new ArrayList<>();

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -52,10 +52,10 @@ class BtpServicePropertySuppliers
                 ServiceIdentifier.of("business-logging"),
                 MultiUrlPropertySupplier
                     .of(BusinessLoggingOptions.class)
-                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice")
-                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice")
+                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice", "/buslogs/configs")
+                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice", "/buslogs/configs/textresource")
                     .withUrlKey(BusinessLoggingOptions.READ_API, "readservice")
-                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice","buslogs/log")
+                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice", "buslogs/log")
                     .factory());
 
     private static final List<OAuth2PropertySupplierResolver> DEFAULT_SERVICE_RESOLVERS = new ArrayList<>();

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -240,7 +240,7 @@ class BtpServicePropertySuppliersTest
                 entry("endpoints.configservice", "https://business-logging.config_api.example.com"),
                 entry("endpoints.readservice", "https://business-logging.read_api.example.com"),
                 entry("endpoints.textresourceservice", "https://business-logging.text_api.example.com"),
-                entry("endpoints.writeservice", "https://business-logging.write_api.example.com"));
+                entry("endpoints.writeservice", "https://business-logging.write_api.example.com/buslogs/log"));
 
         @ParameterizedTest
         @EnumSource( BusinessLoggingOptions.class )


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://github.wdf.sap.corp/MA/sdk/issues/8706

With the above support issue we discovered that `BtpServicePropertySuppliers`  supplies urls provided in the service binding directly without any pre-processing for the `Destination` to be built from the binding.

Although, this works in most cases, most notably in the Business logging service, this causes issues as the service binding seems to have some path appended to the urls, which gets appended later on while making calls from clients generated for this service.

for e.g. in the given binding
```
"endpoints": {
  "configservice": "https://business-logging.config_api.example.com/buslogs/configs",
  "readservice": "https://business-logging.read_api.example.com/odata/v2/com.sap.bs.businesslogging.DisplayMessage",
  "textresourceservice": "https://business-logging.text_api.example.com/buslogs/configs/textresource",
  "writeservice": "https://business-logging.write_api.example.com.cfapps.sap.hana.ondemand.com/buslogs/log"
}
```

For e.g Ideally the Destination created for `writeservice` should only have `https://business-logging.write_api.example.com.cfapps.sap.hana.ondemand.com` and not include the additional path "/buslogs/log".

This PR aims at removing such known redundant paths from the service binding URLs obtained.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
-  [x] Add logic to remove redundant path from URL
- [ ] Add tests

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
