### PR TITLE
feat: Generic (Expert) API for String-Based BtpServiceOptions

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/pom.xml
+++ b/cloudplatform/cloudplatform-connectivity/pom.xml
@@ -116,6 +116,11 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
 			<groupId>org.assertj</groupId>
 			<artifactId>assertj-core</artifactId>
 			<scope>test</scope>

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -46,6 +46,9 @@ public final class BtpServiceOptions
 
     /**
      * Generically creates a new instance of {@link OptionsEnhancer} for the given enhancer name and parameters.
+     * <p>
+     * <b>Note:</b> This API is meant for expert users that want to use the SDK in a more dynamic way. For the vast
+     * majority of consumers, we strongly recommend using the type-safe methods defined in this class.
      *
      * @param enhancerName
      *            The name of the enhancer to be created. This should be the simple class name of the enhancer.

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -53,6 +53,7 @@ public final class BtpServiceOptions
      *            The parameters to pass to the chosen enhancer. These should be the same (including their order) as the
      *            parameters of the type-safe methods defined in this class.
      * @return An instance of {@link OptionsEnhancer} that can be used to configure a destination.
+     * @since 5.9.0
      */
     @Beta
     public static

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -5,6 +5,11 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import java.net.URI;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.BiFunction;
+import java.util.function.Function;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -25,6 +30,43 @@ import lombok.Value;
 @Beta
 public final class BtpServiceOptions
 {
+
+    private static final Map<String, Function<Object[], OptionsEnhancer<?>>> GENERIC_ENHANCER_BUILDERS;
+
+    static {
+        final Map<String, Function<Object[], OptionsEnhancer<?>>> map = new HashMap<>();
+
+        addGenericEnumEnhancerBuilder(map, BusinessRulesOptions.class);
+        addGenericEnumEnhancerBuilder(map, WorkflowOptions.class);
+        addGenericEnumEnhancerBuilder(map, BusinessLoggingOptions.class);
+        IasOptions.addGenericEnhancerBuilder(map);
+
+        GENERIC_ENHANCER_BUILDERS = Collections.unmodifiableMap(map);
+    }
+
+    /**
+     * Generically creates a new instance of {@link OptionsEnhancer} for the given enhancer name and parameters.
+     *
+     * @param enhancerName
+     *            The name of the enhancer to be created. This should be the simple class name of the enhancer.
+     * @param parameters
+     *            The parameters to pass to the chosen enhancer. These should be the same (including their order) as the
+     *            parameters of the type-safe methods defined in this class.
+     * @return An instance of {@link OptionsEnhancer} that can be used to configure a destination.
+     */
+    @Beta
+    public static
+        OptionsEnhancer<?>
+        withGenericOption( @Nonnull final String enhancerName, @Nonnull final Object... parameters )
+    {
+        final Function<Object[], OptionsEnhancer<?>> enhancerBuilder = GENERIC_ENHANCER_BUILDERS.get(enhancerName);
+        if( enhancerBuilder == null ) {
+            throw new IllegalArgumentException("Unknown enhancer name: " + enhancerName);
+        }
+
+        return enhancerBuilder.apply(parameters);
+    }
+
     /**
      * Enhancer that allows to include configuration specific to the
      * <a href="https://api.sap.com/package/SAPCPBusinessRulesAPIs/all">SAP Business Rules Service for Cloud Foundry</a>
@@ -261,6 +303,114 @@ public final class BtpServiceOptions
             public IasCommunicationOptions getValue()
             {
                 return this;
+            }
+        }
+
+        // package-private for testing
+        static void addGenericEnhancerBuilder( @Nonnull final Map<String, Function<Object[], OptionsEnhancer<?>>> map )
+        {
+            final String key = IasOptions.class.getSimpleName();
+            if( map.containsKey(key) ) {
+                throw new IllegalStateException("Generic enhancer builder for " + key + " already registered.");
+            }
+
+            map.put(key, args -> castParameters(args, 0, String.class, method -> {
+                if( "withTargetUri".equals(method) ) {
+                    try {
+                        return castParameters(args, 1, String.class, IasOptions::withTargetUri);
+                    }
+                    catch( final IllegalArgumentException e ) {
+                        // ignored - try to apply overload
+                    }
+
+                    try {
+                        return castParameters(args, 1, URI.class, IasOptions::withTargetUri);
+                    }
+                    catch( final IllegalArgumentException e ) {
+                        throw new IllegalArgumentException(
+                            "Expected parameter 1 to be of type String or URI, but got %s instead."
+                                .formatted(
+                                    args.length > 1 && args[1] != null ? args[1].getClass().getName() : "<null>"));
+                    }
+                }
+
+                if( "withoutTokenForTechnicalProviderUser".equals(method) ) {
+                    return withoutTokenForTechnicalProviderUser();
+                }
+
+                if( "withApplicationName".equals(method) ) {
+                    return castParameters(args, 1, String.class, IasOptions::withApplicationName);
+                }
+
+                if( "withConsumerClient".equals(method) ) {
+                    if( args.length == 2 ) {
+                        return castParameters(args, 1, String.class, IasOptions::withConsumerClient);
+                    }
+
+                    return castParameters(args, 1, String.class, String.class, IasOptions::withConsumerClient);
+                }
+
+                throw new IllegalArgumentException("Unknown Ias Options method: " + method);
+            }));
+        }
+    }
+
+    // package-private for testing
+    static <T extends Enum<T> & OptionsEnhancer<T>> void addGenericEnumEnhancerBuilder(
+        @Nonnull final Map<String, Function<Object[], OptionsEnhancer<?>>> map,
+        @Nonnull final Class<T> enumType )
+    {
+        final String key = enumType.getSimpleName();
+        if( map.containsKey(key) ) {
+            throw new IllegalStateException("Generic enhancer builder for " + key + " already registered.");
+        }
+
+        map.put(key, args -> castParameters(args, 0, String.class, v -> Enum.valueOf(enumType, v)));
+    }
+
+    @Nonnull
+    private static <T1> OptionsEnhancer<?> castParameters(
+        @Nonnull final Object[] parameters,
+        final int parametersOffset,
+        @Nonnull final Class<T1> type1,
+        @Nonnull final Function<T1, OptionsEnhancer<?>> enhancer )
+    {
+        throwIfParametersCannotBeCast(parameters, parametersOffset, type1);
+        return enhancer.apply(type1.cast(parameters[parametersOffset]));
+    }
+
+    @Nonnull
+    private static <T1, T2> OptionsEnhancer<?> castParameters(
+        @Nonnull final Object[] parameters,
+        final int parametersOffset,
+        @Nonnull final Class<T1> type1,
+        @Nonnull final Class<T2> type2,
+        @Nonnull final BiFunction<T1, T2, OptionsEnhancer<?>> enhancer )
+    {
+        throwIfParametersCannotBeCast(parameters, parametersOffset, type1, type2);
+        return enhancer.apply(type1.cast(parameters[parametersOffset]), type2.cast(parameters[parametersOffset + 1]));
+    }
+
+    private static void throwIfParametersCannotBeCast(
+        @Nonnull final Object[] parameters,
+        final int parametersOffset,
+        @Nonnull final Class<?>... types )
+    {
+        if( parameters.length - parametersOffset < types.length ) {
+            throw new IllegalArgumentException(
+                "Expected %d parameter(s), but got %d parameter(s) instead."
+                    .formatted(types.length, parameters.length));
+        }
+
+        for( int i = 0; i < types.length; i++ ) {
+            if( !types[i].isInstance(parameters[i + parametersOffset]) ) {
+                final String actualType =
+                    parameters[i + parametersOffset] == null
+                        ? "<null>"
+                        : parameters[i + parametersOffset].getClass().getName();
+                throw new IllegalArgumentException(
+                    "Expected parameter %d to be of type %s, but got %s instead."
+                        .formatted(i + 1, types[i].getName(), actualType));
             }
         }
     }

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptionsTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptionsTest.java
@@ -1,0 +1,260 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingDestinationOptions.OptionsEnhancer;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+import javax.annotation.Nonnull;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+
+import lombok.Value;
+
+class BtpServiceOptionsTest
+{
+    @Test
+    void testCreateGenericEnumOption()
+    {
+        // collect all available enum enhancers
+        final List<Class<?>> enumEnhancers =
+            Arrays
+                .stream(BtpServiceOptions.class.getClasses())
+                .filter(Class::isEnum)
+                .filter(c -> (c.getModifiers() & Modifier.PUBLIC) > 0)
+                .toList();
+
+        for( final Class<?> enumClass : enumEnhancers ) {
+            final String enumName = enumClass.getSimpleName();
+            for( final Object enumEntry : enumClass.getEnumConstants() ) {
+                assertThat(BtpServiceOptions.withGenericOption(enumName, enumEntry.toString())).isSameAs(enumEntry);
+            }
+        }
+    }
+
+    @Test
+    void testEnumOptionIsCaseSensitive()
+    {
+        final Map<String, Function<Object[], OptionsEnhancer<?>>> map = new HashMap<>();
+
+        BtpServiceOptions.addGenericEnumEnhancerBuilder(map, TestEnumEnhancer.class);
+
+        assertThat(map.get("TestEnumEnhancer").apply(new Object[] { "OPTION1" })).isSameAs(TestEnumEnhancer.OPTION1);
+        assertThatThrownBy(() -> map.get("TestEnumEnhancer").apply(new Object[] { "option1" }))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProvidingTooFewArguments()
+    {
+        final Map<String, Function<Object[], OptionsEnhancer<?>>> map = new HashMap<>();
+
+        BtpServiceOptions.addGenericEnumEnhancerBuilder(map, TestEnumEnhancer.class);
+
+        assertThatThrownBy(() -> map.get("TestEnumEnhancer").apply(new Object[] {}))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProvidingTooManyArguments()
+    {
+        final Map<String, Function<Object[], OptionsEnhancer<?>>> map = new HashMap<>();
+
+        BtpServiceOptions.addGenericEnumEnhancerBuilder(map, TestEnumEnhancer.class);
+
+        assertThat(map.get("TestEnumEnhancer").apply(new Object[] { "OPTION1", "OPTION2" }))
+            .isSameAs(TestEnumEnhancer.OPTION1);
+    }
+
+    @Test
+    void testProvidingWrongArgumentType()
+    {
+        final Map<String, Function<Object[], OptionsEnhancer<?>>> map = new HashMap<>();
+
+        BtpServiceOptions.addGenericEnumEnhancerBuilder(map, TestEnumEnhancer.class);
+
+        assertThatThrownBy(() -> map.get("TestEnumEnhancer").apply(new Object[] { 1 }))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @ParameterizedTest
+    @MethodSource( "genericIasParameters" )
+    void testCreateIasOption( @Nonnull final IasParameter parameter )
+    {
+        final OptionsEnhancer<?> actual =
+            BtpServiceOptions
+                .withGenericOption(BtpServiceOptions.IasOptions.class.getSimpleName(), parameter.arguments);
+        assertThat(actual).isNotNull();
+        parameter.getValidator().accept(actual);
+    }
+
+    @Test
+    void testAllIasMethodsAreTested()
+    {
+        final List<Method> methods =
+            new ArrayList<>(
+                Arrays
+                    .stream(BtpServiceOptions.IasOptions.class.getDeclaredMethods())
+                    .filter(m -> (m.getModifiers() & Modifier.PUBLIC) > 0)
+                    .filter(m -> (m.getModifiers() & Modifier.STATIC) > 0)
+                    .toList());
+        // sanity check
+        assertThat(methods).isNotEmpty();
+
+        for( final IasParameter testedMethod : genericIasParameters().toList() ) {
+            methods.removeIf(testedMethod::matches);
+        }
+
+        assertThat(methods).isEmpty();
+    }
+
+    @Test
+    void testProvidingInvalidIasMethod()
+    {
+        assertThatThrownBy(
+            () -> BtpServiceOptions
+                .withGenericOption(BtpServiceOptions.IasOptions.class.getSimpleName(), "invalidMethod"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProvidingInvalidIasParameter()
+    {
+        assertThatThrownBy(
+            () -> BtpServiceOptions
+                .withGenericOption(BtpServiceOptions.IasOptions.class.getSimpleName(), "withTargetUri", 1337))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProvidingTooFewIasParameters()
+    {
+        assertThatThrownBy(
+            () -> BtpServiceOptions
+                .withGenericOption(BtpServiceOptions.IasOptions.class.getSimpleName(), "withTargetUri"))
+            .isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    void testProvidingTooManyIasParameters()
+    {
+        assertThat(
+            BtpServiceOptions
+                .withGenericOption(
+                    BtpServiceOptions.IasOptions.class.getSimpleName(),
+                    "withTargetUri",
+                    "https://foo.baz",
+                    "https://bar.baz"))
+            .isEqualTo(BtpServiceOptions.IasOptions.withTargetUri("https://foo.baz"));
+    }
+
+    static Stream<IasParameter> genericIasParameters()
+    {
+        return Stream
+            .of(
+                new IasParameter(
+                    "withTargetUri",
+                    new Object[] { "https://example.com" },
+                    actual -> assertThat(actual)
+                        .isEqualTo(BtpServiceOptions.IasOptions.withTargetUri("https://example.com"))),
+                new IasParameter(
+                    "withTargetUri",
+                    new Object[] { URI.create("https://example.com") },
+                    actual -> assertThat(actual)
+                        .isEqualTo(BtpServiceOptions.IasOptions.withTargetUri(URI.create("https://example.com")))),
+                new IasParameter(
+                    "withoutTokenForTechnicalProviderUser",
+                    new Object[0],
+                    actual -> assertThat(actual)
+                        .isEqualTo(BtpServiceOptions.IasOptions.withoutTokenForTechnicalProviderUser())),
+                new IasParameter(
+                    "withApplicationName",
+                    new Object[] { "applicationName" },
+                    actual -> assertThat(actual)
+                        .isEqualTo(BtpServiceOptions.IasOptions.withApplicationName("applicationName"))),
+                new IasParameter(
+                    "withConsumerClient",
+                    new Object[] { "consumerClient" },
+                    actual -> assertThat(actual)
+                        .isEqualTo(BtpServiceOptions.IasOptions.withConsumerClient("consumerClient"))),
+                new IasParameter(
+                    "withConsumerClient",
+                    new Object[] { "consumerClient", "consumerTenant" },
+                    actual -> assertThat(actual)
+                        .isEqualTo(
+                            BtpServiceOptions.IasOptions.withConsumerClient("consumerClient", "consumerTenant"))));
+    }
+
+    @Value
+    private static class IasParameter
+    {
+        Object[] arguments;
+        Consumer<OptionsEnhancer<?>> validator;
+
+        public IasParameter(
+            @Nonnull final String methodName,
+            @Nonnull final Object[] arguments,
+            @Nonnull final Consumer<OptionsEnhancer<?>> validator )
+        {
+            this.arguments = new Object[arguments.length + 1];
+            this.arguments[0] = methodName;
+            System.arraycopy(arguments, 0, this.arguments, 1, arguments.length);
+            this.validator = validator;
+        }
+
+        public String getMethodName()
+        {
+            return (String) arguments[0];
+        }
+
+        public boolean matches( @Nonnull final Method method )
+        {
+            if( !getMethodName().equals(method.getName()) ) {
+                return false;
+            }
+
+            if( arguments.length - 1 != method.getParameterCount() ) {
+                return false;
+            }
+
+            for( int i = 1; i < arguments.length; i++ ) {
+                if( !arguments[i].getClass().equals(method.getParameterTypes()[i - 1]) ) {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        @Override
+        public String toString()
+        {
+            return getMethodName() + "(" + Arrays.toString(arguments) + ")";
+        }
+    }
+
+    private enum TestEnumEnhancer implements OptionsEnhancer<TestEnumEnhancer>
+    {
+        OPTION1,
+        OPTION2;
+
+        @Override
+        public TestEnumEnhancer getValue()
+        {
+            return this;
+        }
+    }
+}


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#434.


This PR adds a string-based API for creating `OptionsEnhancer` instances in the `BtpServiceOptions` class, which is meant to aid experts (i.e. CAP developers) to circumvent referencing specific classes.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~ (we decided to not document this expert API)
- [x] ~Release notes updated~ (we decided to not document this expert API)

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
