### PR TITLE
feat: Remove dependency updates section from release notes and automation script

### DIFF
--- a/.pipeline/scripts/release_notes_automation.py
+++ b/.pipeline/scripts/release_notes_automation.py
@@ -31,20 +31,12 @@ unchanged_sections = [
 """,
 """### 📈 Improvements
 
-- Dependency Updates:
-  - SAP dependency updates:
-    - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-  - Other dependency updates:
-    - Major version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-    - Minor version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
+- 
 
 """,
 """### 🐛 Fixed Issues
 
 - 
-
 """]
 
 def remove_unchanged_sections(file, unchanged_sections):
@@ -66,25 +58,6 @@ def link_github_release(file, version):
     return file
 
 
-def clean_up_dependency_updates(file):
-    empty_dependency_update = "- Update \[thing\]\(https://link-to-thing\) from `a.b.c` to `x.z.y`\n"
-    sap_dependency_update = "  - SAP dependency updates:\n    "+empty_dependency_update
-    major_dependency_update = "    - Major version updates:\n      "+empty_dependency_update
-    minor_dependency_update = "    - Minor version updates:\n      "+empty_dependency_update
-    other_dependency_update = "  - Other dependency updates:\n    "+major_dependency_update+"\n"+minor_dependency_update
-
-    # Dependency Updates cannot be ALL empty since we already removed the entire empty section in remove_unchanged_sections()
-    # First we remove the biggest strings, then the smaller ones
-
-    # 2 biggest strings
-    file = re.sub(sap_dependency_update, "", file)
-    file = re.sub(other_dependency_update, "", file)
-    # smaller strings
-    file = re.sub(major_dependency_update, "", file)
-    file = re.sub(minor_dependency_update, "", file)
-    # smallest leftovers
-    file = re.sub(empty_dependency_update, "", file)
-    return file
 
 releases_pattern = re.compile(r"^## ")
 def count_releases(filename):
@@ -126,7 +99,6 @@ if __name__ == '__main__':
     file = remove_unchanged_sections(file, unchanged_sections)
     file = set_header(file, args.version)
     file = link_github_release(file, args.version)
-    file = clean_up_dependency_updates(file)
 
     target_file = find_target_file(args.version)
     write_release_notes(args.folder, target_file)

--- a/.pipeline/scripts/release_notes_template.md
+++ b/.pipeline/scripts/release_notes_template.md
@@ -16,16 +16,8 @@
 
 ### 📈 Improvements
 
-- Dependency Updates:
-  - SAP dependency updates:
-    - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-  - Other dependency updates:
-    - Major version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-    - Minor version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
+- 
 
 ### 🐛 Fixed Issues
 
 - 
-

--- a/docs/how-to/release.md
+++ b/docs/how-to/release.md
@@ -1,6 +1,6 @@
 # Release the SAP Cloud SDK for Java to Maven Central
 
-- In GitHub, go to the [Prepare Release](https://github.com/SAP/cloud-sdk-java/actions/workflows/prepare_release.yml) Workflow.
+- In GitHub, go to the [Prepare Release](https://github.com/SAP/cloud-sdk-java/actions/workflows/prepare-release.yaml) Workflow.
 - Click **Run workflow** drop-down.
 - Optional: Enter the desired version in the **Release version** field. If not provided, the current snapshot version will be used.
 - Optional: Enter the branch name to release from. By default, this is our `main` branch.
@@ -10,7 +10,7 @@ Additionally, the workflow will create a few PRs:
 
 1. One to update our JavaDocs in [the Documentation Repository](https://github.com/sap/cloud-sdk)
 2. Another one to update our release notes, also in [the Documentation Repository](https://github.com/sap/cloud-sdk)
-    * **Note** As we are splitting our release notes every 15 minor versions, some manual adjustment might be needed
+    * **Note** As we are splitting our release notes every 15 minor versions, some manual adjustment might be needed to both `index.jsx` and `release-notes.mdx`
 3. A third one for the actual changes in [the Code Repository](https://github.com/sap/cloud-sdk-java)
 
 Lastly, the workflow also creates a new draft release and an according tag.
@@ -21,7 +21,7 @@ All of these things will be linked in the Code PR, so that they can be found eas
 As the second to last step, you will trigger the [Perform Release Workflow](https://github.com/SAP/cloud-sdk-java/actions/workflows/perform-release.yml).
 
 This workflow will take care of merging the PRs and creates a **staging release** in [Sonatype](https://oss.sonatype.org/).
-As the very last step, once the _Perform Release_ workflow has finished successfully, you need to log into _Sonatype_ and publish the staging release.
+As the very last step, once the _Perform Release_ workflow has finished successfully, you need to log into _Sonatype_ and publish the staging release using the `Technical User for Releases` account.
 
 That's it!
 The new version should be available for consumers within a few hours.

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,16 +16,8 @@
 
 ### 📈 Improvements
 
-- Dependency Updates:
-  - SAP dependency updates:
-    - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-  - Other dependency updates:
-    - Major version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
-    - Minor version updates:
-      - Update [thing](https://link-to-thing) from `a.b.c` to `x.z.y`
+- 
 
 ### 🐛 Fixed Issues
 
 - 
-


### PR DESCRIPTION
## Overview

This pull request includes changes to the release notes automation script, release notes template, release documentation, and the release notes themselves. The primary change is the removal of the dependency updates section from the release notes and the associated cleanup function from the automation script.

## Changes

1. **.pipeline/scripts/release_notes_automation.py**: Removed the `clean_up_dependency_updates` function which was responsible for removing empty dependency update sections from the release notes. This function is no longer needed as the dependency updates section has been removed from the release notes template.

2. **.pipeline/scripts/release_notes_template.md**: Removed the dependency updates section from the release notes template. This section was previously used to list updates to dependencies, but it has been decided that this information is no longer needed in the release notes.

3. **docs/how-to/release.md**: Updated the release documentation to reflect the changes to the release notes and the release notes automation script. Also, corrected the link to the Prepare Release workflow and added a note about the need for manual adjustment to `index.jsx` and `release-notes.mdx` when splitting release notes.

4. **release_notes.md**: Removed the dependency updates section from the release notes. This section was previously used to list updates to dependencies, but it has been decided that this information is no longer needed in the release notes.

## Reviewer Instructions

Please review the changes to ensure that the removal of the dependency updates section from the release notes and the associated cleanup function from the automation script have been correctly implemented. Also, please check the updated release documentation for accuracy.