### PR TITLE
fix: DwC Auth Token not available

### DIFF
--- a/cloudplatform/connectivity-dwc/pom.xml
+++ b/cloudplatform/connectivity-dwc/pom.xml
@@ -70,6 +70,10 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>com.auth0</groupId>
+			<artifactId>java-jwt</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.slf4j</groupId>
 			<artifactId>jcl-over-slf4j</artifactId>
 			<scope>runtime</scope>

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -35,6 +35,9 @@ public class DwcHeaderUtils
      * The name of the header that contains the Deploy with Confidence scopes information.
      */
     public static final String DWC_SUBDOMAIN_HEADER = "dwc-subdomain";
+    /**
+     * The name of the header that contains the Deploy with Confidence JWT token.
+     */
     public static final String DWC_JWT_HEADER = "dwc-jwt";
 
     /**

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -96,9 +96,10 @@ public class DwcHeaderUtils
      * @return The value of the {@link #DWC_JWT_HEADER} header.
      * @throws DwcHeaderNotFoundException
      *             if the header was not found.
+     * @since 5.6.0
      */
     @Nonnull
-    public static String getDwcTokenOrThrow()
+    public static String getDwcJwtOrThrow()
     {
         return getNonEmptyDwcHeaderValue(DWC_JWT_HEADER);
     }

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -35,6 +35,7 @@ public class DwcHeaderUtils
      * The name of the header that contains the Deploy with Confidence scopes information.
      */
     public static final String DWC_SUBDOMAIN_HEADER = "dwc-subdomain";
