### PR TITLE
feat: [Destinations] Increase Http Client Cache Duration

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCache.java
@@ -37,7 +37,7 @@ public class DefaultHttpClientCache extends AbstractHttpClientCache
      */
     DefaultHttpClientCache()
     {
-        this(5, TimeUnit.MINUTES);
+        this(1, TimeUnit.HOURS);
     }
 
     /**
@@ -67,7 +67,7 @@ public class DefaultHttpClientCache extends AbstractHttpClientCache
      */
     DefaultHttpClientCache( final long duration, @Nonnull final TimeUnit unit, @Nonnull final Ticker ticker )
     {
-        cache = Caffeine.newBuilder().expireAfterWrite(duration, unit).ticker(ticker).build();
+        cache = Caffeine.newBuilder().expireAfterAccess(duration, unit).ticker(ticker).build();
         CacheManager.register(cache);
     }
 

--- a/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCacheTest.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCacheTest.java
@@ -58,10 +58,10 @@ class DefaultHttpClientCacheTest
     }
 
     @Test
-    void testGetClientExpiresAfterWrite()
+    void testGetClientExpiresAfterAccess()
     {
         final AtomicLong ticker = new AtomicLong(0);
-        sut = new DefaultHttpClientCache(5L, TimeUnit.MINUTES, ticker::get);
+        sut = new DefaultHttpClientCache(10L, TimeUnit.MINUTES, ticker::get);
 
         final HttpClient clientWithDestination1 = sut.tryGetHttpClient(DESTINATION, FACTORY).get();
         assertThat(clientWithDestination1).isSameAs(sut.tryGetHttpClient(DESTINATION, FACTORY).get());
@@ -69,13 +69,19 @@ class DefaultHttpClientCacheTest
         final HttpClient clientWithoutDestination1 = sut.tryGetHttpClient(FACTORY).get();
         assertThat(clientWithoutDestination1).isSameAs(sut.tryGetHttpClient(FACTORY).get());
 
-        ticker.updateAndGet(t -> t + 3 * NANOSECONDS_IN_MINUTE);
+        ticker.updateAndGet(t -> t + 5 * NANOSECONDS_IN_MINUTE);
 
         // cache is still valid
         assertThat(clientWithDestination1).isSameAs(sut.tryGetHttpClient(DESTINATION, FACTORY).get());
         assertThat(clientWithoutDestination1).isSameAs(sut.tryGetHttpClient(FACTORY).get());
 
-        ticker.updateAndGet(t -> t + 3 * NANOSECONDS_IN_MINUTE);
+        ticker.updateAndGet(t -> t + 7 * NANOSECONDS_IN_MINUTE);
+
+        // cache is still valid
+        assertThat(clientWithDestination1).isSameAs(sut.tryGetHttpClient(DESTINATION, FACTORY).get());
+        assertThat(clientWithoutDestination1).isSameAs(sut.tryGetHttpClient(FACTORY).get());
+
+        ticker.updateAndGet(t -> t + 11 * NANOSECONDS_IN_MINUTE);
 
         // cache has expired
         final HttpClient clientWithDestination2 = sut.tryGetHttpClient(DESTINATION, FACTORY).get();

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Cache.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Cache.java
@@ -32,7 +32,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 class DefaultApacheHttpClient5Cache implements ApacheHttpClient5Cache
 {
-    static final Duration DEFAULT_DURATION = Duration.ofMinutes(5L);
+    static final Duration DEFAULT_DURATION = Duration.ofHours(1L);
     static final Ticker DEFAULT_TICKER = Ticker.systemTicker();
 
     @Nonnull
@@ -45,7 +45,7 @@ class DefaultApacheHttpClient5Cache implements ApacheHttpClient5Cache
 
     DefaultApacheHttpClient5Cache( @Nonnull final Duration cacheDuration, @Nonnull final Ticker ticker )
     {
-        cache = Caffeine.newBuilder().expireAfterWrite(cacheDuration).ticker(ticker).build();
+        cache = Caffeine.newBuilder().expireAfterAccess(cacheDuration).ticker(ticker).build();
         CacheManager.register(cache);
     }
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,7 +18,8 @@
 
 ### 📈 Improvements
 
-- 
+- Improve the efficiency of HTTP clients: The default cache duration for HTTP clients have been increased to expire one hour after last access (was 5 minutes after creation).
+  Aside from a performance improvement, this improves the handling of cookies, as they are retained for much longer.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#430.

### Feature scope:
 
- [x] Change to `afterLastAccess`
- [x] Increase duration to `1 Hour`


## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] [Documentation updated](https://github.com/SAP/cloud-sdk/pull/1771)
- [x] Release notes updated

