### PR TITLE
feat: [Destinations] Always send APP_TID for IAS Token Requests

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -177,6 +177,15 @@ class BtpServicePropertySuppliers
                 attachIasCommunicationOptions(oAuth2OptionsBuilder);
             }
             attachClientKeyStore(oAuth2OptionsBuilder);
+            String appTid = switch( options.getOnBehalfOf() ) {
+                case TECHNICAL_USER_PROVIDER -> getCredentialOrThrow(String.class, "app_tid");
+                case TECHNICAL_USER_CURRENT_TENANT -> TenantAccessor
+                    .tryGetCurrentTenant()
+                    .map(Tenant::getTenantId)
+                    .getOrElse(() -> getCredentialOrThrow(String.class, "app_tid"));
+                case NAMED_USER_CURRENT_TENANT -> TenantAccessor.getCurrentTenant().getTenantId();
+            };
+            oAuth2OptionsBuilder.withTokenRetrievalParameter("app_tid", appTid);
 
             return oAuth2OptionsBuilder.build();
         }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -178,6 +178,7 @@ class BtpServicePropertySuppliers
                 oAuth2OptionsBuilder
                     .withTokenRetrievalParameter("app_tid", getCredentialOrThrow(String.class, "app_tid"));
             }
+            attachClientKeyStore(oAuth2OptionsBuilder);
 
             return oAuth2OptionsBuilder.build();
         }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -175,17 +175,9 @@ class BtpServicePropertySuppliers
                 oAuth2OptionsBuilder.withSkipTokenRetrieval(true);
             } else {
                 attachIasCommunicationOptions(oAuth2OptionsBuilder);
+                oAuth2OptionsBuilder
+                    .withTokenRetrievalParameter("app_tid", getCredentialOrThrow(String.class, "app_tid"));
             }
-            attachClientKeyStore(oAuth2OptionsBuilder);
-            String appTid = switch( options.getOnBehalfOf() ) {
-                case TECHNICAL_USER_PROVIDER -> getCredentialOrThrow(String.class, "app_tid");
-                case TECHNICAL_USER_CURRENT_TENANT -> TenantAccessor
-                    .tryGetCurrentTenant()
-                    .map(Tenant::getTenantId)
-                    .getOrElse(() -> getCredentialOrThrow(String.class, "app_tid"));
-                case NAMED_USER_CURRENT_TENANT -> TenantAccessor.getCurrentTenant().getTenantId();
-            };
-            oAuth2OptionsBuilder.withTokenRetrievalParameter("app_tid", appTid);
 
             return oAuth2OptionsBuilder.build();
         }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -4,7 +4,6 @@
 
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.sap.cloud.sdk.cloudplatform.connectivity.OAuth2Service.TenantPropagationStrategy.TENANT_SUBDOMAIN;
 import static com.sap.cloud.security.xsuaa.util.UriUtil.expandPath;
 
 import java.net.URI;