+    public static final String DWC_JWT_HEADER = "dwc-jwt";
 
     /**
      * This method fetches the value of the {@link #DWC_TENANT_HEADER} header or throws an
@@ -83,6 +84,20 @@ public class DwcHeaderUtils
             throw new DwcHeaderNotFoundException("Header value of " + DWC_USER_HEADER + " has no logon name.");
         }
         return logonName;
+    }
+
+    /**
+     * This method fetches the value of the {@link #DWC_JWT_HEADER} header or throws an
+     * {@link DwcHeaderNotFoundException} if the header was not found.
+     *
+     * @return The value of the {@link #DWC_JWT_HEADER} header.
+     * @throws DwcHeaderNotFoundException
+     *             if the header was not found.
+     */
+    @Nonnull
+    public static String getDwcTokenOrThrow()
+    {
+        return getNonEmptyDwcHeaderValue(DWC_JWT_HEADER);
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
@@ -1,0 +1,41 @@
+package com.sap.cloud.sdk.cloudplatform.security;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.auth0.jwt.JWT;
+import com.sap.cloud.sdk.cloudplatform.DwcHeaderUtils;
+import com.sap.cloud.sdk.cloudplatform.security.exception.AuthTokenAccessException;
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContext;
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextAccessor;
+
+import io.vavr.control.Try;
+
+public class DwcAuthTokenFacade extends DefaultAuthTokenFacade
+{
+    private static final String AUTH_TOKEN = AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN;
+
+    @Nonnull
+    @Override
+    public Try<AuthToken> tryGetCurrentToken()
+    {
+        @Nullable
+        final ThreadContext currentContext = ThreadContextAccessor.getCurrentContextOrNull();
+        if( currentContext != null && currentContext.containsProperty(AUTH_TOKEN) ) {
+            return currentContext.getPropertyValue(AUTH_TOKEN);
+        }
+        return Try.of(DwcAuthTokenFacade::extractAuthTokenFromDwcHeaders);
+    }
+
+    @Nonnull
+    private static AuthToken extractAuthTokenFromDwcHeaders()
+    {
+        try {
+            final String token = DwcHeaderUtils.getDwcTokenOrThrow();
+            return new AuthToken(JWT.decode(token));
+        }
+        catch( final Exception e ) {
+            throw new AuthTokenAccessException("Failed to extract auth token from DwC headers.", e);
+        }
+    }
+}

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
@@ -13,8 +13,9 @@ import io.vavr.control.Try;
 
 /**
  * Auth token facade for Deploy with Confidence (DwC) environment.
-  * @since 5.6.0
-  */
+ *
+ * @since 5.6.0
+ */
 public class DwcAuthTokenFacade extends DefaultAuthTokenFacade
 {
     private static final String AUTH_TOKEN = AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN;
@@ -35,7 +36,7 @@ public class DwcAuthTokenFacade extends DefaultAuthTokenFacade
     private static AuthToken extractAuthTokenFromDwcHeaders()
     {
         try {
-            final String token = DwcHeaderUtils.getDwcTokenOrThrow();
+            final String token = DwcHeaderUtils.getDwcJwtOrThrow();
             return new AuthToken(JWT.decode(token));
         }
         catch( final Exception e ) {

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
@@ -11,6 +11,9 @@ import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextAccessor;
 
 import io.vavr.control.Try;
 
+/**
+ * Auth token facade for Deploy with Confidence (DwC) environment.
+ */
 public class DwcAuthTokenFacade extends DefaultAuthTokenFacade
 {
     private static final String AUTH_TOKEN = AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN;

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacade.java
@@ -13,7 +13,8 @@ import io.vavr.control.Try;
 
 /**
  * Auth token facade for Deploy with Confidence (DwC) environment.
- */
+  * @since 5.6.0
+  */
 public class DwcAuthTokenFacade extends DefaultAuthTokenFacade
 {
     private static final String AUTH_TOKEN = AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN;

--- a/cloudplatform/connectivity-dwc/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.AuthTokenFacade
+++ b/cloudplatform/connectivity-dwc/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.AuthTokenFacade
@@ -1,0 +1,1 @@
+com.sap.cloud.sdk.cloudplatform.security.DwcAuthTokenFacade

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
@@ -1,0 +1,63 @@
+package com.sap.cloud.sdk.cloudplatform.security;
+
+import static com.sap.cloud.sdk.cloudplatform.DwcHeaderUtils.DWC_JWT_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.auth0.jwt.JWT;
+import com.auth0.jwt.algorithms.Algorithm;
+import com.google.common.collect.ImmutableMap;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderContainer;
+import com.sap.cloud.sdk.cloudplatform.security.exception.AuthTokenAccessException;
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContext;
+import com.sap.cloud.sdk.cloudplatform.thread.ThreadContextAccessor;
+
+import io.vavr.control.Try;
+
+class DwcAuthTokenFacadeTest
+{
+    @Test
+    void testFacadeIsPickedUpAutomatically()
+    {
+        assertThat(AuthTokenAccessor.getAuthTokenFacade()).isInstanceOf(DwcAuthTokenFacade.class);
+    }
+
+    @Test
+    void testSuccessfulAuthTokenRetrieval()
+    {
+        final String token = JWT.create().sign(Algorithm.none());
+
+        final AuthToken expectedToken = new AuthToken(JWT.decode(token));
+        final Map<String, String> headers = ImmutableMap.of(DWC_JWT_HEADER, token);
+
+        RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> {
+            final ThreadContext currentContext = ThreadContextAccessor.getCurrentContext();
+            final AuthToken currentToken = AuthTokenAccessor.getCurrentToken();
+            final Try<AuthToken> maybeTokenFromContext =
+                currentContext.getPropertyValue(AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN);
+
+            assertThat(currentToken).isEqualTo(expectedToken);
+            assertThat(maybeTokenFromContext).contains(expectedToken);
+        });
+    }
+
+    @Test
+    void testUnsuccessfulAuthTokenRetrieval()
+    {
+        RequestHeaderAccessor.executeWithHeaderContainer(RequestHeaderContainer.EMPTY, () -> {
+            final ThreadContext currentContext = ThreadContextAccessor.getCurrentContext();
+            final Try<AuthToken> authTokenFailure = AuthTokenAccessor.tryGetCurrentToken();
+            final Try<AuthToken> shouldBeFailure =
+                currentContext.getPropertyValue(AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN);
+
+            assertThat(authTokenFailure.isFailure()).isTrue();
+            assertThat(authTokenFailure.getCause()).isInstanceOf(AuthTokenAccessException.class);
+            assertThat(shouldBeFailure.isFailure()).isTrue();
+            assertThat(authTokenFailure).isSameAs(shouldBeFailure);
+        });
+    }
+}

--- a/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.AuthTokenFacade
+++ b/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.AuthTokenFacade
@@ -1,1 +1,0 @@
-com.sap.cloud.sdk.cloudplatform.security.DefaultAuthTokenFacade

--- a/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.secret.SecretStoreFacade
+++ b/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.secret.SecretStoreFacade
@@ -1,1 +1,0 @@
-com.sap.cloud.sdk.cloudplatform.security.secret.ScpCfSecretStoreFacade

--- a/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.user.UserFacade
+++ b/cloudplatform/security/src/main/resources/META-INF/services/com.sap.cloud.sdk.cloudplatform.security.user.UserFacade
@@ -1,1 +1,0 @@
-com.sap.cloud.sdk.cloudplatform.security.user.ScpCfPrincipalFacade

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fix an issue where the `AuthTokenAccessor` would not recognise JWT tokens passed in via the `dwc-jwt` header.


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#424.

I think we just forgot to implement this earlier. This change makes our `AuthTokenAccessor` actually return a token in the DwC case. Without this change, one always gets an exception (unless using CAP).

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

