### PR TITLE
chore: Deprecate `RfcDestination` and associated usages

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultRfcDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultRfcDestination.java
@@ -13,7 +13,10 @@ import lombok.experimental.Delegate;
 
 /**
  * Immutable default implementation of the {@link RfcDestination} interface.
+ *
+ * @deprecated Please use {@link DefaultDestination} instead.
  */
+@Deprecated
 @EqualsAndHashCode
 @RequiredArgsConstructor( access = AccessLevel.PRIVATE )
 public final class DefaultRfcDestination implements RfcDestination

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/Destination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/Destination.java
@@ -47,7 +47,10 @@ public interface Destination extends DestinationProperties
      *
      * @throws IllegalArgumentException
      *             if this object cannot be converted as a {@code RfcDestination}.
+     *
+     * @deprecated Please use {@link #asHttp()} instead.
      */
+    @Deprecated
     @Nonnull
     default RfcDestination asRfc()
         throws IllegalArgumentException
@@ -63,6 +66,7 @@ public interface Destination extends DestinationProperties
      *
      * @return {@code true}, if a call to {@link #asRfc()} will succeed; {@code false} otherwise.
      */
+    @Deprecated
     default boolean isRfc()
     {
         return this instanceof RfcDestination || DefaultRfcDestination.canBeConstructedFrom(this);

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/Destination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/Destination.java
@@ -48,7 +48,7 @@ public interface Destination extends DestinationProperties
      * @throws IllegalArgumentException
      *             if this object cannot be converted as a {@code RfcDestination}.
      *
-     * @deprecated Please use {@link #asHttp()} instead.
+     * @deprecated Please use the {@link Destination} as is by removing the {@code asRfc()} conversion.
      */
     @Deprecated
     @Nonnull

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/EnvVarDestinationLoader.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/EnvVarDestinationLoader.java
@@ -179,6 +179,7 @@ public class EnvVarDestinationLoader implements DestinationLoader
                 + ".");
     }
 
+    @SuppressWarnings( "deprecation" )
     private Destination parseDestination( final JsonNode destinationNode )
     {
         final HashMap<String, String> map = new HashMap<>();

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/RfcDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/RfcDestination.java
@@ -8,7 +8,10 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
  * Platform independent representation of a rfc destination as a collection of key-value pairs.
  * <p>
  * Additionally, provides an easy way to decorate itself with a given decorator function.
+ *
+ * @deprecated Please use {@link Destination} instead.
  */
+@Deprecated
 public interface RfcDestination extends Destination, RfcDestinationProperties
 {
 

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/RfcDestinationProperties.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/RfcDestinationProperties.java
@@ -6,7 +6,10 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 /**
  * Adds RFC relevant fields to the "generic" destination.
+ *
+ * @deprecated Please use {@link DefaultDestination} instead.
  */
+@Deprecated
 public interface RfcDestinationProperties extends DestinationProperties
 {
 

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/CustomDestinationRegistrationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/CustomDestinationRegistrationTest.java
@@ -18,6 +18,7 @@ class CustomDestinationRegistrationTest
     private static final HttpDestination httpDestination =
         DefaultHttpDestination.builder("foo").name("httpDestination").build();
 
+    @SuppressWarnings("deprecation")
     private static final RfcDestination rfcDestination =
         DefaultDestination.builder().name("rfcDestination").build().asRfc();
 
@@ -27,6 +28,7 @@ class CustomDestinationRegistrationTest
         DestinationAccessor.setLoader(null);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testBasicUseCase()
     {

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/CustomDestinationRegistrationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/CustomDestinationRegistrationTest.java
@@ -18,7 +18,7 @@ class CustomDestinationRegistrationTest
     private static final HttpDestination httpDestination =
         DefaultHttpDestination.builder("foo").name("httpDestination").build();
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings( "deprecation" )
     private static final RfcDestination rfcDestination =
         DefaultDestination.builder().name("rfcDestination").build().asRfc();
 
@@ -28,7 +28,7 @@ class CustomDestinationRegistrationTest
         DestinationAccessor.setLoader(null);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings( "deprecation" )
     @Test
     void testBasicUseCase()
     {

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
@@ -125,6 +125,7 @@ class DefaultDestinationTest
         assertThat(httpDestination).isInstanceOf(DefaultHttpDestination.class);
     }
 
+    @Deprecated
     @Test
     void testRfcConverter()
     {

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
@@ -7,8 +7,9 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.net.URI;
-import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
 import org.junit.jupiter.api.Test;
 
@@ -25,6 +26,7 @@ class DefaultDestinationTest
         assertThat(destination.get(someKey)).contains(someValue);
     }
 
+    @SuppressWarnings("deprecation")
     @Test
     void testIdentity()
     {
@@ -55,8 +57,8 @@ class DefaultDestinationTest
         final String someKey = "someKey";
         final String someValue = "someValue";
         final DestinationProperties destination = DefaultDestination.builder().property(someKey, someValue).build();
-        Iterable<String> propertiesKeysResult = destination.getPropertyNames();
-        Iterable<String> expectedKeys = Arrays.asList(someKey);
+        final Iterable<String> propertiesKeysResult = destination.getPropertyNames();
+        final Iterable<String> expectedKeys = List.of(someKey);
         assertThat(propertiesKeysResult).containsAll(expectedKeys);
     }
 
@@ -82,7 +84,7 @@ class DefaultDestinationTest
         final String someKey = "someKey";
         final String originalValue = "someValue";
 
-        final HashMap<String, Object> properties = new HashMap<>();
+        final Map<String, Object> properties = new HashMap<>();
         properties.put(someKey, originalValue);
 
         final DestinationProperties destination = DefaultDestination.fromMap(properties).build();

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultDestinationTest.java
@@ -26,7 +26,7 @@ class DefaultDestinationTest
         assertThat(destination.get(someKey)).contains(someValue);
     }
 
-    @SuppressWarnings("deprecation")
+    @SuppressWarnings( "deprecation" )
     @Test
     void testIdentity()
     {

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultRfcDestinationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultRfcDestinationTest.java
@@ -8,6 +8,7 @@ import org.assertj.core.api.Assertions;
 import org.assertj.vavr.api.VavrAssertions;
 import org.junit.jupiter.api.Test;
 
+@Deprecated
 class DefaultRfcDestinationTest
 {
     private static final String SOME_NAME = "Some Destination Name";

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactory.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactory.java
@@ -83,6 +83,7 @@ class DestinationServiceFactory
         }
     }
 
+    @Deprecated
     private static Destination handleRfcDestination( final DestinationProperties baseProperties )
     {
         return DefaultRfcDestination.fromProperties(baseProperties);

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceFactoryTest.java
@@ -68,6 +68,7 @@ class DestinationServiceFactoryTest
         assertThat(result.get("foo")).contains("bar");
     }
 
+    @Deprecated
     @Test
     void testRfcDestination()
     {

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -722,6 +722,7 @@ class DestinationServiceTest
         verify(scpCfDestinationServiceAdapter, times(0)).getConfigurationAsJsonWithUserToken(any(), any());
     }
 
+    @SuppressWarnings( "deprecation" )
     @Test
     void testEmailDestination()
     {

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,7 @@
 
 ### 🔧 Compatibility Notes
 
-- Deprecated `RfcDestination` and all associated usages. The replacement is `DefaultDestination`.
+- Deprecated `RfcDestination` and all associated usages. The replacement is `Destination`.
 
 ### ✨ New Functionality
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,7 @@
 
 ### 🔧 Compatibility Notes
 
-- 
+- Deprecated `RfcDestination` and all associated usages. The replacement is `DefaultDestination`.
 
 ### ✨ New Functionality
 


### PR DESCRIPTION
## Summary

Closes SAP/cloud-sdk-java-backlog#315

## Changes

- Deprecated the `RfcDestination` interface and all associated usages. The replacement is `Destination`.

## Instructions for Reviewers

Please review the changes and ensure that all deprecated usages have been correctly marked and that the replacements are correctly suggested.