### PR TITLE
Fix: Business Logging Service Binding removed from Endpoint URLs

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -69,10 +69,10 @@ class BtpServicePropertySuppliers
                 ServiceIdentifier.of("business-logging"),
                 MultiUrlPropertySupplier
                     .of(BusinessLoggingOptions.class)
-                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice")
-                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice")
+                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice", () -> true)
+                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice", () -> true)
                     .withUrlKey(BusinessLoggingOptions.READ_API, "readservice")
-                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice")
+                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice", () -> true)
                     .factory());
 
     private static final List<OAuth2PropertySupplierResolver> DEFAULT_SERVICE_RESOLVERS = new ArrayList<>();

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -6,6 +6,7 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import static com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.IasOptions.IasCommunicationOptions;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.IasOptions.IasTargetUri;
+import static com.sap.cloud.sdk.cloudplatform.connectivity.MultiUrlPropertySupplier.REMOVE_PATH;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -71,10 +72,10 @@ class BtpServicePropertySuppliers
                 ServiceIdentifier.of("business-logging"),
                 MultiUrlPropertySupplier
                     .of(BusinessLoggingOptions.class)
-                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice")
-                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice")
-                    .withUrlKey(BusinessLoggingOptions.READ_API, "readservice")
-                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice")
+                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice", REMOVE_PATH)
+                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice", REMOVE_PATH)
+                    .withUrlKey(BusinessLoggingOptions.READ_API, "readservice", REMOVE_PATH)
+                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice", REMOVE_PATH)
                     .factory());
     static final OAuth2PropertySupplierResolver AI_CORE =
         OAuth2PropertySupplierResolver.forServiceIdentifier(ServiceIdentifier.of("aicore"), AiCore::new);

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -69,10 +69,10 @@ class BtpServicePropertySuppliers
                 ServiceIdentifier.of("business-logging"),
                 MultiUrlPropertySupplier
                     .of(BusinessLoggingOptions.class)
-                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice", () -> true)
-                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice", () -> true)
+                    .withUrlKey(BusinessLoggingOptions.CONFIG_API, "configservice")
+                    .withUrlKey(BusinessLoggingOptions.TEXT_API, "textresourceservice")
                     .withUrlKey(BusinessLoggingOptions.READ_API, "readservice")
-                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice", () -> true)
+                    .withUrlKey(BusinessLoggingOptions.WRITE_API, "writeservice")
                     .factory());
 
     private static final List<OAuth2PropertySupplierResolver> DEFAULT_SERVICE_RESOLVERS = new ArrayList<>();

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -74,21 +74,7 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         URI endpointUrl = getCredential(URI.class, "endpoints", bindingKey).get();
         final boolean removePath = urlKeys.get(option).get(bindingKey).get();
         if( removePath ) {
-            final String path = endpointUrl.getPath();
-            try {
-                endpointUrl =
-                    new URI(
-                        endpointUrl.getScheme(),
-                        endpointUrl.getAuthority(),
-                        null,
-                        endpointUrl.getQuery(),
-                        endpointUrl.getFragment());
-            }
-            catch( URISyntaxException e ) {
-                throw new DestinationAccessException(
-                    "Unable to create a URI from '" + endpointUrl + "' by removing path '" + path + "'",
-                    e);
-            }
+            endpointUrl = endpointUrl.resolve("/");
         }
         return endpointUrl;
     }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -61,11 +61,11 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         final Optional<String> maybeBindingKey = urlKeys.get(option).keySet().stream().findFirst();
         if( maybeBindingKey.isEmpty() ) {
             throw new IllegalStateException(
-                    "Found option value "
-                            + option
-                            + " for "
-                            + enhancerClass.getName()
-                            + ", but no URL key was registered for this value. Please ensure that for each possible choice a URL key is registered.");
+                "Found option value "
+                    + option
+                    + " for "
+                    + enhancerClass.getName()
+                    + ", but no URL key was registered for this value. Please ensure that for each possible choice a URL key is registered.");
         }
 
         final String bindingKey = maybeBindingKey.get();
