### PR TITLE
fix: [HttpClient] Fix Destination Reference in ApacheHttpClient5Wrapper

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
@@ -13,6 +13,7 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 
@@ -21,7 +22,6 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessE
 import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
 
 import lombok.AccessLevel;
-import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -107,7 +107,7 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         requestBuilder.setUri(requestUri);
 
         for( final Header header : destination.getHeaders(requestUri) ) {
-            requestBuilder.addHeader(new HeaderWithEquals(header.getName(), header.getValue()));
+            requestBuilder.addHeader(new BasicHeader(header.getName(), header.getValue()));
 
             log
                 .debug(
@@ -118,13 +118,5 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         }
 
         return requestBuilder.build();
-    }
-
-    @Data
-    static class HeaderWithEquals implements org.apache.hc.core5.http.Header
-    {
-        private final String name;
-        private final String value;
-        boolean sensitive;
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
@@ -5,7 +5,6 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import java.io.IOException;
-import java.io.Serial;
 import java.net.URI;
 import java.net.URISyntaxException;
 
@@ -14,7 +13,6 @@ import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ClassicHttpRequest;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.io.support.ClassicRequestBuilder;
-import org.apache.hc.core5.http.message.BasicHeader;
 import org.apache.hc.core5.http.protocol.HttpContext;
 import org.apache.hc.core5.io.CloseMode;
 
@@ -23,6 +21,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessE
 import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
 
 import lombok.AccessLevel;
+import lombok.Data;
 import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
@@ -121,23 +120,11 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         return requestBuilder.build();
     }
 
-    static class HeaderWithEquals extends BasicHeader
+    @Data
+    static class HeaderWithEquals implements org.apache.hc.core5.http.Header
     {
-        @Serial
-        private static final long serialVersionUID = -4835409423484900327L;
-
-        HeaderWithEquals( String name, Object value )
-        {
-            super(name, value);
-        }
-
-        @Override
-        public boolean equals( Object obj )
-        {
-            if( !(obj instanceof BasicHeader other) ) {
-                return false;
-            }
-            return getName().equals(other.getName()) && getValue().equals(other.getValue());
-        }
+        private final String name;
+        private final String value;
+        boolean sensitive;
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Cache.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Cache.java
@@ -94,6 +94,9 @@ class DefaultApacheHttpClient5Cache implements ApacheHttpClient5Cache
         catch( final RuntimeException e ) {
             return Try.failure(new HttpClientInstantiationException(e));
         }
+        if( destination != null && httpClient instanceof ApacheHttpClient5Wrapper ) {
+            return Try.success(((ApacheHttpClient5Wrapper) httpClient).withDestination(destination));
+        }
         return Try.success(httpClient);
     }
 

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
@@ -23,6 +23,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.sap.cloud.sdk.cloudplatform.cache.CacheManager;
+import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Wrapper.HeaderWithEquals;
 import com.sap.cloud.sdk.testutil.TestContext;
 
 class DefaultApacheHttpClient5CacheTest
@@ -394,11 +395,10 @@ class DefaultApacheHttpClient5CacheTest
         final List<org.apache.hc.core5.http.Header> headersRequest2 = new ArrayList<>();
         request1.headerIterator().forEachRemaining(headersRequest1::add);
         request2.headerIterator().forEachRemaining(headersRequest2::add);
-        assertThat(headersRequest1)
-            .containsExactly(new ApacheHttpClient5Wrapper.HeaderWithEquals(header1.getName(), header1.getValue()));
+        assertThat(headersRequest1).containsExactly(new HeaderWithEquals(header1.getName(), header1.getValue()));
         assertThat(headersRequest2)
             .containsExactly(
-                new ApacheHttpClient5Wrapper.HeaderWithEquals(header1.getName(), header1.getValue()),
-                new ApacheHttpClient5Wrapper.HeaderWithEquals(header2.getName(), header2.getValue()));
+                new HeaderWithEquals(header1.getName(), header1.getValue()),
+                new HeaderWithEquals(header2.getName(), header2.getValue()));
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
@@ -18,12 +18,12 @@ import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hc.client5.http.classic.HttpClient;
 import org.apache.hc.client5.http.classic.methods.HttpGet;
 import org.apache.hc.core5.http.ClassicHttpRequest;
+import org.apache.hc.core5.http.message.BasicHeader;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
 import com.sap.cloud.sdk.cloudplatform.cache.CacheManager;
-import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Wrapper.HeaderWithEquals;
 import com.sap.cloud.sdk.testutil.TestContext;
 
 class DefaultApacheHttpClient5CacheTest
@@ -395,10 +395,15 @@ class DefaultApacheHttpClient5CacheTest
         final List<org.apache.hc.core5.http.Header> headersRequest2 = new ArrayList<>();
         request1.headerIterator().forEachRemaining(headersRequest1::add);
         request2.headerIterator().forEachRemaining(headersRequest2::add);
-        assertThat(headersRequest1).containsExactly(new HeaderWithEquals(header1.getName(), header1.getValue()));
+
+        // recursive comparison because BasicHeader doesn't implement equals/hashCode
+        assertThat(headersRequest1)
+            .usingRecursiveFieldByFieldElementComparator()
+            .containsExactly(new BasicHeader(header1.getName(), header1.getValue()));
         assertThat(headersRequest2)
+            .usingRecursiveFieldByFieldElementComparator()
             .containsExactly(
-                new HeaderWithEquals(header1.getName(), header1.getValue()),
-                new HeaderWithEquals(header2.getName(), header2.getValue()));
+                new BasicHeader(header1.getName(), header1.getValue()),
+                new BasicHeader(header2.getName(), header2.getValue()));
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientWrapperTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientWrapperTest.java
@@ -1,0 +1,31 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
+
+class HttpClientWrapperTest
+{
+    @Test
+    void testDestinationWrapping()
+    {
+        final DefaultHttpDestination firstDestination = DefaultHttpDestination.builder("http://foo.com").build();
+        final DefaultHttpDestination secondDestination =
+            DefaultHttpDestination.builder("http://foo.com").headerProviders(c -> List.of()).build();
+        final DefaultHttpDestination thirdDestination = DefaultHttpDestination.builder("http://bar.com").build();
+        final ApacheHttpClient5Wrapper sut =
+            new ApacheHttpClient5Wrapper(mock(CloseableHttpClient.class), firstDestination);
+
+        assertThat(sut.withDestination(firstDestination)).isSameAs(sut);
+        assertThat(sut.withDestination(firstDestination)).isNotSameAs(sut.withDestination(secondDestination));
+
+        assertThatThrownBy(() -> sut.withDestination(thirdDestination)).isInstanceOf(ShouldNotHappenException.class);
+    }
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -27,5 +27,5 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fixed an issue where adding header providers to a destination after it had already been used to obtain an Apache `HttpClient` 5 would not work as expected.
 


### PR DESCRIPTION
## Overview

This PR ports the change done in #218 to the HttpClient 5. Probably, this was just forgotten to do with the original PR.
