### PR TITLE
Run workflow "continuous-integration" on "push" events

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -1,5 +1,7 @@
 name: "Continuous Integration"
 on:
+  push:
+    branches: [ "main" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
Related backlog task: https://github.com/SAP/cloud-sdk-java-backlog/issues/409

**Current State:**
* `continuous-integration.yaml` is being executed for every PR build.
* `continuous-integration.yaml` is being executed for PR squash + merge on `main` branch.
* `continuous-integration.yaml` is being executed on `main` commits (without PR).
* _CodeQL_ complains in all cases with the following warning:
  
  > ⚠️ **Run CodeQL Analysis**
  > 1 issue was detected with this workflow: Please specify an on.push hook to analyze and see code scanning alerts from the default branch on the Security tab.


**Expectation:**
* The above warning is fixed by merging this PR.
