### PR TITLE
[Draft] [OData] Expose Content-Id of failing changeset response

### DIFF
--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/exception/ODataResponseException.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/exception/ODataResponseException.java
@@ -51,6 +51,42 @@ public class ODataResponseException extends ODataException
     @Nonnull
     private final Option<String> httpBody;
 
+    @Getter
+    @Nonnull
+    private final Option<Integer> contentId;
+
+    /**
+     * Default constructor.
+     *
+     * @param request
+     *            The original OData request reference.
+     * @param httpResponse
+     *            The {@link HttpResponse} that gave raise to this exception.
+     * @param message
+     *            The error message.
+     * @param cause
+     *            The error cause.
+     * @param causeRequestContentId
+     *            The error causing request content-id.
+     */
+    public ODataResponseException(
+        @Nonnull final ODataRequestGeneric request,
+        @Nonnull final HttpResponse httpResponse,
+        @Nonnull final String message,
+        @Nullable final Throwable cause,
+        @Nullable final Integer causeRequestContentId )
+    {
+        super(request, message, cause);
+        httpCode = httpResponse.getStatusLine().getStatusCode();
+        httpHeaders = Arrays.asList(httpResponse.getAllHeaders());
+        contentId = Option.of(causeRequestContentId);
+        httpBody =
+            Try
+                .of(() -> EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8))
+                .onFailure(this::addSuppressed)
+                .toOption();
+    }
+
     /**
      * Default constructor.
      *
@@ -69,13 +105,6 @@ public class ODataResponseException extends ODataException
         @Nonnull final String message,
         @Nullable final Throwable cause )
     {
-        super(request, message, cause);
-        httpCode = httpResponse.getStatusLine().getStatusCode();
-        httpHeaders = Arrays.asList(httpResponse.getAllHeaders());
-        httpBody =
-            Try
-                .of(() -> EntityUtils.toString(httpResponse.getEntity(), StandardCharsets.UTF_8))
-                .onFailure(this::addSuppressed)
-                .toOption();
+        this(request, httpResponse, message, cause, null);
     }
 }

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/MultipartParser.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/MultipartParser.java
@@ -32,6 +32,7 @@ import org.apache.http.entity.ContentType;
 import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.RequiredArgsConstructor;
+import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -40,7 +41,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @Slf4j
 @RequiredArgsConstructor( access = AccessLevel.PACKAGE )
-class MultipartParser
+class MultipartParser implements AutoCloseable
 {
     private static final Charset DEFAULT_CHARSET = StandardCharsets.UTF_8;
     private static final String MULTIPART_MIXED_MIME_TYPE = "multipart/mixed";
@@ -59,6 +60,7 @@ class MultipartParser
      *            The HTTP response to read from: content-type, input-stream and charset.
      * @return A new instance of {@link MultipartParser}.
      */
+    @SuppressWarnings( "PMD.CloseResource" ) // The attached InputStream is closed by the MultipartParser itself.
     public static MultipartParser ofHttpResponse( @Nonnull final HttpResponse httpResponse )
     {
         final HttpEntity entity = httpResponse.getEntity();
@@ -121,7 +123,7 @@ class MultipartParser
      * @return An iterable multi-part response.
      */
     @Nonnull
-    public List<List<String>> toList()
+    public List<List<Entry>> toList()
     {
         return toList(Function.identity());
     }
@@ -139,7 +141,7 @@ class MultipartParser
      * @return An iterable multi-part response, with custom deserialization.
      */
     @Nonnull
-    public <T> List<List<T>> toList( @Nonnull final Function<String, T> transformation )
+    public <T> List<List<T>> toList( @Nonnull final Function<Entry, T> transformation )
     {
         return toStream()
             .map(segments -> segments.map(transformation).collect(Collectors.toList()))
@@ -154,14 +156,14 @@ class MultipartParser
      * @return An iterable multi-part response.
      */
     @Nonnull
-    public Stream<Stream<String>> toStream()
+    public Stream<Stream<Entry>> toStream()
     {
         // Create a stream from a spliterator but only retrieve the spliterator upon terminal operation of stream.
-        final Stream<Spliterator<String>> result =
+        final Stream<Spliterator<Entry>> result =
             StreamSupport.stream(this::createSpliterator, MultipartSpliterator.CHARACTERISTICS, false);
 
         // Translate stream of spliterators to stream of stream. Make sure all previous spliterators were fully consumed.
-        final AtomicReference<Spliterator<String>> previous = new AtomicReference<>(Spliterators.emptySpliterator());
+        final AtomicReference<Spliterator<Entry>> previous = new AtomicReference<>(Spliterators.emptySpliterator());
 
         return result.map(currentSpliterator -> {
             // if previous spliterator was not yet fully consumed, do so with the remaining elements
@@ -172,7 +174,7 @@ class MultipartParser
         });
     }
 
-    private Spliterator<Spliterator<String>> createSpliterator()
+    private Spliterator<Spliterator<Entry>> createSpliterator() // Response
     {
         final MultipartParserReader batchRead = new MultipartParserReader(reader, delimiter);
 
@@ -191,14 +193,14 @@ class MultipartParser
                 return getChangeset(maybeChangesetBoundary.get(), batchRead);
             } else { // single response
                 final String content = batchRead.untilDelimiter();
-                return Collections.singleton(content).spliterator();
+                return Collections.singleton(new Entry(segmentHead, content)).spliterator();
             }
         });
     }
 
     @Nonnull
     private
