### PR TITLE
fix: Fix Surefire reports on Dependabots PRs

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -234,7 +234,7 @@ jobs:
       - name: "Test Report"
         #Surefire reports are failing on pull requests created from forks and from GitHub Apps like dependabot
         #https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
-        if: github.event.pull_request.head.repo.full_name == 'SAP/cloud-sdk-java' || github.actor != 'dependabot[bot]'
+        if: github.event.pull_request.head.repo.full_name == 'SAP/cloud-sdk-java' && github.actor != 'dependabot[bot]'
         uses: scacap/action-surefire-report@v1
       - name: "Coverage Report"
         run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -232,9 +232,11 @@ jobs:
           mvn $MVN_ARGS
 
       - name: "Test Report"
-        if: github.event.pull_request.head.repo.full_name == 'SAP/cloud-sdk-java'
+        #Surefire reports are failing on pull requests created from forks and from GitHub Apps like dependabot
+        #https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
+        if: github.event.pull_request.head.repo.full_name == 'SAP/cloud-sdk-java' || github.actor != 'dependabot[bot]'
         uses: scacap/action-surefire-report@v1
-      - name: Coverage Report
+      - name: "Coverage Report"
         run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"
 
   static-code-analysis:


### PR DESCRIPTION
## Summary
This PR addresses the issue of failing Surefire reports on pull requests created from forks and from GitHub Apps like dependabot. The changes in this PR modify the continuous integration workflow to handle these cases correctly.

## Backlog Item
This PR is related to the backlog item [#419 Fix dependency update PR test-report error](https://github.com/SAP/cloud-sdk-java-backlog/issues/419).

## Reviewer Instructions
Please review the changes in the continuous integration workflow file and ensure that the updated condition for the "Test Report" step is correct.