### PR TITLE
Make Service Binding Library usage backwards-compatible

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -36,9 +36,12 @@ class BtpServicePropertySuppliers
     static final OAuth2PropertySupplierResolver CONNECTIVITY =
         OAuth2PropertySupplierResolver.forServiceIdentifier(ServiceIdentifier.CONNECTIVITY, ConnectivityProxy::new);
 
+    /**
+     * {@link ServiceIdentifier#IDENTITY_AUTHENTICATION} referenced indirectly for backwards compatibility.
+     */
     static final OAuth2PropertySupplierResolver IDENTITY_AUTHENTICATION =
         OAuth2PropertySupplierResolver
-            .forServiceIdentifier(ServiceIdentifier.IDENTITY_AUTHENTICATION, IdentityAuthentication::new);
+            .forServiceIdentifier(ServiceIdentifier.of("identity"), IdentityAuthentication::new);
 
     static final OAuth2PropertySupplierResolver WORKFLOW =
         OAuth2PropertySupplierResolver

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -275,6 +275,11 @@ class OAuth2Service
         private static final String XSUAA_TOKEN_PATH = "/oauth/token";
         private static final Duration DEFAULT_TIME_OUT = Duration.ofSeconds(10);
 
+        /**
+         * {@link ServiceIdentifier#IDENTITY_AUTHENTICATION} referenced indirectly for backwards compatibility.
+         */
+        private static final ServiceIdentifier IDENTITY_AUTHENTICATION = ServiceIdentifier.of("identity");
+
         private URI tokenUri;
         private ClientIdentity identity;
         private OnBehalfOf onBehalfOf = OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT;
@@ -328,7 +333,7 @@ class OAuth2Service
         Builder withTenantPropagationStrategyFrom( @Nullable final ServiceIdentifier serviceIdentifier )
         {
             final TenantPropagationStrategy tenantPropagationStrategy;
-            if( ServiceIdentifier.IDENTITY_AUTHENTICATION.equals(serviceIdentifier) ) {
+            if( IDENTITY_AUTHENTICATION.equals(serviceIdentifier) ) {
                 tenantPropagationStrategy = TenantPropagationStrategy.TENANT_SUBDOMAIN;
             } else {
                 tenantPropagationStrategy = TenantPropagationStrategy.ZID_HEADER;


### PR DESCRIPTION
Related BLI
* https://github.com/SAP/cloud-sdk-java-backlog/issues/412

We've noticed an incompatibility with SJB (**2.2.0**):
* They haven't updated to service-binding-lib [`0.10.3`](https://github.com/SAP/btp-environment-variable-access/releases/tag/0.10.3) yet. At runtime class loading issues will occur.

More context:
* To enable SJB you need to set service-binding-lib `scope=provided`
* When using `scope=compile` duplicate entries in class-path will break class loading.