-        Spliterator<String>
+        Spliterator<Entry>
         getChangeset( @Nonnull final String changesetDelimiter, final MultipartParserReader batchRead )
     {
         final MultipartParserReader changesetRead = new MultipartParserReader(reader, changesetDelimiter);
@@ -217,7 +219,7 @@ class MultipartParser
             if( changesetRead.isFinished() ) {
                 batchRead.untilDelimiter(); // position reader to next batch delimiter
             }
-            return content;
+            return new Entry(subSegmentHead, content);
         });
     }
 
@@ -248,5 +250,18 @@ class MultipartParser
             log.debug("Unexpected value in HTTP header \"Content-Type\" of OData batch response: {}", contentType);
         }
         return getDelimiterFromContentType(contentType);
+    }
+
+    @Override
+    public void close()
+    {
+        Try.run(reader::close).onFailure(e -> log.warn("Failed to close HTTP entity multi-part parser.", e));
+    }
+
+    @Value
+    static class Entry
+    {
+        String meta;
+        String payload;
     }
 }

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataHealthyResponseValidator.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataHealthyResponseValidator.java
@@ -48,9 +48,14 @@ class ODataHealthyResponseValidator
             return;
         }
 
+        final Integer contentId =
+            httpResponse instanceof MultipartHttpResponse
+                ? ((MultipartHttpResponse) httpResponse).getContentId()
+                : null;
         final Integer statusCode = statusLine == null ? null : statusLine.getStatusCode();
         final String msg = "The HTTP response code (" + statusCode + ") indicates an error.";
-        final ODataResponseException preparedException = new ODataResponseException(request, httpResponse, msg, null);
+        final ODataResponseException preparedException =
+            new ODataResponseException(request, httpResponse, msg, null, contentId);
 
         final Try<ODataServiceError> odataError = Try.of(() -> loadErrorFromResponse(result));
         if( odataError.isSuccess() ) {

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -122,7 +122,7 @@ public class ODataRequestResultMultipartGeneric
         }
 
         final ODataRequestResultGeneric result = new ODataRequestResultGeneric(request, response);
-        result.disableBufferingHttpResponse(); // the HttpResponse is already evaluated
+        result.disableBufferingHttpResponse(); // the artificial HttpResponse is static, no buffer required
         ODataHealthyResponseValidator.requireHealthyResponse(result);
         return result;
     }

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -111,6 +111,7 @@ public class ODataRequestResultMultipartGeneric implements ODataRequestResultMul
         }
 
         final ODataRequestResultGeneric result = new ODataRequestResultGeneric(request, response);
+        result.disableBufferingHttpResponse(); // the HttpResponse is already evaluated
         ODataHealthyResponseValidator.requireHealthyResponse(result);
         return result;
     }

--- a/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/MultipartParserTest.java
+++ b/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/MultipartParserTest.java
@@ -2,6 +2,7 @@ package com.sap.cloud.sdk.datamodel.odata.client.request;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import static com.sap.cloud.sdk.datamodel.odata.client.request.MultipartParser.Entry;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.mock;
@@ -60,12 +61,12 @@ class MultipartParserTest
         final String delimiter = "--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef";
 
         // user code
-        final List<List<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
+        final List<List<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
         final MultipartHttpResponse httpResponse = MultipartHttpResponse.ofHttpContent(result.get(0).get(0));
 
         assertThat(result).hasSize(1);
         assertThat(result.get(0)).hasSize(1);
-        assertThat(result.get(0).get(0)).startsWith("HTTP/1.1 200 OK");
+        assertThat(result.get(0).get(0).getPayload()).startsWith("HTTP/1.1 200 OK");
 
         assertThat(httpResponse.getAllHeaders()).satisfiesExactly(header -> {
             assertThat(header.getName()).isEqualTo("Content-Type");
@@ -93,7 +94,7 @@ class MultipartParserTest
         final String delimiter = "--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef";
 
         // user code
-        final List<List<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
+        final List<List<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
         assertThat(result).isEmpty();
     }
 
@@ -106,7 +107,7 @@ class MultipartParserTest
         final String delimiter = "--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef";
 
         // user code
-        final List<List<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
+        final List<List<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
         assertThat(result).isEmpty();
     }
 