@@ -77,15 +77,17 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
             final String path = endpointUrl.getPath();
             try {
                 endpointUrl =
-                        new URI(
-                                endpointUrl.getScheme(),
-                                endpointUrl.getAuthority(),
-                                null,
-                                endpointUrl.getQuery(),
-                                endpointUrl.getFragment());
-            } catch ( URISyntaxException e ) {
+                    new URI(
+                        endpointUrl.getScheme(),
+                        endpointUrl.getAuthority(),
+                        null,
+                        endpointUrl.getQuery(),
+                        endpointUrl.getFragment());
+            }
+            catch( URISyntaxException e ) {
                 throw new DestinationAccessException(
-                        "Unable to create a URI from '" + endpointUrl + "' by removing path '" + path + "'", e);
+                    "Unable to create a URI from '" + endpointUrl + "' by removing path '" + path + "'",
+                    e);
             }
         }
         return endpointUrl;
@@ -137,10 +139,14 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         @Nonnull
         Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey )
         {
-            return withUrlKey(enhancer,urlKey, () -> enhancerClass == BtpServiceOptions.BusinessLoggingOptions.class);
+            return withUrlKey(enhancer, urlKey, () -> enhancerClass == BtpServiceOptions.BusinessLoggingOptions.class);
         }
+
         @Nonnull
-        private Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey, @Nonnull final Supplier<Boolean> isPathless )
+        private Builder<T> withUrlKey(
+            @Nonnull final OptionsEnhancer<T> enhancer,
+            @Nonnull final String urlKey,
+            @Nonnull final Supplier<Boolean> isPathless )
         {
             final Map<String, Supplier<Boolean>> keyPathMap = new HashMap<>();
             keyPathMap.put(urlKey, isPathless);

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -5,9 +5,12 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Function;
+import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 
@@ -30,12 +33,12 @@ import lombok.extern.slf4j.Slf4j;
 final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends DefaultOAuth2PropertySupplier
 {
     private final Class<T> enhancerClass;
-    private final Map<OptionsEnhancer<T>, String> urlKeys;
+    private final Map<OptionsEnhancer<T>, Map<String, Supplier<Boolean>>> urlKeys;
 
     private MultiUrlPropertySupplier(
         @Nonnull final ServiceBindingDestinationOptions options,
         @Nonnull final Class<T> enhancerClass,
-        @Nonnull final Map<OptionsEnhancer<T>, String> urlKeys )
+        @Nonnull final Map<OptionsEnhancer<T>, Map<String, Supplier<Boolean>>> urlKeys )
     {
         super(options);
         this.enhancerClass = enhancerClass;
@@ -55,17 +58,37 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         }
 
         final T option = maybeOption.get();
-        final String bindingKey = urlKeys.get(option);
-        if( bindingKey == null ) {
+        final Optional<String> maybeBindingKey = urlKeys.get(option).keySet().stream().findFirst();
+        if( maybeBindingKey.isEmpty() ) {
             throw new IllegalStateException(
-                "Found option value "
-                    + option
-                    + " for "
-                    + enhancerClass.getName()
-                    + ", but no URL key was registered for this value. Please ensure that for each possible choice a URL key is registered.");
+                    "Found option value "
+                            + option
+                            + " for "
+                            + enhancerClass.getName()
+                            + ", but no URL key was registered for this value. Please ensure that for each possible choice a URL key is registered.");
         }
+
+        final String bindingKey = maybeBindingKey.get();
         log.debug("Option {} selected, using binding key {}.", option, bindingKey);
-        return getCredential(URI.class, "endpoints", bindingKey).get();
+
+        URI endpointUrl = getCredential(URI.class, "endpoints", bindingKey).get();
+        final boolean isPathless = urlKeys.get(option).get(bindingKey).get();
+        if( isPathless ) {
+            final String path = endpointUrl.getPath();
+            try {
+                endpointUrl =
+                        new URI(
+                                endpointUrl.getScheme(),
+                                endpointUrl.getAuthority(),
+                                null,
+                                endpointUrl.getQuery(),
+                                endpointUrl.getFragment());
+            } catch ( URISyntaxException e ) {
+                throw new DestinationAccessException(
+                        "Unable to create a URI from '" + endpointUrl + "' by removing path '" + path + "'", e);
+            }
+        }
+        return endpointUrl;
     }
 
     /**
@@ -95,7 +118,7 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
     static final class Builder<T extends OptionsEnhancer<T>>
     {
         private final Class<T> enhancerClass;
-        private final Map<OptionsEnhancer<T>, String> urlKeys = new HashMap<>();
+        private final Map<OptionsEnhancer<T>, Map<String, Supplier<Boolean>>> urlKeys = new HashMap<>();
 
         /**
          * Add a key under which the URL is to be found in a service binding for the given option. Typically, the
@@ -114,7 +137,32 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         @Nonnull
         Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey )
         {
-            urlKeys.put(enhancer, urlKey);
+            return withUrlKey(enhancer,urlKey, () -> false);
+        }
+
+        /**
+         * Add a key under which the URL is to be found in a service binding for the given option. Typically, the
+         * {@code enhancer} should be an enum, and you should add a key for each enum value.
+         *
+         * @param enhancer
+         *          An instance of the {@link OptionsEnhancer} that represents one possible option choice. It will be
+         *          used to select the URL and compared to the instance that is eventually passed in the
+         *          {@link ServiceBindingDestinationOptions} via {@code hashCode()}. This should typically be an enum value.
+         * @param urlKey
+         *          The key under which the URL is to be found in a service binding. It will be looked up in the
+         *          {@code endpoints} property of the {@code credentials} section of the service binding.
+         * @param isPathless
+         *          A supplier that returns true if the URL should be pathless, e.g. if the path will be appended during
+         *          OpenAPI/OData client generation and thus is redundant for the destination.
+         *          on {@code MultiUrlPropertySupplier#getServiceUri()}.
+         * @return This builder.
+         */
+        @Nonnull
+        Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey, @Nonnull final Supplier<Boolean> isPathless )
+        {
+            final Map<String, Supplier<Boolean>> keyPathMap = new HashMap<>();
+            keyPathMap.put(urlKey, isPathless);
+            urlKeys.put(enhancer, keyPathMap);
             return this;
         }
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -27,7 +27,7 @@ import lombok.extern.slf4j.Slf4j;
  *            The class of the {@link OptionsEnhancer}.
  */
 @Slf4j
