### PR TITLE
chore: [DevOps] Add .java-version to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,4 @@ javadoc.properties
 
 local_maven_repo
 badges/
+.java-version


### PR DESCRIPTION
## Context

File used by [jenv](https://github.com/jenv/jenv). Low prio obviously