@@ -120,7 +121,7 @@ class MultipartParserTest
         final String delimiter = "--some-delimiter";
 
         // user code
-        final List<List<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
+        final List<List<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
         assertThat(result).isEmpty();
     }
 
@@ -134,7 +135,7 @@ class MultipartParserTest
         final String delimiter = "--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef";
 
         // user code
-        final List<List<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
+        final List<List<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toList();
         assertThat(result).isEmpty();
     }
 
@@ -184,7 +185,7 @@ class MultipartParserTest
         final String delimiter = "--batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef";
 
         // user code
-        final Stream<Stream<String>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toStream();
+        final Stream<Stream<Entry>> result = MultipartParser.ofInputStream(response, UTF_8, delimiter).toStream();
 
         // assert behavior
         assertThat(result.count()).isEqualTo(2); // first access successful
@@ -204,7 +205,7 @@ class MultipartParserTest
         resp.setHeader("Content-Type", "multipart/mixed; boundary=batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef");
 
         // user code
-        final Stream<Stream<String>> result = MultipartParser.ofHttpResponse(resp).toStream();
+        final Stream<Stream<Entry>> result = MultipartParser.ofHttpResponse(resp).toStream();
 
         // assert behavior
         assertThat(result.count()).isEqualTo(2); // first access successful
@@ -224,13 +225,13 @@ class MultipartParserTest
         resp.setHeader("Content-Type", "multipart/mixed; boundary=batchresponse_76ef6b0a-a0e2-4f31-9f70-f5d3f73a6bef");
 
         // user code
-        final List<List<String>> result = MultipartParser.ofHttpResponse(resp).toList();
+        final List<List<Entry>> result = MultipartParser.ofHttpResponse(resp).toList();
 
         // assert behavior
         assertThat(result).isNotEmpty();
 
-        for( final List<String> segments : result ) {
-            for( final String segment : segments ) {
+        for( final List<Entry> segments : result ) {
+            for( final Entry segment : segments ) {
                 // ignore
             }
         }
@@ -240,10 +241,10 @@ class MultipartParserTest
             .satisfiesExactly(
                 segments1 -> assertThat(segments1)
                     .satisfiesExactly(
-                        payload1 -> assertThat(payload1).contains("HTTP/1.1 201 Created"),
-                        payload2 -> assertThat(payload2).contains("HTTP/1.1 201 Created")),
+                        entry1 -> assertThat(entry1.getPayload()).contains("HTTP/1.1 201 Created"),
+                        entry2 -> assertThat(entry2.getPayload()).contains("HTTP/1.1 201 Created")),
                 segments2 -> assertThat(segments2)
-                    .satisfiesExactly(payload1 -> assertThat(payload1).contains("HTTP/1.1 404 Not Found")));
+                    .satisfiesExactly(entry1 -> assertThat(entry1.getPayload()).contains("HTTP/1.1 404 Not Found")));
     }
 
     @SneakyThrows

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/referenceservice/ODataClientBatchResponseParsingUnitTest.java
@@ -267,6 +267,7 @@ class ODataClientBatchResponseParsingUnitTest
             .satisfies(e -> {
                 assertThat(e.getHttpCode()).isEqualTo(400);
                 assertThat(e.getHttpBody().get()).contains("The FirstName field is required");
+                assertThat(e.getContentId()).containsExactly(2);
             });
 
         assertThatExceptionOfType(ODataResponseException.class)
@@ -274,6 +275,7 @@ class ODataClientBatchResponseParsingUnitTest
             .satisfies(e -> {
                 assertThat(e.getHttpCode()).isEqualTo(400);
                 assertThat(e.getHttpBody().get()).contains("The FirstName field is required");
+                assertThat(e.getContentId()).containsExactly(2);
             });
 
         final ODataRequestResultGeneric resultReadByKey = batchResponse.getResult(readByKey);


### PR DESCRIPTION
This approach...

* **does not consume** the lazily evaluated `HttpResponse` from the batch response. All lazy behavior properties of `ODataRequestResultMultipartGeneric` are kept maintained.
* **no longer throws away** the batch meta information but instead combines it with the original payload to new class `Entry(String meta, String payload)` whereas the meta information like `Content-ID` can be extracted easily.
* All changes are not public API breaking. The affected classes are package-private.