-class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends DefaultOAuth2PropertySupplier
+final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends DefaultOAuth2PropertySupplier
 {
     /**
      * A URL transformation function that removes the entire path of the provided URL. Can be used with
@@ -162,7 +162,7 @@ class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends DefaultOAut
     }
 
     @RequiredArgsConstructor
-    static class UrlExtractor
+    static final class UrlExtractor
     {
         private static final Function<URI, URI> NO_TRANSFORMATION = url -> url;
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -72,8 +72,8 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         log.debug("Option {} selected, using binding key {}.", option, bindingKey);
 
         URI endpointUrl = getCredential(URI.class, "endpoints", bindingKey).get();
-        final boolean isPathless = urlKeys.get(option).get(bindingKey).get();
-        if( isPathless ) {
+        final boolean removePath = urlKeys.get(option).get(bindingKey).get();
+        if( removePath ) {
             final String path = endpointUrl.getPath();
             try {
                 endpointUrl =

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplier.java
@@ -137,28 +137,10 @@ final class MultiUrlPropertySupplier<T extends OptionsEnhancer<T>> extends Defau
         @Nonnull
         Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey )
         {
-            return withUrlKey(enhancer,urlKey, () -> false);
+            return withUrlKey(enhancer,urlKey, () -> enhancerClass == BtpServiceOptions.BusinessLoggingOptions.class);
         }
-
-        /**
-         * Add a key under which the URL is to be found in a service binding for the given option. Typically, the
-         * {@code enhancer} should be an enum, and you should add a key for each enum value.
-         *
-         * @param enhancer
-         *          An instance of the {@link OptionsEnhancer} that represents one possible option choice. It will be
-         *          used to select the URL and compared to the instance that is eventually passed in the
-         *          {@link ServiceBindingDestinationOptions} via {@code hashCode()}. This should typically be an enum value.
-         * @param urlKey
-         *          The key under which the URL is to be found in a service binding. It will be looked up in the
-         *          {@code endpoints} property of the {@code credentials} section of the service binding.
-         * @param isPathless
-         *          A supplier that returns true if the URL should be pathless, e.g. if the path will be appended during
-         *          OpenAPI/OData client generation and thus is redundant for the destination.
-         *          on {@code MultiUrlPropertySupplier#getServiceUri()}.
-         * @return This builder.
-         */
         @Nonnull
-        Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey, @Nonnull final Supplier<Boolean> isPathless )
+        private Builder<T> withUrlKey( @Nonnull final OptionsEnhancer<T> enhancer, @Nonnull final String urlKey, @Nonnull final Supplier<Boolean> isPathless )
         {
             final Map<String, Supplier<Boolean>> keyPathMap = new HashMap<>();
             keyPathMap.put(urlKey, isPathless);

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -254,6 +254,14 @@ class BtpServicePropertySuppliersTest
                 entry("endpoints.textresourceservice", "https://business-logging.text_api.example.com"),
                 entry("endpoints.writeservice", "https://business-logging.write_api.example.com"));
 
