### PR TITLE
Fix NPE in ActionRequestBuilder.serialize

### DIFF
--- a/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestActionTest.java
+++ b/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestActionTest.java
@@ -86,6 +86,7 @@ class ODataRequestActionTest
         actionParameters.put("booleanParameter", true);
         actionParameters.put("integerParameter", 9000);
         actionParameters.put("decimalParameter", 3.14d);
+        actionParameters.put("nullParameter", null);
         final ODataRequestAction request =
             new ODataRequestAction(
                 ODATA_SERVICE_PATH,

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
@@ -13,6 +13,7 @@ import javax.annotation.Nullable;
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
 import com.google.gson.JsonElement;
+import com.google.gson.JsonNull;
 import com.google.gson.JsonObject;
 import com.google.gson.TypeAdapter;
 import com.google.gson.reflect.TypeToken;

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
@@ -105,7 +105,7 @@ public abstract class ActionRequestBuilder<BuilderT extends ActionRequestBuilder
     private <T> JsonElement serialize( @Nullable final T parameter )
     {
         if( parameter == null ) {
-            return gson.toJsonTree(null);
+            return JsonNull.INSTANCE;
         }
 
         @SuppressWarnings( "unchecked" )

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/ActionRequestBuilder.java
@@ -8,6 +8,7 @@ import java.util.Collections;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
@@ -101,8 +102,12 @@ public abstract class ActionRequestBuilder<BuilderT extends ActionRequestBuilder
      * Serializes the passed parameter with custom type adapters and returns a JsonElement.
      */
     @Nonnull
-    private <T> JsonElement serialize( @Nonnull final T parameter )
+    private <T> JsonElement serialize( @Nullable final T parameter )
     {
+        if( parameter == null ) {
+            return gson.toJsonTree(null);
+        }
+
         @SuppressWarnings( "unchecked" )
         final TypeToken<T> typeToken = TypeToken.get((Class<T>) parameter.getClass());
         final TypeAdapter<T> typeAdapter = GSON_VDM_ADAPTER_FACTORY.create(gson, typeToken);

--- a/datamodel/odata-v4/odata-v4-core/src/test/resources/SingleValueActionRequestBuilderTest/ActionNullEntityRequestBody.json
+++ b/datamodel/odata-v4/odata-v4-core/src/test/resources/SingleValueActionRequestBuilderTest/ActionNullEntityRequestBody.json
@@ -1,0 +1,3 @@
+{
+  "entityParameter": null
+}

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,4 +22,4 @@
 ### 🐛 Fixed Issues
 
 - Fix an issue that would cause a NPE when using bound services backed by IAS via the [dedicated service binding format](/docs/java/features/connectivity/service-bindings#service-binding-format).
-- Fix an issue that would cause a NPE when using the OData `applyAction` method with a `null` parameter value in the action entity.
+- Fix an issue that would cause a NPE when using the OData `applyAction` method with a `null` parameter value.

--- a/release_notes.md
+++ b/release_notes.md
@@ -22,3 +22,4 @@
 ### 🐛 Fixed Issues
 
 - Fix an issue that would cause a NPE when using bound services backed by IAS via the [dedicated service binding format](/docs/java/features/connectivity/service-bindings#service-binding-format).
+- Fix an issue that would cause a NPE when using the OData `applyAction` method with a `null` parameter value in the action entity.


### PR DESCRIPTION
## Context

closes SAP/cloud-sdk-java-backlog#441

Customer support issue: [ActionRequestBuilder.serialize throws NullPointerException if parameter is null](https://github.com/SAP/cloud-sdk-java/issues/401#top)

### Feature scope:
 
- [x] Fix an issue that would cause a NPE when using the OData `applyAction` method with a `null` parameter value.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated