### PR TITLE
fix: [DevOps] Fix Broken Maven Plugin Tests and Ban JUnit4

### DIFF
--- a/cloudplatform/connectivity-destination-service/pom.xml
+++ b/cloudplatform/connectivity-destination-service/pom.xml
@@ -176,6 +176,12 @@
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>junit</artifactId>
+					<groupId>junit</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.cloud.security.xsuaa</groupId>

--- a/cloudplatform/connectivity-oauth/pom.xml
+++ b/cloudplatform/connectivity-oauth/pom.xml
@@ -163,6 +163,12 @@
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>junit</artifactId>
+					<groupId>junit</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.mockito</groupId>

--- a/cloudplatform/security/pom.xml
+++ b/cloudplatform/security/pom.xml
@@ -111,6 +111,12 @@
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>junit</artifactId>
+					<groupId>junit</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.cloud.environment.servicebinding</groupId>

--- a/cloudplatform/security/src/test/java/com/sap/cloud/sdk/cloudplatform/security/principal/OAuth2AuthTokenPrincipalExtractorTest.java
+++ b/cloudplatform/security/src/test/java/com/sap/cloud/sdk/cloudplatform/security/principal/OAuth2AuthTokenPrincipalExtractorTest.java
@@ -9,7 +9,6 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
@@ -48,13 +47,6 @@ class OAuth2AuthTokenPrincipalExtractorTest
                 PREFIX + ".Equipment.View",
                 PREFIX + ".Persons.View",
                 PREFIX + ".Workplaces.View");
-
-    private static final List<String> PREFIX_STRIPPED_SCOPES =
-        SCOPES
-            .stream()
-            .filter(scope -> scope.startsWith(PREFIX + "."))
-            .map(name -> name.replace(PREFIX + ".", ""))
-            .collect(Collectors.toList());
 
     @AfterEach
     void cleanupAccessors()

--- a/cloudplatform/tenant/pom.xml
+++ b/cloudplatform/tenant/pom.xml
@@ -101,6 +101,12 @@
 			<groupId>com.sap.cloud.security</groupId>
 			<artifactId>java-security-test</artifactId>
 			<scope>test</scope>
+			<exclusions>
+				<exclusion>
+					<artifactId>junit</artifactId>
+					<groupId>junit</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.sap.cloud.environment.servicebinding</groupId>

--- a/codestyle/sdk_specific_pmd_rules.xml
+++ b/codestyle/sdk_specific_pmd_rules.xml
@@ -122,6 +122,29 @@
             ]]>
         </example>
     </rule>
+    <rule name="UseOfJunit4" language="java"
+          message="Do not use JUnit 4."
+          class="net.sourceforge.pmd.lang.rule.XPathRule">
+        <description>
+            Never use JUnit 4 to run tests. Use JUnit Jupiter instead.
+        </description>
+        <priority>1</priority>
+        <properties>
+            <property name="xpath">
+                <value>
+                    <![CDATA[
+                        //ImportDeclaration
+                        [starts-with(Name/@Image, 'org.junit.Test')]
+                    ]]>
+                </value>
+            </property>
+        </properties>
+        <example>
+            <![CDATA[
+            import org.junit.Test;
+            ]]>
+        </example>
+    </rule>
     <rule name="NullAnnotationMissingOnPublicMethod" language="java"
           message="Public method is not annotated with @Nonnull or @Nullable."
           class="net.sourceforge.pmd.lang.rule.XPathRule">

--- a/codestyle/sdk_specific_pmd_rules.xml
+++ b/codestyle/sdk_specific_pmd_rules.xml
@@ -122,29 +122,6 @@
             ]]>
         </example>
     </rule>
-    <rule name="UseOfJunit4" language="java"
-          message="Do not use JUnit 4."
-          class="net.sourceforge.pmd.lang.rule.XPathRule">
-        <description>
-            Never use JUnit 4 to run tests. Use JUnit Jupiter instead.
-        </description>
-        <priority>1</priority>
-        <properties>
-            <property name="xpath">
-                <value>
-                    <![CDATA[
-                        //ImportDeclaration
-                        [starts-with(Name/@Image, 'org.junit.Test')]
-                    ]]>
-                </value>
-            </property>
-        </properties>
-        <example>
-            <![CDATA[
-            import org.junit.Test;
-            ]]>
-        </example>
-    </rule>
     <rule name="NullAnnotationMissingOnPublicMethod" language="java"
           message="Public method is not annotated with @Nonnull or @Nullable."
           class="net.sourceforge.pmd.lang.rule.XPathRule">