+        private final ServiceBinding bindingWithRedundantPaths =
+                bindingWithCredentials(
+                        ServiceIdentifier.of("business-logging"),
+                        entry("endpoints.configservice", "https://business-logging.config_api.example.com/buslogs/configs"),
+                        entry("endpoints.readservice", "https://business-logging.read_api.example.com"),
+                        entry("endpoints.textresourceservice", "https://business-logging.text_api.example.com/buslogs/configs/textresources"),
+                        entry("endpoints.writeservice", "https://business-logging.write_api.example.com/buslogs/log"));
+
         @ParameterizedTest
         @EnumSource( BusinessLoggingOptions.class )
         void testApiSelection( final BusinessLoggingOptions api )
@@ -263,7 +271,16 @@ class BtpServicePropertySuppliersTest
 
             final OAuth2PropertySupplier sut = BUSINESS_LOGGING.resolve(options);
 
-            assertThat(sut.getServiceUri().toString()).contains(api.name().toLowerCase());
+            final ServiceBindingDestinationOptions redundantOptions =
+                    ServiceBindingDestinationOptions.forService(bindingWithRedundantPaths).withOption(api).build();
+
+            final OAuth2PropertySupplier redundantSut = BUSINESS_LOGGING.resolve(redundantOptions);
+
+            final String uriString = sut.getServiceUri().toString();
+
+            assertThat(uriString).contains(api.name().toLowerCase());
+
+            assertThat(redundantSut.getServiceUri().toString()).isEqualTo(uriString);
         }
 
         @Test

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -293,7 +293,9 @@ class BtpServicePropertySuppliersTest
             bindingWithCredentials(
                 ServiceIdentifier.of("business-logging"),
                 entry("endpoints.configservice", "https://business-logging.config_api.example.com/buslogs/configs"),
-                entry("endpoints.readservice", "https://business-logging.read_api.example.com"),
+                entry(
+                    "endpoints.readservice",
+                    "https://business-logging.read_api.example.com/odata/v2/com.sap.bs.businesslogging.DisplayMessage"),
                 entry(
                     "endpoints.textresourceservice",
                     "https://business-logging.text_api.example.com/buslogs/configs/textresources"),
@@ -307,17 +309,21 @@ class BtpServicePropertySuppliersTest
                 ServiceBindingDestinationOptions.forService(binding).withOption(api).build();
 
             final OAuth2PropertySupplier sut = BUSINESS_LOGGING.resolve(options);
+            assertThat(sut).isNotNull();
 
             final ServiceBindingDestinationOptions redundantOptions =
                 ServiceBindingDestinationOptions.forService(bindingWithRedundantPaths).withOption(api).build();
 
             final OAuth2PropertySupplier redundantSut = BUSINESS_LOGGING.resolve(redundantOptions);
+            assertThat(redundantSut).isNotNull();
 
-            final String uriString = sut.getServiceUri().toString();
+            final URI uri = sut.getServiceUri();
+            assertThat(uri).hasPath("/");
+            assertThat(uri.toString()).contains(api.name().toLowerCase());
 
-            assertThat(uriString).contains(api.name().toLowerCase());
-
-            assertThat(redundantSut.getServiceUri().toString()).isEqualTo(uriString);
+            final URI redundantUri = redundantSut.getServiceUri();
+            assertThat(redundantUri).hasPath("/");
+            assertThat(redundantUri).isEqualTo(uri);
         }
 
         @Test

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -259,12 +259,14 @@ class BtpServicePropertySuppliersTest
                 entry("endpoints.writeservice", "https://business-logging.write_api.example.com"));
 
         private final ServiceBinding bindingWithRedundantPaths =
