### PR TITLE
Add implementation reference to interface parameter declaration in JavaDoc

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2DestinationBuilder.java
@@ -61,6 +61,8 @@ public class OAuth2DestinationBuilder
          * @param behalf
          *            The OAuth2 token representative.
          * @return The same builder instance.
+         * @see com.sap.cloud.security.config.ClientCertificate
+         * @see com.sap.cloud.security.config.ClientCredentials
          * @since 4.10.0
          */
         @Nonnull


### PR DESCRIPTION
Related
https://github.com/orgs/SAP/projects/62/views/5?pane=issue&itemId=55522157

Not sure whether this brings any benefit. But the user was unable to locate the implementation classes by themselves.