--- a/datamodel/odata-v4/odata-v4-generator-maven-plugin/pom.xml
+++ b/datamodel/odata-v4/odata-v4-generator-maven-plugin/pom.xml
@@ -40,6 +40,8 @@
 		<enforcer.skipEnforceScopeJavaEE>true</enforcer.skipEnforceScopeJavaEE>
 		<!-- allow scope compile for lombok since this module is not included as dependency -->
 		<enforcer.skipEnforceScopeLombok>true</enforcer.skipEnforceScopeLombok>
+		<!-- allow JUnit 4 as we need to compile against MojoRule, but we don't use JUnit 4 for test execution itself -->
+		<enforcer.skipBanJunit4>true</enforcer.skipBanJunit4>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +69,11 @@
 			<scope>provided</scope>
 		</dependency>
 		<!-- scope "test" -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/datamodel/odata/odata-generator-maven-plugin/pom.xml
+++ b/datamodel/odata/odata-generator-maven-plugin/pom.xml
@@ -40,6 +40,8 @@
 		<enforcer.skipEnforceScopeJavaEE>true</enforcer.skipEnforceScopeJavaEE>
 		<!-- allow scope compile for lombok since this module is not included as dependency -->
 		<enforcer.skipEnforceScopeLombok>true</enforcer.skipEnforceScopeLombok>
+		<!-- allow JUnit 4 as we need to compile against MojoRule, but we don't use JUnit 4 for test execution itself -->
+		<enforcer.skipBanJunit4>true</enforcer.skipBanJunit4>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +69,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<!-- scope "test" -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JUnit 4 must not be used for test execution -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/datamodel/odata/odata-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/odata/generator/DataModelGeneratorMojoTest.java
+++ b/datamodel/odata/odata-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/odata/generator/DataModelGeneratorMojoTest.java
@@ -11,28 +11,21 @@ import java.io.File;
 import java.net.URL;
 
 import org.apache.maven.plugin.testing.MojoRule;
-import org.junit.Rule;
-import org.junit.Test;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import com.sap.cloud.sdk.datamodel.odata.generator.annotation.DefaultAnnotationStrategy;
 import com.sap.cloud.sdk.datamodel.odata.utility.NameSource;
 import com.sap.cloud.sdk.datamodel.odata.utility.S4HanaNamingStrategy;
 
-public class DataModelGeneratorMojoTest
+class DataModelGeneratorMojoTest
 {
-    @Rule
-    public MojoRule rule = new MojoRule();
-
     @Test
-    public void test()
-        throws Exception
+    void test()
+        throws Throwable
     {
-        final URL resource = getClass().getClassLoader().getResource(getClass().getSimpleName());
-        assertThat(resource).isNotNull();
-
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
+        final DataModelGeneratorMojo mojo = loadTestProject();
         final DataModelGenerator generator = mojo.getDataModelGenerator();
 
         assertSoftly(softly -> {
@@ -61,5 +54,29 @@ public class DataModelGeneratorMojoTest
             softly.assertThat(generator.getCopyrightHeader()).isEmpty();
             softly.assertThat(generator.isServiceMethodsPerEntitySet()).isTrue();
         });
+    }
+
+    private DataModelGeneratorMojo loadTestProject()
+        throws Throwable
+    {
+        final URL resource = getClass().getClassLoader().getResource(getClass().getSimpleName());
+        assertThat(resource).isNotNull();
+
+        final File pomFile = new File(resource.getFile());
+
+        final MojoRule rule = new MojoRule();
+        // hacky workaround to invoke the internal call to "testCase.setUp()" inside MojoRule
+        // exploiting the fact that the setup is not teared down after "evaluate" returns
+        // this workaround is applied because "lookupConfiguredMojo" is not available on AbstractMojoTestCase
+        // and this way we can skip the effort to re-implement what is already available in MojoRule
+        rule.apply(new Statement()
+        {
+            @Override
+            public void evaluate()
+            {
+
+            }
+        }, Description.createSuiteDescription("dummy")).evaluate();
+        return (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
     }
 }

--- a/datamodel/openapi/openapi-generator-maven-plugin/pom.xml
+++ b/datamodel/openapi/openapi-generator-maven-plugin/pom.xml
@@ -40,6 +40,8 @@
 		<enforcer.skipEnforceScopeJavaEE>true</enforcer.skipEnforceScopeJavaEE>
 		<!-- allow scope compile for lombok since this module is not included as dependency -->
 		<enforcer.skipEnforceScopeLombok>true</enforcer.skipEnforceScopeLombok>
+		<!-- allow JUnit 4 as we need to compile against MojoRule, but we don't use JUnit 4 for test execution itself -->
+		<enforcer.skipBanJunit4>true</enforcer.skipBanJunit4>
 	</properties>
 	<dependencies>
 		<dependency>
@@ -67,6 +69,12 @@
 			<scope>provided</scope>
 		</dependency>
 		<!-- scope "test" -->
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-api</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<!-- JUnit 4 must not be used for test execution -->
 		<dependency>
 			<groupId>junit</groupId>
 			<artifactId>junit</artifactId>

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoIntegrationTest.java
@@ -52,7 +52,7 @@ class DataModelGeneratorMojoIntegrationTest
     }
 
     // Run this test method manually to overwrite the folder containing the expected content with the latest generator state