-                bindingWithCredentials(
-                        ServiceIdentifier.of("business-logging"),
-                        entry("endpoints.configservice", "https://business-logging.config_api.example.com/buslogs/configs"),
-                        entry("endpoints.readservice", "https://business-logging.read_api.example.com"),
-                        entry("endpoints.textresourceservice", "https://business-logging.text_api.example.com/buslogs/configs/textresources"),
-                        entry("endpoints.writeservice", "https://business-logging.write_api.example.com/buslogs/log"));
+            bindingWithCredentials(
+                ServiceIdentifier.of("business-logging"),
+                entry("endpoints.configservice", "https://business-logging.config_api.example.com/buslogs/configs"),
+                entry("endpoints.readservice", "https://business-logging.read_api.example.com"),
+                entry(
+                    "endpoints.textresourceservice",
+                    "https://business-logging.text_api.example.com/buslogs/configs/textresources"),
+                entry("endpoints.writeservice", "https://business-logging.write_api.example.com/buslogs/log"));
 
         @ParameterizedTest
         @EnumSource( BusinessLoggingOptions.class )
@@ -276,7 +278,7 @@ class BtpServicePropertySuppliersTest
             final OAuth2PropertySupplier sut = BUSINESS_LOGGING.resolve(options);
 
             final ServiceBindingDestinationOptions redundantOptions =
-                    ServiceBindingDestinationOptions.forService(bindingWithRedundantPaths).withOption(api).build();
+                ServiceBindingDestinationOptions.forService(bindingWithRedundantPaths).withOption(api).build();
 
             final OAuth2PropertySupplier redundantSut = BUSINESS_LOGGING.resolve(redundantOptions);
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MultiUrlPropertySupplierTest.java
@@ -1,0 +1,23 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static com.sap.cloud.sdk.cloudplatform.connectivity.MultiUrlPropertySupplier.REMOVE_PATH;
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.net.URI;
+
+import org.junit.jupiter.api.Test;
+
+class MultiUrlPropertySupplierTest
+{
+    @Test
+    void testRemovePath()
+    {
+        assertThat(REMOVE_PATH.apply(URI.create("https://user:pass@foo.bar/baz")))
+            .hasToString("https://user:pass@foo.bar/");
+        assertThat(REMOVE_PATH.apply(URI.create("https://foo.bar/baz?$select=oof"))).hasToString("https://foo.bar/");
+        assertThat(REMOVE_PATH.apply(URI.create("https://foo.bar"))).hasToString("https://foo.bar/");
+        assertThat(REMOVE_PATH.apply(URI.create("https://foo.bar/"))).hasToString("https://foo.bar/");
+        assertThat(REMOVE_PATH.apply(URI.create("https://foo.bar?$select=oof"))).hasToString("https://foo.bar/");
+    }
+
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,5 +22,7 @@
 ### 🐛 Fixed Issues
 
 - Fix an issue where the same `HttpClient` would be used for different users when using `PrincipalPropagation` and thus could potentially share the same (session) cookies.
+- Fix an issue where destinations for the Business Logging service that are created from a service binding (using the `ServiceBindingDestinationLoader` API) contained the concrete API path.
+  This behavior caused problems when using such a destination in a client generated with the SAP Cloud SDK's OpenApi generator.
 - [DwC] Fix an issue where the `AuthTokenAccessor` would not recognise JWT tokens passed in via the `dwc-jwt` header.
 - [DwC] Fix an issue where the current tenant would not be resolved if the `dwc-subdomain` header was missing.


### PR DESCRIPTION
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#416

Some Business Logging service endpoints contain redundant paths that get appended again when generated clients are called, creating bad paths. The fix removes paths from the returned URLs for Business Logging service, so they may be later appended without conflict. 

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] remove paths from endpoint urls for Business Logging

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated
