### PR TITLE
fix: [Destinations] Allow for Custom Proxy Config in ON_PREMISE Destinations

### DIFF
--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
@@ -22,6 +22,7 @@ import javax.annotation.Nonnull;
 
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 
@@ -313,6 +314,28 @@ class MegacliteServiceBindingDestinationLoaderTest
                 .build();
 
         assertThatThrownBy(() -> sut.getDestination(options)).isInstanceOf(DestinationAccessException.class);
+    }
+
+    @Test
+    @DisplayName( "An already existing proxy configuration should not be overridden." )
+    void testConnectivityWithExistingProxyConfig()
+    {
+        final DefaultHttpDestination destination =
+            DefaultHttpDestination
+                .builder("foo")
+                .proxy(URI.create("http://bar"))
+                .proxyType(ProxyType.ON_PREMISE)
+                .buildInternal();
+
+        final ServiceBindingDestinationOptions options =
+            ServiceBindingDestinationOptions
+                .forService(MegacliteServiceBindingAccessor.CONNECTIVITY_BINDING)
+                .withOption(ProxyOptions.destinationToBeProxied(destination))
+                .build();
+        final HttpDestination result = sut.getDestination(options);
+
+        assertThat(result.getProxyConfiguration()).isNotEmpty();
+        assertThat(result.getProxyConfiguration().get().getUri()).isEqualTo(URI.create("http://bar"));
     }
 
     @Test

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -269,7 +269,7 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
         final String destinationName =
             destinationToBeProxied.get(DestinationProperty.NAME).getOrElse("<unnamed-destination>");
         final DefaultHttpDestination.Builder destinationBuilder =
-            DefaultHttpDestination.fromDestination(destinationToBeProxied).proxy(proxyUrl);
+            DefaultHttpDestination.fromDestination(destinationToBeProxied);
 
         if( oAuth2Options.skipTokenRetrieval() ) {
             log.debug("Skipping OAuth2 token retrieval for proxied destination '{}'.", destinationName);
@@ -293,7 +293,11 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
             destinationBuilder.keyStore(oAuth2Options.getClientKeyStore());
         }
 
-        return destinationBuilder.buildInternal();
+        // don't override the proxy URL if it has been set explicitly/manually already
+        if( destinationToBeProxied.getProxyConfiguration().isDefined() ) {
+            return destinationBuilder.buildInternal();
+        }
+        return destinationBuilder.proxy(proxyUrl).buildInternal();
     }
 
     DestinationHeaderProvider createHeaderProvider(

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoaderTest.java
@@ -26,6 +26,7 @@ import java.util.function.Predicate;
 import org.apache.http.HttpHeaders;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.InOrder;
 import org.mockito.Mockito;
@@ -402,6 +403,31 @@ class OAuth2ServiceBindingDestinationLoaderTest
                 eq(HttpHeaders.PROXY_AUTHORIZATION),
                 eq(OAuth2Options.DEFAULT),
                 eq(TEST_SERVICE));
+    }
+
+    @Test
+    @DisplayName( "An already existing proxy configuration should not be overridden." )
+    void testConnectivityWithExistingProxyConfig()
+    {
+        final DefaultHttpDestination destination =
+            DefaultHttpDestination
+                .builder("foo")
+                .proxy(URI.create("http://bar"))
+                .proxyType(ProxyType.ON_PREMISE)
+                .buildInternal();
+        final HttpDestination result =
+            sut
+                .toProxiedDestination(
+                    destination,
+                    URI.create("yolo"),
+                    URI.create("foo"),
+                    credentials,
+                    OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT,
+                    OAuth2Options.DEFAULT,
+                    TEST_SERVICE);
+
+        assertThat(result.getProxyConfiguration()).isNotEmpty();
+        assertThat(result.getProxyConfiguration().get().getUri()).isEqualTo(URI.create("http://bar"));
     }
 
     @Test

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,6 +16,7 @@
 
 ### 📈 Improvements
 
+- Improve the `DefaultHttpDestination` builder API: For destinations with proxy type `ON_PREMISE` the proxy URL can now be customized by using the `proxy` method of the builder.
 - Dependency Updates:
   - SAP dependency updates:
     - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`


### PR DESCRIPTION
## Context

Previously, any invocation to `proxy(..)` on `DefaultHttpDestination.Builder` was meaningless, if the destination has the proxy type `ON_PREMISE, because the value would be overriden when adding the on-prem logic.

This change is handy for local testing (where you need to set the proxy URL to localhost) or any scenario where a non-default connectivity proxy config is used.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated
