### PR TITLE
Improve error handling for Missing Connectivity Proxy information

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -224,7 +224,7 @@ public final class DefaultHttpDestination implements HttpDestination
                         .stream()
                         .filter(Objects::nonNull)
                         .map(value -> new Header(HttpHeaders.AUTHORIZATION, value))
-                        .collect(Collectors.toList());
+                        .toList();
 
                 if( headersToAdd.isEmpty() ) {
                     final String msg =
@@ -972,10 +972,10 @@ public final class DefaultHttpDestination implements HttpDestination
                 throw new IllegalArgumentException("Cannot build a HttpDestination without a URL.");
             }
 
-            // NOT using the typed property here since this would break change detection in our ScpCfDestinationLoader
-            property(DestinationProperty.TYPE.getKeyName(), DestinationType.HTTP.toString());
+            if( get(DestinationProperty.TYPE).isEmpty() ) {
+                property(DestinationProperty.TYPE, DestinationType.HTTP);
+            }
 
-            // handle proxy type == OnPremise
             if( builder.get(DestinationProperty.PROXY_TYPE).contains(ProxyType.ON_PREMISE) ) {
                 try {
                     return proxyHandler.handle(this);
@@ -986,7 +986,6 @@ public final class DefaultHttpDestination implements HttpDestination
                     log.error(msg, e);
                 }
             }
-
             return buildInternal();
         }
 

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -982,7 +982,13 @@ public final class DefaultHttpDestination implements HttpDestination
                 }
                 catch( final Exception e ) {
                     final String msg =
-                        "Unable to resolve proxy configuration for destination. This destination cannot be used for anything other than reading its properties.";
+                        """
+                            Unable to resolve proxy configuration for destination. \\
+                            This destination cannot be used for anything other than reading its properties. \\
+                            This is unexpected and will be changed to fail instead in a future version of Cloud SDK. \\
+                            Please analyze the attached stack trace and resolve the issue. \\
+                            In case only the properties of a destination should be accessed, without performing authorization flows, please use the 'getDestinationProperties'  method on 'DestinationService' instead.\\
+                            """;
                     log.error(msg, e);
                 }
             }

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -110,7 +110,7 @@ class DefaultHttpDestinationBuilderProxyHandler
      *         found.
      */
     @Nonnull
-    ServiceBinding getServiceBindingConnectivity()
+    private ServiceBinding getServiceBindingConnectivity()
     {
         final ServiceBindingAccessor serviceBindingAccessor = getServiceBindingAccessor();
 

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -126,9 +126,8 @@ class DefaultHttpDestinationBuilderProxyHandler
         } else if( serviceBindings.size() > 1 ) {
             throw new DestinationAccessException(
                 "Unable to resolve connectivity service binding. More than one service bindings found that match Connectivity.");
-        } else {
-            return serviceBindings.get(0);
         }
+        return serviceBindings.get(0);
     }
 
     @Nonnull

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -16,7 +16,6 @@ import com.sap.cloud.environment.servicebinding.api.ServiceBindingAccessor;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationNotFoundException;
-import com.sap.cloud.sdk.cloudplatform.exception.ShouldNotHappenException;
 import com.sap.cloud.sdk.cloudplatform.security.AuthTokenAccessor;
 
 import io.vavr.control.Option;
@@ -41,10 +40,10 @@ class DefaultHttpDestinationBuilderProxyHandler
             DestinationNotFoundException
     {
         if( !builder.get(DestinationProperty.PROXY_TYPE).contains(ProxyType.ON_PREMISE) ) {
-            throw new ShouldNotHappenException(
-                "Proxy handler was invoked for destination "
+            throw new IllegalStateException(
+                "Proxy handler was invoked unexpectedly for destination "
                     + builder.get(DestinationProperty.NAME).getOrElse("unnamed-destination")
-                    + " that is not supposed to be proxied.");
+                    + " which does not have proxy type 'ON_PREMISE'.");
         }
         // add location id header provider, useful to identify one of multiple cloud connectors
         builder.headerProviders(new SapConnectivityLocationIdHeaderProvider());
@@ -113,7 +112,7 @@ class DefaultHttpDestinationBuilderProxyHandler
     @Nonnull
     ServiceBinding getServiceBindingConnectivity()
     {
-        final ServiceBindingAccessor serviceBindingAccessor = DefaultServiceBindingAccessor.getInstance();
+        final ServiceBindingAccessor serviceBindingAccessor = getServiceBindingAccessor();
 
         final Predicate<ServiceBinding> predicate =
             b -> ServiceIdentifier.CONNECTIVITY.equals(b.getServiceIdentifier().orElse(null));
@@ -130,6 +129,12 @@ class DefaultHttpDestinationBuilderProxyHandler
         } else {
             return serviceBindings.get(0);
         }
+    }
+
+    @Nonnull
+    ServiceBindingAccessor getServiceBindingAccessor()
+    {
+        return DefaultServiceBindingAccessor.getInstance();
     }
 
     /**

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -308,7 +308,7 @@ public class DestinationService implements DestinationLoader
     @SuppressWarnings( "unchecked" )
     @Nonnull
     private
-        List<Destination>
+        List<DestinationProperties>
         getAndDeserializeDestinations( @Nonnull final String servicePath, @Nonnull final OnBehalfOf behalf )
             throws DestinationAccessException
     {
@@ -323,6 +323,10 @@ public class DestinationService implements DestinationLoader
                         "Found a destination without name. A name is required for destinations defined in the destination service.");
                 }
             })
+            // it's important that we build the generic default destination here
+            // if we were to build HttpDestinations via DefaultHttpDestination.Builder#build we would trigger on-premise proxy header auth flows
+            // which we don't want for only computing the destination properties
+            // since we return DestinationProperties (and not Destination) we don't have to worry about .asHttp() (which intern would trigger the build() method) being invoked on the result
             .map(DefaultDestination.Builder::build)
             .collect(Collectors.toList());
     }

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
@@ -16,9 +16,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
 import java.util.Collections;
+import java.util.List;
 
 import javax.annotation.Nonnull;
 
@@ -62,7 +64,7 @@ class ConnectivityServiceTest
     @BeforeEach
     void setupServiceBinding( @Nonnull final WireMockRuntimeInfo wm )
     {
-        sut = new DefaultHttpDestinationBuilderProxyHandler();
+        sut = spy(new DefaultHttpDestinationBuilderProxyHandler());
         final ServiceBinding connectivityService =
             new DefaultServiceBindingBuilder()
                 .withServiceIdentifier(ServiceIdentifier.CONNECTIVITY)
@@ -77,7 +79,7 @@ class ConnectivityServiceTest
                         .put("onpremise_proxy_port", "1234")
                         .build())
                 .build();
-        when(sut.getServiceBindingConnectivity()).thenReturn(connectivityService);
+        when(sut.getServiceBindingAccessor()).thenReturn(() -> List.of(connectivityService));
     }
 
     @Test

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServicePrincipalPropagationTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServicePrincipalPropagationTest.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.verify;
 
 import java.net.URI;
 import java.util.Collection;
+import java.util.List;
 import java.util.function.Consumer;
 
 import javax.annotation.Nonnull;
@@ -32,11 +33,13 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
+import org.junit.jupiter.api.parallel.Isolated;
 
 import com.github.tomakehurst.wiremock.client.WireMock;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
 import com.google.common.collect.ImmutableMap;
+import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingAccessor;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingBuilder;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
@@ -49,6 +52,7 @@ import com.sap.cloud.sdk.testutil.TestContext;
 import io.vavr.control.Try;
 import lombok.Value;
 
+@Isolated( "Test modifies global service bindings" )
 @WireMockTest
 class DestinationServicePrincipalPropagationTest
 {
@@ -92,7 +96,7 @@ class DestinationServicePrincipalPropagationTest
                 .withCredentials(credentials)
                 .build();
 
-        DefaultHttpDestinationBuilderProxyHandler.setServiceBindingConnectivity(connectivityService);
+        DefaultServiceBindingAccessor.setInstance(() -> List.of(connectivityService));
 
         doReturn(DESTINATION)
             .when(destinationServiceAdapter)
@@ -108,7 +112,7 @@ class DestinationServicePrincipalPropagationTest
     @AfterEach
     void tearDownConnectivity()
     {
-        DefaultHttpDestinationBuilderProxyHandler.setServiceBindingConnectivity(null);
+        DefaultServiceBindingAccessor.setInstance(null);
     }
 
     @Test

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
@@ -275,7 +275,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         final DefaultHttpDestinationBuilderProxyHandler proxyHandler =
             spy(new DefaultHttpDestinationBuilderProxyHandler());
         when(proxyHandler.getServiceBindingDestinationLoader()).thenReturn(sut);
-        when(proxyHandler.getServiceBindingConnectivity()).thenReturn(CONNECTIVITY_BINDING);
+        when(proxyHandler.getServiceBindingAccessor()).thenReturn(() -> List.of(CONNECTIVITY_BINDING));
 
         final DefaultHttpDestination.Builder builder =
             DefaultHttpDestination


### PR DESCRIPTION
## Context

This PR improves the error handling in case adding on-premise headers failed. The error message is now more expressive and prepares a future update to change the behavior to be more consistent with the rest of the SDk.

### Feature scope:
 
- [x] Increase relevant error messages to `error` log level
- [x] Add some comments to clarify some rather implicit interactions

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] ~Release notes updated~
