### PR TITLE
fix: Allow DwC Tenant without Subdomain

### DIFF
--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -7,6 +7,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.common.annotations.Beta;
 import com.google.common.base.Strings;
@@ -15,6 +16,7 @@ import com.sap.cloud.sdk.cloudplatform.exception.DwcHeaderNotFoundException;
 import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
 import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderContainer;
 
+import io.vavr.control.Try;
 import lombok.Value;
 
 /**
@@ -66,6 +68,20 @@ public class DwcHeaderUtils
     public static String getDwCSubdomainOrThrow()
     {
         return getNonEmptyDwcHeaderValue(DWC_SUBDOMAIN_HEADER);
+    }
+
+    /**
+     * This method fetches the value of the {@link #DWC_SUBDOMAIN_HEADER} header. If the header is not present,
+     * {@code null} will be returned instead.
+     *
+     * @return Either the value of the {@link #DWC_SUBDOMAIN_HEADER} header, or {@code null} if the header is not
+     *         present.
+     * @since 5.6.0
+     */
+    @Nullable
+    public static String getDwCSubdomainOrNull()
+    {
+        return Try.of(() -> getNonEmptyDwcHeaderValue(DWC_SUBDOMAIN_HEADER)).getOrNull();
     }
 
     /**

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/tenant/DwcTenantFacade.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/tenant/DwcTenantFacade.java
@@ -39,7 +39,7 @@ public class DwcTenantFacade extends DefaultTenantFacade
     {
         try {
             final String tenantId = DwcHeaderUtils.getDwcTenantIdOrThrow();
-            final String subdomain = DwcHeaderUtils.getDwCSubdomainOrThrow();
+            final String subdomain = DwcHeaderUtils.getDwCSubdomainOrNull();
             return new DefaultTenant(tenantId, subdomain);
         }
         catch( final Exception e ) {

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtilsTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtilsTest.java
@@ -1,0 +1,66 @@
+package com.sap.cloud.sdk.cloudplatform;
+
+import static com.sap.cloud.sdk.cloudplatform.DwcHeaderUtils.DWC_SUBDOMAIN_HEADER;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.List;
+import java.util.Map;
+
+import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.sdk.cloudplatform.requestheader.DefaultRequestHeaderContainer;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderAccessor;
+import com.sap.cloud.sdk.cloudplatform.requestheader.RequestHeaderContainer;
+
+class DwcHeaderUtilsTest
+{
+    @Test
+    void testSubdomainHeaderOrNullWithoutHeaderContainer()
+    {
+        // sanity
+        assertThat(RequestHeaderAccessor.tryGetHeaderContainer()).isEmpty();
+
+        assertThat(DwcHeaderUtils.getDwCSubdomainOrNull()).isNull();
+    }
+
+    @Test
+    void testSubdomainHeaderOrNullWithoutHeader()
+    {
+        RequestHeaderAccessor.executeWithHeaderContainer(RequestHeaderContainer.EMPTY, () -> {
+            // sanity
+            assertThat(RequestHeaderAccessor.getHeaderContainer().getHeaderValues(DWC_SUBDOMAIN_HEADER)).isEmpty();
+
+            assertThat(DwcHeaderUtils.getDwCSubdomainOrNull()).isNull();
+        });
+    }
+
+    @Test
+    void testSubdomainHeaderOrNull()
+    {
+        final String expectedValue = "subdomain";
+        RequestHeaderAccessor.executeWithHeaderContainer(Map.of(DWC_SUBDOMAIN_HEADER, expectedValue), () -> {
+            // sanity
+            assertThat(RequestHeaderAccessor.getHeaderContainer().getHeaderValues(DWC_SUBDOMAIN_HEADER))
+                .containsExactly(expectedValue);
+
+            assertThat(DwcHeaderUtils.getDwCSubdomainOrNull()).isEqualTo(expectedValue);
+        });
+    }
+
+    @Test
+    void testSubdomainHeaderOrNullWithMultipleValues()
+    {
+        final String firstValue = "first";
+        final String secondValue = "second";
+        final RequestHeaderContainer requestHeaderContainer =
+            DefaultRequestHeaderContainer
+                .fromMultiValueMap(Map.of(DWC_SUBDOMAIN_HEADER, List.of(firstValue, secondValue)));
+        RequestHeaderAccessor.executeWithHeaderContainer(requestHeaderContainer, () -> {
+            // sanity
+            assertThat(RequestHeaderAccessor.getHeaderContainer().getHeaderValues(DWC_SUBDOMAIN_HEADER))
+                .containsExactly(firstValue, secondValue);
+
+            assertThat(DwcHeaderUtils.getDwCSubdomainOrNull()).isEqualTo(firstValue);
+        });
+    }
+}

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DwcTenantFacadeTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DwcTenantFacadeTest.java
@@ -46,6 +46,25 @@ class DwcTenantFacadeTest
     }
 
     @Test
+    void testSuccessfulTenantWithoutSubdomainRetrieval()
+    {
+        final Map<String, String> headers = Map.of(DWC_TENANT_HEADER, "tenant-value");
+
+        final DefaultTenant expectedTenant = new DefaultTenant("tenant-value", null);
+
+        RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> {
+            final ThreadContext currentContext = ThreadContextAccessor.getCurrentContext();
+            final DefaultTenant currentTenant = (DefaultTenant) TenantAccessor.getCurrentTenant();
+            final Try<Tenant> shouldBeSuccess =
+                currentContext.getPropertyValue(TenantThreadContextListener.PROPERTY_TENANT);
+
+            assertThat(currentTenant).isEqualTo(expectedTenant);
+            assertThat(shouldBeSuccess.isSuccess()).isTrue();
+            assertThat(shouldBeSuccess.get()).isEqualTo(expectedTenant);
+        });
+    }
+
+    @Test
     void testUnsuccessfulTenantRetrieval()
     {
         RequestHeaderAccessor.executeWithHeaderContainer(Collections.emptyMap(), () -> {

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,5 @@
 
 ### 🐛 Fixed Issues
 
-- Fix an issue where the `AuthTokenAccessor` would not recognise JWT tokens passed in via the `dwc-jwt` header.
+- [DwC] Fix an issue where the `AuthTokenAccessor` would not recognise JWT tokens passed in via the `dwc-jwt` header.
+- [DwC] Fix an issue where the current tenant would not be resolved if the `dwc-subdomain` header was missing. 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Customer issue: https://sap-cpe.slack.com/archives/C0115K14FMG/p1710143831812869

At the moment, DwC does not support domains for IAS-only tenants.
As such, our DwC specific tenant retrieval logic fails.

This PR fixes this issue by making the subdomain optional while resolving the tenant information from the DwC headers.

**NOTE**: The DwC colleagues are working on also providing the tenant's subdomain as part of [this issue](https://github.tools.sap/deploy-with-confidence/issues/issues/2147) (they said they will be working on this somewhen in Q2/24).

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] DwC tenant retrieval no longer throws an exception in case the subdomain is not present  

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