@@ -198,7 +197,7 @@ class OAuth2Service
 
     private void setAppTidInCaseOfIAS( @Nullable final String tenantId )
     {
-        if( tenantPropagationStrategy == TENANT_SUBDOMAIN && tenantId != null ) {
+        if( tenantPropagationStrategy == TenantPropagationStrategy.TENANT_SUBDOMAIN && tenantId != null ) {
             // the IAS property supplier will have set this to the provider ID by default
             // we have to override it here to match the current tenant, if the current tenant is defined
             additionalParameters.put("app_tid", tenantId);
@@ -224,7 +223,7 @@ class OAuth2Service
     @Nullable
     private String getTenantSubdomainOrNull( @Nullable final Tenant tenant )
     {
-        if( tenantPropagationStrategy != TENANT_SUBDOMAIN ) {
+        if( tenantPropagationStrategy != TenantPropagationStrategy.TENANT_SUBDOMAIN ) {
             return null;
         }
 
@@ -373,7 +372,7 @@ class OAuth2Service
         {
             final TenantPropagationStrategy tenantPropagationStrategy;
             if( IDENTITY_AUTHENTICATION.equals(serviceIdentifier) ) {
-                tenantPropagationStrategy = TENANT_SUBDOMAIN;
+                tenantPropagationStrategy = TenantPropagationStrategy.TENANT_SUBDOMAIN;
             } else {
                 tenantPropagationStrategy = TenantPropagationStrategy.ZID_HEADER;
             }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/IdentityAuthenticationServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/IdentityAuthenticationServiceBindingDestinationLoaderTest.java
@@ -276,7 +276,8 @@ class IdentityAuthenticationServiceBindingDestinationLoaderTest
                 .builder()
                 .copy(Map.of())
                 .withServiceIdentifier(IDENTITY_AUTHENTICATION)
-                .withCredentials(Map.of("clientid", "foo", "clientsecret", "bar", "url", "https://foo.com"))
+                .withCredentials(
+                    Map.of("clientid", "foo", "clientsecret", "bar", "url", "https://foo.com", "app_tid", "provider"))
                 .build();
         DefaultServiceBindingAccessor.setInstance(() -> List.of(iasBinding));
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
@@ -1,10 +1,13 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.equalTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.okJson;
 import static com.github.tomakehurst.wiremock.client.WireMock.post;
 import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
 import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig;
+import static com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf.NAMED_USER_CURRENT_TENANT;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.OnBehalfOf.TECHNICAL_USER_PROVIDER;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
@@ -27,19 +30,24 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
 import org.junit.jupiter.api.parallel.Isolated;
 
+import com.auth0.jwt.JWT;
 import com.github.tomakehurst.wiremock.http.RequestMethod;
 import com.github.tomakehurst.wiremock.junit5.WireMockExtension;
 import com.github.tomakehurst.wiremock.stubbing.ServeEvent;
 import com.sap.cloud.sdk.cloudplatform.cache.CacheManager;
+import com.sap.cloud.sdk.cloudplatform.connectivity.OAuth2Service.TenantPropagationStrategy;
 import com.sap.cloud.sdk.cloudplatform.connectivity.SecurityLibWorkarounds.ZtisClientIdentity;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationOAuthTokenException;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceIsolationMode;
+import com.sap.cloud.sdk.cloudplatform.security.AuthToken;
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 import com.sap.cloud.sdk.testutil.TestContext;
 import com.sap.cloud.security.config.ClientCredentials;
 import com.sap.cloud.security.config.ClientIdentity;
+import com.sap.cloud.security.config.Service;
+import com.sap.cloud.security.test.JwtGenerator;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 
 import lombok.SneakyThrows;
@@ -128,18 +136,91 @@ class OAuth2ServiceTest
     }
 
     @Test
-    void singleOAuth2ServiceImplSingleSubscriber()
+    void testZidHeaderTenantStrategy()
     {
         final OAuth2Service service =
-            OAuth2Service.builder().withTokenUri(SERVER_1.baseUrl()).withIdentity(IDENTITY_1).build();
+            OAuth2Service
+                .builder()
+                .withTokenUri(SERVER_1.baseUrl())
+                .withIdentity(IDENTITY_1)
+                .withTenantPropagationStrategy(TenantPropagationStrategy.ZID_HEADER)
+                .build();
 
-        final String token1 = TenantAccessor.executeWithTenant(new DefaultTenant("abcd"), service::retrieveAccessToken);
-        final String token2 = TenantAccessor.executeWithTenant(new DefaultTenant("abcd"), service::retrieveAccessToken);
+        TenantAccessor.executeWithTenant(new DefaultTenant("abcd"), service::retrieveAccessToken);
+        TenantAccessor.executeWithTenant(new DefaultTenant("abcd"), service::retrieveAccessToken);
 
-        assertThat(token1).isEqualTo(TOKEN_1);
-        assertThat(token2).isEqualTo(TOKEN_1);
+        SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withHeader("x-zid", equalTo("abcd")));
+    }
 
-        SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")));
+    @Test
+    void testSubdomainTenantStrategy()
+    {
+        final OAuth2Service.Builder serviceBuilder =
+            OAuth2Service
+                .builder()
+                .withTokenUri(SERVER_1.baseUrl())
+                .withIdentity(IDENTITY_1)
+                .withAdditionalParameter("app_tid", "provider")
+                .withTenantPropagationStrategy(TenantPropagationStrategy.TENANT_SUBDOMAIN);
+        {
+            // behalf: current tenant
+            OAuth2Service service = serviceBuilder.build();
+            // we have to use localhost here as subdomains because this test doesn't mock different subdomains
+            // instead, that aspect is tested in OAuth2IntegrationTest
+            service.retrieveAccessToken();
+            TenantAccessor.executeWithTenant(new DefaultTenant("t1", "localhost"), service::retrieveAccessToken);
+            TenantAccessor.executeWithTenant(new DefaultTenant("t2", "localhost"), service::retrieveAccessToken);
+
+            SERVER_1
+                .verify(
+                    1,
+                    postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing("app_tid=provider")));
+            SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing("app_tid=t1")));
+            SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing("app_tid=t2")));
+        }
+        {
+            // behalf provider
+            final OAuth2Service service = serviceBuilder.withOnBehalfOf(TECHNICAL_USER_PROVIDER).build();
+
+            service.retrieveAccessToken();
+            TenantAccessor.executeWithTenant(new DefaultTenant("t2", "localhost"), service::retrieveAccessToken);
+
+            SERVER_1
+                .verify(
+                    1,
+                    postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing("app_tid=provider")));
+            SERVER_1
+                .verify(
+                    1,
+                    postRequestedFor(urlEqualTo("/oauth/token")).withRequestBody(containing("app_tid=provider")));
+        }
+        {
+            // behalf named user
+            final OAuth2Service service = serviceBuilder.withOnBehalfOf(NAMED_USER_CURRENT_TENANT).build();
+
+            assertThatThrownBy(service::retrieveAccessToken);
+
+            context.setTenant(new DefaultTenant("tenant", "localhost"));
+            context.setPrincipal();
+            final String token =
+                JwtGenerator
+                    .getInstance(Service.IAS, "clientid")
+                    .withClaimValue("app_tid", "tenant")
+                    .createToken()
+                    .getTokenValue();
+            context.setAuthToken(new AuthToken(JWT.decode(token)));
+
+            service.retrieveAccessToken();
+
+            SERVER_1
+                .verify(
+                    1,
+                    postRequestedFor(urlEqualTo("/oauth/token"))
+                        .withRequestBody(containing("app_tid=tenant"))
+                        .withRequestBody(
+                            containing("grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer".replace(":", "%3A")))
+                        .withRequestBody(containing("assertion=" + token)));
+        }
     }
 
     @Test