-    @Test
+    // @Test
     void regenerateExpectedSodastoreLibrary()
         throws Throwable
     {

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoUnitTest.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoUnitTest.java
@@ -12,9 +12,10 @@ import java.net.URL;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.MojoRule;
-import org.junit.Rule;
-import org.junit.Test;
-import org.junit.rules.TemporaryFolder;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.runner.Description;
+import org.junit.runners.model.Statement;
 
 import com.sap.cloud.sdk.datamodel.openapi.generator.exception.OpenApiGeneratorException;
 import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
@@ -22,31 +23,23 @@ import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfigurati
 
 import io.vavr.control.Try;
 
-public class DataModelGeneratorMojoUnitTest
+class DataModelGeneratorMojoUnitTest
 {
-    @Rule
-    public MojoRule rule = new MojoRule();
+    @TempDir
+    File outputDirectory;
 
-    @Rule
-    public TemporaryFolder outputDirectory = TemporaryFolder.builder().assureDeletion().build();
+    private DataModelGeneratorMojo sut;
 
     @Test
-    public void testInvocationWithAllParameters()
-        throws Exception
+    void testInvocationWithAllParameters()
+        throws Throwable
     {
-        final URL resource =
-            getClass().getClassLoader().getResource("DataModelGeneratorMojoUnitTest/testInvocationWithAllParameters");
+        sut = loadTestProject("testInvocationWithAllParameters");
 
-        assertThat(resource).isNotNull();
-
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
-
-        final GenerationConfiguration configuration = mojo.retrieveGenerationConfiguration().get();
+        final GenerationConfiguration configuration = sut.retrieveGenerationConfiguration().get();
 
         assertThat(configuration.getApiMaturity()).isEqualTo(ApiMaturity.RELEASED);
-        assertThat(configuration.isVerbose());
+        assertThat(configuration.isVerbose()).isTrue();
         assertThat(configuration.getOutputDirectory()).isEqualTo("output-directory");
         assertThat(configuration.getInputSpec())
             .isEqualTo("DataModelGeneratorMojoUnitTest/testInvocationWithAllParameters/input/sodastore.yaml");
@@ -55,26 +48,18 @@ public class DataModelGeneratorMojoUnitTest
         assertThat(configuration.deleteOutputDirectory()).isTrue();
         assertThat(configuration.isOneOfAnyOfGenerationEnabled()).isFalse();
 
-        mojo.setOutputDirectory(outputDirectory.newFolder("output").toString());
+        sut.setOutputDirectory(outputDirectory.getAbsolutePath());
 
-        mojo.execute();
+        sut.execute();
     }
 
     @Test
-    public void testInvocationWithMandatoryParameters()
-        throws Exception
+    void testInvocationWithMandatoryParameters()
+        throws Throwable
     {
-        final URL resource =
-            getClass()
-                .getClassLoader()
-                .getResource("DataModelGeneratorMojoUnitTest/testInvocationWithMandatoryParameters");
-        assertThat(resource).isNotNull();
+        sut = loadTestProject("testInvocationWithMandatoryParameters");
 
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
-
-        final GenerationConfiguration configuration = mojo.retrieveGenerationConfiguration().get();
+        final GenerationConfiguration configuration = sut.retrieveGenerationConfiguration().get();
 
         assertThat(configuration.getApiMaturity()).isEqualTo(ApiMaturity.RELEASED);
         assertThat(configuration.isVerbose()).isFalse();
@@ -85,24 +70,18 @@ public class DataModelGeneratorMojoUnitTest
         assertThat(configuration.getApiPackage()).isEqualTo("com.sap.cloud.sdk.datamodel.rest.test.api");
         assertThat(configuration.deleteOutputDirectory()).isFalse();
 
-        mojo.setOutputDirectory(outputDirectory.newFolder("output").toString());
+        sut.setOutputDirectory(outputDirectory.getAbsolutePath());
 
-        mojo.execute();
+        sut.execute();
     }
 
     @Test
-    public void testEmptyRequiredParameter()
-        throws Exception
+    void testEmptyRequiredParameter()
+        throws Throwable
     {
-        final URL resource =
-            getClass().getClassLoader().getResource("DataModelGeneratorMojoUnitTest/testEmptyRequiredParameter");
-        assertThat(resource).isNotNull();
+        sut = loadTestProject("testEmptyRequiredParameter");
 
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
-
-        final Try<Void> mojoExecutionTry = Try.run(mojo::execute);
+        final Try<Void> mojoExecutionTry = Try.run(sut::execute);
 
         assertThat(mojoExecutionTry.isFailure()).isTrue();
 
@@ -116,60 +95,64 @@ public class DataModelGeneratorMojoUnitTest
     }
 
     @Test
-    public void testSkipExecution()
-        throws Exception
+    void testSkipExecution()
+        throws Throwable
     {
-        final URL resource =
-            getClass().getClassLoader().getResource("DataModelGeneratorMojoUnitTest/testSkipExecution");
-        assertThat(resource).isNotNull();
+        sut = loadTestProject("testSkipExecution");
 
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
-
-        mojo.execute();
-
+        sut.execute();
         //no reasonable assertion possible
     }
 
     @Test
-    public void testInvocationWithUnexpectedApiMaturity()
-        throws Exception
+    void testInvocationWithUnexpectedApiMaturity()
+        throws Throwable
     {
-        final URL resource =
-            getClass()
-                .getClassLoader()
-                .getResource("DataModelGeneratorMojoUnitTest/testInvocationWithUnexpectedApiMaturity");
-        assertThat(resource).isNotNull();
-
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
+        sut = loadTestProject("testInvocationWithUnexpectedApiMaturity");
 
         assertThatExceptionOfType(MojoExecutionException.class)
-            .isThrownBy(mojo::execute)
+            .isThrownBy(sut::execute)
             .withCauseInstanceOf(IllegalArgumentException.class);
     }
 
     @Test
-    public void testAdditionalPropertiesAndEnablingAnyOfOneOfGeneration()
-        throws Exception
+    void testAdditionalPropertiesAndEnablingAnyOfOneOf()
+        throws Throwable
     {
-        final URL resource =
-            getClass()
-                .getClassLoader()
-                .getResource("DataModelGeneratorMojoUnitTest/testAdditionalPropertiesAndEnablingAnyOfOneOf");
-        assertThat(resource).isNotNull();
+        sut = loadTestProject("testAdditionalPropertiesAndEnablingAnyOfOneOf");
 
-        final File pomFile = new File(resource.getFile());
-
-        final DataModelGeneratorMojo mojo = (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
-
-        assertThat(mojo.retrieveGenerationConfiguration().get().getAdditionalProperties())
+        assertThat(sut.retrieveGenerationConfiguration().get().getAdditionalProperties())
             .containsEntry("param1", "val1")
             .containsEntry("param2", "val2")
             .containsEntry("useAbstractionForFiles", "true");
 
-        assertThat(mojo.retrieveGenerationConfiguration().get().isOneOfAnyOfGenerationEnabled()).isTrue();
+        assertThat(sut.retrieveGenerationConfiguration().get().isOneOfAnyOfGenerationEnabled()).isTrue();
+    }
+
+    private DataModelGeneratorMojo loadTestProject( String testDir )
+        throws Throwable
+    {
+        final URL resource =
+            DataModelGeneratorMojoUnitTest.class
+                .getClassLoader()
+                .getResource("DataModelGeneratorMojoUnitTest/" + testDir);
+        assertThat(resource).isNotNull();
+
+        final File pomFile = new File(resource.getFile());
+
+        final MojoRule rule = new MojoRule();
+        // hacky workaround to invoke the internal call to "testCase.setUp()" inside MojoRule
+        // exploiting the fact that the setup is not teared down after "evaluate" returns
+        // this workaround is applied because "lookupConfiguredMojo" is not available on AbstractMojoTestCase
+        // and this way we can skip the effort to re-implement what is already available in MojoRule
+        rule.apply(new Statement()
+        {
+            @Override
+            public void evaluate()
+            {
+
+            }
+        }, Description.createSuiteDescription("dummy")).evaluate();
+        return (DataModelGeneratorMojo) rule.lookupConfiguredMojo(pomFile, "generate");
     }
 }

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoUnitTest.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojoUnitTest.java
@@ -12,7 +12,8 @@ import java.net.URL;
 
 import org.apache.maven.plugin.MojoExecutionException;
 import org.apache.maven.plugin.testing.MojoRule;
-import org.junit.jupiter.api.Test;
+// import org.junit.jupiter.api.Test;
+import org.junit.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
@@ -34,7 +35,7 @@ class DataModelGeneratorMojoUnitTest
     void testInvocationWithAllParameters()
         throws Throwable
     {
-        sut = loadTestProject("testInvocationWithAllParameters");
+        sut = loadTestProject("/testInvocationWithAllParameters");
 
         final GenerationConfiguration configuration = sut.retrieveGenerationConfiguration().get();
 
@@ -57,7 +58,7 @@ class DataModelGeneratorMojoUnitTest
     void testInvocationWithMandatoryParameters()
         throws Throwable
     {
-        sut = loadTestProject("testInvocationWithMandatoryParameters");
+        sut = loadTestProject("/testInvocationWithMandatoryParameters");
 
         final GenerationConfiguration configuration = sut.retrieveGenerationConfiguration().get();
 
@@ -79,7 +80,7 @@ class DataModelGeneratorMojoUnitTest
     void testEmptyRequiredParameter()
         throws Throwable
     {
-        sut = loadTestProject("testEmptyRequiredParameter");
+        sut = loadTestProject("/testEmptyRequiredParameter");
 
         final Try<Void> mojoExecutionTry = Try.run(sut::execute);
 
@@ -98,7 +99,7 @@ class DataModelGeneratorMojoUnitTest
     void testSkipExecution()
         throws Throwable
     {
-        sut = loadTestProject("testSkipExecution");
+        sut = loadTestProject("/testSkipExecution");
 
         sut.execute();
         //no reasonable assertion possible
@@ -108,7 +109,7 @@ class DataModelGeneratorMojoUnitTest
     void testInvocationWithUnexpectedApiMaturity()
         throws Throwable
     {
-        sut = loadTestProject("testInvocationWithUnexpectedApiMaturity");
+        sut = loadTestProject("/testInvocationWithUnexpectedApiMaturity");
 
         assertThatExceptionOfType(MojoExecutionException.class)
             .isThrownBy(sut::execute)
@@ -119,7 +120,7 @@ class DataModelGeneratorMojoUnitTest
     void testAdditionalPropertiesAndEnablingAnyOfOneOf()
         throws Throwable
     {
-        sut = loadTestProject("testAdditionalPropertiesAndEnablingAnyOfOneOf");
+        sut = loadTestProject("/testAdditionalPropertiesAndEnablingAnyOfOneOf");
 
         assertThat(sut.retrieveGenerationConfiguration().get().getAdditionalProperties())
             .containsEntry("param1", "val1")
@@ -132,10 +133,7 @@ class DataModelGeneratorMojoUnitTest
     private DataModelGeneratorMojo loadTestProject( String testDir )
         throws Throwable
     {
-        final URL resource =
-            DataModelGeneratorMojoUnitTest.class
-                .getClassLoader()
-                .getResource("DataModelGeneratorMojoUnitTest/" + testDir);
+        final URL resource = getClass().getClassLoader().getResource(getClass().getSimpleName() + testDir);
         assertThat(resource).isNotNull();
 
         final File pomFile = new File(resource.getFile());

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/NewSoda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/NewSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class NewSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -182,7 +184,7 @@ public class NewSoda
   }
 
   /**
-   * Get the value of an unrecognizable property of the {@link NewSoda}.
+   * Get the value of an unrecognizable property of this {@link NewSoda} instance.
    * @param name  The name of the property
    * @return The value of the property
    * @throws NoSuchElementException  If no property with the given name could be found.
@@ -194,6 +196,19 @@ public class NewSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Set an unrecognizable property of this {@link NewSoda} instance. If the map previously contained a mapping
+   * for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void setCustomField( @Nonnull String customFieldName, @Nullable Object customFieldValue )
+  {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/Soda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/Soda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -60,6 +61,7 @@ public class Soda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -213,7 +215,7 @@ public class Soda
   }
 
   /**
-   * Get the value of an unrecognizable property of the {@link Soda}.
+   * Get the value of an unrecognizable property of this {@link Soda} instance.
    * @param name  The name of the property
    * @return The value of the property
    * @throws NoSuchElementException  If no property with the given name could be found.
@@ -225,6 +227,19 @@ public class Soda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Set an unrecognizable property of this {@link Soda} instance. If the map previously contained a mapping
+   * for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void setCustomField( @Nonnull String customFieldName, @Nullable Object customFieldValue )
+  {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/UpdateSoda.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/model/UpdateSoda.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 import com.fasterxml.jackson.annotation.JsonAnySetter;
+import com.fasterxml.jackson.annotation.JsonAnyGetter;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import com.fasterxml.jackson.annotation.JsonTypeName;
@@ -57,6 +58,7 @@ public class UpdateSoda
   private Float price;
 
   @JsonAnySetter
+  @JsonAnyGetter
   private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
    /**
@@ -182,7 +184,7 @@ public class UpdateSoda
   }
 
   /**
-   * Get the value of an unrecognizable property of the {@link UpdateSoda}.
+   * Get the value of an unrecognizable property of this {@link UpdateSoda} instance.
    * @param name  The name of the property
    * @return The value of the property
    * @throws NoSuchElementException  If no property with the given name could be found.
@@ -194,6 +196,19 @@ public class UpdateSoda
     }
     return cloudSdkCustomFields.get(name);
   }
+
+  /**
+   * Set an unrecognizable property of this {@link UpdateSoda} instance. If the map previously contained a mapping
+   * for the key, the old value is replaced by the specified value.
+   * @param customFieldName The name of the property
+   * @param customFieldValue The value of the property
+   */
+  @JsonIgnore
+  public void setCustomField( @Nonnull String customFieldName, @Nullable Object customFieldValue )
+  {
+      cloudSdkCustomFields.put(customFieldName, customFieldValue);
+  }
+
 
   @Override
   public boolean equals(@Nullable final java.lang.Object o) {

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoUnitTest/testInvocationWithUnexpectedApiMaturity/pom.xml
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoUnitTest/testInvocationWithUnexpectedApiMaturity/pom.xml
@@ -13,7 +13,7 @@
 				<groupId>com.sap.cloud.sdk.datamodel</groupId>
 				<artifactId>openapi-generator-maven-plugin</artifactId>
 				<configuration>
-					<inputSpec>DataModelGeneratorMojoUnitTest/testInvocationWithAllParameters/input/sodastore.yaml</inputSpec>
+					<inputSpec>DataModelGeneratorMojoUnitTest/testInvocationWithUnexpectedApiMaturity/input/sodastore.yaml</inputSpec>
 					<apiPackage>com.sap.cloud.sdk.datamodel.rest.test.api</apiPackage>
                     <modelPackage>com.sap.cloud.sdk.datamodel.rest.test.model</modelPackage>
                     <apiMaturity>unexpected-api-maturity</apiMaturity>

--- a/pom.xml
+++ b/pom.xml
@@ -106,6 +106,7 @@
 		<olingo-v4.version>5.0.0</olingo-v4.version>
 		<olingo-v2.version>2.0.13</olingo-v2.version>
 		<maven-plugin.version>3.9.6</maven-plugin.version>
+		<maven-plugin-annotations.version>3.11.0</maven-plugin-annotations.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<caffeine.version>3.1.8</caffeine.version>
 		<openapi-generator.version>7.3.0</openapi-generator.version>
@@ -166,7 +167,7 @@
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>3.11.0</version>
+				<version>${maven-plugin-annotations.version}</version>
 				<scope>provided</scope>
 			</dependency>
 			<!--Dependencies used in generators-->

--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,7 @@
 		<enforcer.skipEnforceScopeJavaEE>false</enforcer.skipEnforceScopeJavaEE>
 		<enforcer.skipEnforceScopeLombok>false</enforcer.skipEnforceScopeLombok>
 		<enforcer.skipBanGeneratedModulesReference>false</enforcer.skipBanGeneratedModulesReference>
+		<enforcer.skipBanJunit4>false</enforcer.skipBanJunit4>
 		<surefire.forkCount>4</surefire.forkCount>
 		<surefire.include>*</surefire.include>
 		<surefire.exclude />
@@ -104,7 +105,7 @@
 		<codemodel.version>2.6</codemodel.version>
 		<olingo-v4.version>5.0.0</olingo-v4.version>
 		<olingo-v2.version>2.0.13</olingo-v2.version>
-		<maven-plugin.version>3.9.0</maven-plugin.version>
+		<maven-plugin.version>3.9.6</maven-plugin.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<caffeine.version>3.1.8</caffeine.version>
 		<openapi-generator.version>7.3.0</openapi-generator.version>
@@ -165,7 +166,7 @@
 			<dependency>
 				<groupId>org.apache.maven.plugin-tools</groupId>
 				<artifactId>maven-plugin-annotations</artifactId>
-				<version>${maven-plugin.version}</version>
+				<version>3.11.0</version>
 				<scope>provided</scope>
 			</dependency>
 			<!--Dependencies used in generators-->
@@ -600,6 +601,23 @@
 											<exclude>com.sap.cloud.sdk.datamodel:odata-api-sample</exclude>
 											<exclude>com.sap.cloud.sdk.datamodel:odata-v4-api-sample</exclude>
 											<exclude>com.sap.cloud.sdk.datamodel:openapi-api-sample</exclude>
+										</excludes>
+									</bannedDependencies>
+								</rules>
+							</configuration>
+						</execution>
+						<execution>
+							<id>ban-old-junit</id>
+							<goals>
+								<goal>enforce</goal>
+							</goals>
+							<configuration>
+								<skip>${enforcer.skipBanJunit4}</skip>
+								<rules>
+									<bannedDependencies>
+										<message>Do not use JUnit 4.X, instead exclusively use Junit Jupiter. JUnit 4 tests will (silently) simply not be executed.</message>
+										<excludes>
+											<exclude>junit:junit</exclude>
 										</excludes>
 									</bannedDependencies>
 								</rules>


### PR DESCRIPTION
## Overview

This pull request fixes the tests for our 3 maven plugins. Currently, the tests are **not executed**. This is because they are defined using JUnit 4, but our JUnit execution engine (defined here) only executes JUnit 5 tests. Unfortunately, this goes completely undetected.

## Changes

* Migrate maven plugin tests to JUnit 5
  * Apply a bit of workaround code to make the JUnit4-based `MojoRule` from `maven-plugin-test-harness` work inside the JUnit 5 tests
  * Fix any broken test code
* Ban JUnit 4 via dependency rule
* ~Ban import statements for JUnit 4 test annotation (`org.junit.Test`) via PMD rule~ 
  * Moved to separate PR
  * This is done to enforce that in the maven plugin modules, where we still need to have JUnit 4 on the classpath, it can't be used to annotate tests

## Notes

Alternatively to:

> Migrate maven plugin tests to JUnit 5

one could also change the JUnit execution engine just for the maven plugin modules. But that also kinda feels bad and again, the risk is a JUnit 5 test is added but not executed.

So I opted for the workaround code for now..