@@ -156,7 +237,8 @@ class OAuth2ServiceTest
         assertThat(token1).isEqualTo(TOKEN_1);
         assertThat(token2).isEqualTo(TOKEN_1);
 
-        SERVER_1.verify(2, postRequestedFor(urlEqualTo("/oauth/token")));
+        SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withHeader("x-zid", equalTo("tenant 1")));
+        SERVER_1.verify(1, postRequestedFor(urlEqualTo("/oauth/token")).withHeader("x-zid", equalTo("tenant 2")));
     }
 
     @Test

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,6 +18,9 @@
 
 - Improve the efficiency of HTTP clients: The default cache duration for HTTP clients have been increased to expire one hour after last access (was 5 minutes after creation).
   Aside from a performance improvement, this improves the handling of cookies, as they are retained for much longer.
+- Improve connecting to IAS-based applications and services.
+  Scenarios where an IAS tenant is connected to multiple subaccounts of an application are now supported.
+  - Note that when mocking an IAS binding for testing the binding entry `app_tid` is now required.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

This PR changes token flows to IAS to always send the `app_tid` parameter. This is required in case an IAS tenant is used across multiple different subaccounts. We got confirmation that it is safe to always send this, thus adding it in.

### Feature scope:
 
- [x] Always send `app_tid`
- [x] Strengthen tests

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated

