### PR TITLE
fix: perform release workflow

### DIFF
--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -65,6 +65,7 @@ runs:
         
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
+        echo "[DEBUG] Excluded Check Runs: '${{ inputs.excluded-check-runs }}'"
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
         echo "[DEBUG] Excluded workflows: $EXCLUDED_WORKFLOWS"
         

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -20,7 +20,7 @@ inputs:
   excluded-check-runs:
     description: "A JSON object, where the keys are the names of the workflows to exclude. The values are a list of step names to ignore. If the list is empty, all steps of the workflow will be ignored."
     required: false
-    default: '{"${{ github.workflow }}": []}'
+    default: '{\"${{ github.workflow }}\": []}'
 
 outputs:
   pr-number:

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -67,7 +67,7 @@ runs:
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
         echo "[DEBUG] Excluded Check Runs: '${{ inputs.excluded-check-runs }}'"
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
-        echo "[DEBUG] Excluded workflows: $EXCLUDED_WORKFLOWS"
+        echo "[DEBUG] Excluded workflows: '$EXCLUDED_WORKFLOWS'"
         
         while IFS= read -r EXCLUDED_WORKFLOW; do
           if [[ -z "$EXCLUDED_WORKFLOW" ]]; then
@@ -77,9 +77,9 @@ runs:
             break
           fi
         
-          echo "[DEBUG] Excluding steps from workflow $EXCLUDED_WORKFLOW"
-          EXCLUDED_STEPS=$(jq -r '."$EXCLUDED_WORKFLOW"[]' <<< "${{ inputs.excluded-check-runs }}")
-          echo "[DEBUG] Excluded steps: $EXCLUDED_STEPS"
+          echo "[DEBUG] Excluding steps from workflow '$EXCLUDED_WORKFLOW'"
+          EXCLUDED_STEPS=$(jq -r '."${EXCLUDED_WORKFLOW}" | .[]' <<< "${{ inputs.excluded-check-runs }}")
+          echo "[DEBUG] Excluded steps: '$EXCLUDED_STEPS'"
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then
             # the provided list is empty, so ignore all steps of the workflow

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -75,7 +75,7 @@ runs:
           fi
         
           echo "[DEBUG] Excluding steps from workflow $EXCLUDED_WORKFLOW"
-          EXCLUDED_STEPS=$(jq -r '."$EXCLUDED_WORKFLOW"[]' <<< "${{ inputs.excluded-check-runs }}")
+          EXCLUDED_STEPS=$(jq -r '.\"$EXCLUDED_WORKFLOW\"[]' <<< "${{ inputs.excluded-check-runs }}")
           echo "[DEBUG] Excluded steps: $EXCLUDED_STEPS"
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -18,9 +18,9 @@ inputs:
     required: false
     default: ${{ github.token }}
   excluded-check-runs:
-    description: "A comma-separated list of workflow names that are excluded from the Check Runs check"
+    description: "A JSON object, where the keys are the names of the workflows to exclude. The values are a list of step names to ignore. If the list is empty, all steps of the workflow will be ignored."
     required: false
-    default: ${{ github.workflow }}
+    default: '{"${{ github.workflow }}": []}'
 
 outputs:
   pr-number:
@@ -34,7 +34,7 @@ runs:
   using: composite
   steps:
     - name: "Print Action Start"
-      run: echo ">>>>> Starting PR Is Mergeable Action; inputs = ${{ toJson(inputs) }}"
+      run: echo ">>>>> Starting PR Is Mergeable Action; Not printing inputs, as they might contain sensitive information"
       shell: bash
 
     - name: "Check Whether PR Is Mergeable"
@@ -65,13 +65,21 @@ runs:
         
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
-        IFS=',' read -ra EXCLUDED_WORKFLOWS <<< "${{ inputs.excluded-check-runs }}"
+        EXCLUDED_WORKFLOWS=$(jq 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
         for EXCLUDED_WORKFLOW in "${EXCLUDED_WORKFLOWS[@]}"; do
           if [[ -z "$FAILED_CHECK_RUNS" ]]; then
             break
           fi
         
-          FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW")' <<< "$FAILED_CHECK_RUNS")
+          EXCLUDED_STEPS=$(jq -r '."$EXCLUDED_WORKFLOW"[]' <<< "${{ inputs.excluded-check-runs }}")
+          if [[ -z "$EXCLUDED_STEPS" ]]; then
+            # the provided list is empty, so ignore all steps of the workflow
+            FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW")' <<< "$FAILED_CHECK_RUNS")
+          else
+            for EXCLUDED_STEP in "${EXCLUDED_STEPS[@]}"; do
+              FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW" and .name != "$EXCLUDED_STEP")' <<< "$FAILED_CHECK_RUNS")
+            done
+          fi
         done
         
         if [[ -n "$FAILED_CHECK_RUNS" ]]; then

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -66,12 +66,17 @@ runs:
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
+        echo "[DEBUG] Excluded workflows: $EXCLUDED_WORKFLOWS"
+        
         for EXCLUDED_WORKFLOW in "${EXCLUDED_WORKFLOWS[@]}"; do
           if [[ -z "$FAILED_CHECK_RUNS" ]]; then
             break
           fi
         
+          echo "[DEBUG] Excluding steps from workflow $EXCLUDED_WORKFLOW"
           EXCLUDED_STEPS=$(jq -r '."$EXCLUDED_WORKFLOW"[]' <<< "${{ inputs.excluded-check-runs }}")
+          echo "[DEBUG] Excluded steps: $EXCLUDED_STEPS"
+        
           if [[ -z "$EXCLUDED_STEPS" ]]; then
             # the provided list is empty, so ignore all steps of the workflow
             FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW")' <<< "$FAILED_CHECK_RUNS")

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -69,13 +69,16 @@ runs:
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
         echo "[DEBUG] Excluded workflows: $EXCLUDED_WORKFLOWS"
         
-        for EXCLUDED_WORKFLOW in "${EXCLUDED_WORKFLOWS[@]}"; do
+        while IFS= read -r EXCLUDED_WORKFLOW; do
+          if [[ -z "$EXCLUDED_WORKFLOW" ]]; then
+            continue
+          fi
           if [[ -z "$FAILED_CHECK_RUNS" ]]; then
             break
           fi
         
           echo "[DEBUG] Excluding steps from workflow $EXCLUDED_WORKFLOW"
-          EXCLUDED_STEPS=$(jq -r '.\"$EXCLUDED_WORKFLOW\"[]' <<< "${{ inputs.excluded-check-runs }}")
+          EXCLUDED_STEPS=$(jq -r '."$EXCLUDED_WORKFLOW"[]' <<< "${{ inputs.excluded-check-runs }}")
           echo "[DEBUG] Excluded steps: $EXCLUDED_STEPS"
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then
@@ -86,7 +89,7 @@ runs:
               FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW" and .name != "$EXCLUDED_STEP")' <<< "$FAILED_CHECK_RUNS")
             done
           fi
-        done
+        done <<< "$EXCLUDED_WORKFLOWS"
         
         if [[ -n "$FAILED_CHECK_RUNS" ]]; then
           echo "PR #$PR_NUMBER (in ${{ inputs.repo }}) contains failed check runs: "

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -65,9 +65,7 @@ runs:
         
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
-        echo "[DEBUG] Excluded Check Runs: '${{ inputs.excluded-check-runs }}'"
         EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
-        echo "[DEBUG] Excluded workflows: '$EXCLUDED_WORKFLOWS'"
         
         while IFS= read -r EXCLUDED_WORKFLOW; do
           if [[ -z "$EXCLUDED_WORKFLOW" ]]; then
@@ -77,9 +75,7 @@ runs:
             break
           fi
         
-          echo "[DEBUG] Excluding steps from workflow '$EXCLUDED_WORKFLOW'"
           EXCLUDED_STEPS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" '.[$workflow] | .[]' <<< "${{ inputs.excluded-check-runs }}")
-          echo "[DEBUG] Excluded steps: '$EXCLUDED_STEPS'"
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then
             # the provided list is empty, so ignore all steps of the workflow

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -83,11 +83,14 @@ runs:
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then
             # the provided list is empty, so ignore all steps of the workflow
-            FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW")' <<< "$FAILED_CHECK_RUNS")
+            FAILED_CHECK_RUNS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" 'select(.workflowName != $workflow)' <<< "$FAILED_CHECK_RUNS")
           else
-            for EXCLUDED_STEP in "${EXCLUDED_STEPS[@]}"; do
-              FAILED_CHECK_RUNS=$(jq -r 'select(.workflowName != "$EXCLUDED_WORKFLOW" and .name != "$EXCLUDED_STEP")' <<< "$FAILED_CHECK_RUNS")
-            done
+            while IFS= read -r EXCLUDED_STEP; do
+              if [[ -z "$EXCLUDED_STEP" ]]; then
+                  continue
+              fi
+              FAILED_CHECK_RUNS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" --arg step "$EXCLUDED_STEP" 'select(.workflowName != $workflow and .name != $step)' <<< "$FAILED_CHECK_RUNS")
+            done <<< "$EXCLUDED_STEPS"
           fi
         done <<< "$EXCLUDED_WORKFLOWS"
         

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -78,7 +78,7 @@ runs:
           fi
         
           echo "[DEBUG] Excluding steps from workflow '$EXCLUDED_WORKFLOW'"
-          EXCLUDED_STEPS=$(jq -r '."${EXCLUDED_WORKFLOW}" | .[]' <<< "${{ inputs.excluded-check-runs }}")
+          EXCLUDED_STEPS=$(jq -r --arg workflow "$EXCLUDED_WORKFLOW" '.[$workflow] | .[]' <<< "${{ inputs.excluded-check-runs }}")
           echo "[DEBUG] Excluded steps: '$EXCLUDED_STEPS'"
         
           if [[ -z "$EXCLUDED_STEPS" ]]; then

--- a/.github/actions/pr-is-mergeable/action.yaml
+++ b/.github/actions/pr-is-mergeable/action.yaml
@@ -65,7 +65,7 @@ runs:
         
         # check runs are things like our CI pipeline
         FAILED_CHECK_RUNS=$(jq -r '.[] | select(.__typename == "CheckRun" and .conclusion != "SUCCESS" and .conclusion != "NEUTRAL")' <<< "$PR_CHECKS")
-        EXCLUDED_WORKFLOWS=$(jq 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
+        EXCLUDED_WORKFLOWS=$(jq -r 'keys[]' <<< "${{ inputs.excluded-check-runs }}")
         for EXCLUDED_WORKFLOW in "${EXCLUDED_WORKFLOWS[@]}"; do
           if [[ -z "$FAILED_CHECK_RUNS" ]]; then
             break

--- a/.github/actions/workflow-succeeded/action.yaml
+++ b/.github/actions/workflow-succeeded/action.yaml
@@ -55,9 +55,12 @@ runs:
         JOBS_JSON=$(gh run view "${{ steps.find-run-id.outputs.RUN_ID }}" --json jobs)
         NON_SUCCESSFUL_JOBS=$(jq -r '.jobs[] | select(.conclusion != "success" and .conclusion != "neutral")' <<< "$JOBS_JSON")
         EXCLUDED_JOBS=$(jq -r '.[]' <<< "${{ inputs.excluded-jobs }}")
-        for EXCLUDED_JOB in "${EXCLUDED_JOBS[@]}"; do
-          NON_SUCCESSFUL_JOBS=$(jq 'select(.name != $EXCLUDED_JOB)' <<< "$NON_SUCCESSFUL_JOBS")
-        done
+        while IFS= read -r EXCLUDED_JOB; do
+          if [[ -z "$EXCLUDED_JOB" ]]; then
+            continue
+          fi
+          NON_SUCCESSFUL_JOBS=$(jq -r --arg name "$EXCLUDED_JOB" 'select(.name != $name)' <<< "$NON_SUCCESSFUL_JOBS")
+        done <<< "$EXCLUDED_JOBS"
         
         if [[ -n "$NON_SUCCESSFUL_JOBS" ]]; then
           echo "The following jobs did not succeed:"

--- a/.github/actions/workflow-succeeded/action.yaml
+++ b/.github/actions/workflow-succeeded/action.yaml
@@ -44,7 +44,7 @@ runs:
           exit 1
         fi
         
-        ECHO "RUN_ID=$(jq -r '.databaseId' <<< "$RUN_JSON")" >> $GITHUB_OUTPUT
+        echo "RUN_ID=$(jq -r '.databaseId' <<< "$RUN_JSON")" >> $GITHUB_OUTPUT
       shell: bash
       env:
         GH_TOKEN: ${{ inputs.token }}

--- a/.github/actions/workflow-succeeded/action.yaml
+++ b/.github/actions/workflow-succeeded/action.yaml
@@ -1,0 +1,91 @@
+name: "Workflow Succeeded"
+description: "Checks whether the latest run of a given workflow for a given commit SHA succeeded"
+
+inputs:
+  workflow:
+    description: "The name of the workflow to check"
+    required: true
+  sha:
+    description: "The commit SHA to check the workflow for"
+    required: true
+  repo:
+    description: "The repository of the workflow"
+    required: false
+    default: ${{ github.repository }}
+  token:
+    description: "The GitHub access token (with workflow read permissions) to access the workflow"
+    required: false
+    default: ${{ github.token }}
+  excluded-jobs:
+    description: "A JSON list of job names to ignore"
+    required: false
+    default: '[]'
+outputs:
+  run-id:
+    description: "The ID of the latest run of the workflow"
+    value: ${{ steps.find-run-id.outputs.RUN_ID }}
+  succeeded:
+    description: "Whether the latest run of the workflow succeeded"
+    value: ${{ steps.set-result.outputs.RESULT }}
+
+runs:
+  using: composite
+  steps:
+    - name: "Print Action Start"
+      run: echo ">>>>> Starting Workflow Succeeded Action; Not printing inputs, as they might contain sensitive information"
+      shell: bash
+
+    - name: "Determine Run Id"
+      id: find-run-id
+      run: |
+        RUN_JSON=$(gh run list --commit "${{ inputs.sha }}" --workflow "${{ inputs.workflow }}" --repo "${{ inputs.repo }}" --status completed --limit 1 --json databaseId,conclusion | jq '.[0]')
+        
+        if [[ "$(jq -r '.conclusion' <<< "$RUN_JSON")" != "success" ]]; then
+          exit 1
+        fi
+        
+        ECHO "RUN_ID=$(jq -r '.databaseId' <<< "$RUN_JSON")" >> $GITHUB_OUTPUT
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+
+    - name: "Check Run Jobs"
+      id: check-run-jobs
+      run: |
+        JOBS_JSON=$(gh run view "${{ steps.find-run-id.outputs.RUN_ID }}" --json jobs)
+        NON_SUCCESSFUL_JOBS=$(jq -r '.jobs[] | select(.conclusion != "success" and .conclusion != "neutral")' <<< "$JOBS_JSON")
+        EXCLUDED_JOBS=$(jq -r '.[]' <<< "${{ inputs.excluded-jobs }}")
+        for EXCLUDED_JOB in "${EXCLUDED_JOBS[@]}"; do
+          NON_SUCCESSFUL_JOBS=$(jq 'select(.name != $EXCLUDED_JOB)' <<< "$NON_SUCCESSFUL_JOBS")
+        done
+        
+        if [[ -n "$NON_SUCCESSFUL_JOBS" ]]; then
+          echo "The following jobs did not succeed:"
+          echo "$NON_SUCCESSFUL_JOBS"
+          exit 1
+        fi
+      shell: bash
+      env:
+        GH_TOKEN: ${{ inputs.token }}
+
+    - name: "Set Result"
+      if: always()
+      id: set-result
+      run: |
+        if [[ "${{ steps.find-run-id.outcome }}" != "success" ]]; then
+          echo "RESULT=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        
+        if [[ "${{ steps.check-run-jobs.outcome }}" != "success" ]]; then
+          echo "RESULT=false" >> $GITHUB_OUTPUT
+          exit 0
+        fi
+        
+        echo "RESULT=true" >> $GITHUB_OUTPUT
+      shell: bash
+
+    - name: "Print Action End"
+      if: always()
+      run: echo "<<<<< Finished Workflow Succeeded Action"
+      shell: bash

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -69,11 +69,7 @@ jobs:
         uses: ./.github/actions/pr-is-mergeable
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
-          excluded-check-runs: >
-            {
-              "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"],
-              "dependabot merger": []
-            }
+          excluded-check-runs: '{ "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"], "dependabot merger": [] }'
 
       - name: "Check Code Release Commit Continuous Integration"
         if: ${{ inputs.skip-pr-merge != 'true' }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -29,6 +29,7 @@ jobs:
       release-commit: ${{ steps.determine-branch-names.outputs.RELEASE_COMMIT }}
     permissions:
       pull-requests: read
+      contents: read
     runs-on: ubuntu-latest
     steps:
       - name: "Determine Branch Names"

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/pr-is-mergeable
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
-          excluded-check-runs: '{ "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"], "dependabot merger": [] }'
+          excluded-check-runs: '{ \"Continuous Integration\": [\"Run BlackDuck Scan\", \"Run Security Rating\"], \"dependabot merger\": [] }'
 
       - name: "Check Code Release Commit Continuous Integration"
         if: ${{ inputs.skip-pr-merge != 'true' }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -69,7 +69,7 @@ jobs:
         uses: ./.github/actions/pr-is-mergeable
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
-          excluded-check-runs: |
+          excluded-check-runs: >
             {
               "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"],
               "dependabot merger": []

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -61,8 +61,8 @@ jobs:
 
       - name: "Checkout Repository"
         uses: actions/checkout@v4
-        with:
-          ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
+#        with:
+#          ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
 
       - name: "Check Whether Code PR Can Be Merged"
         if: ${{ inputs.skip-pr-merge != 'true' }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -69,7 +69,11 @@ jobs:
         uses: ./.github/actions/pr-is-mergeable
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
-          excluded-check-runs: '{ \"Continuous Integration\": [\"Run BlackDuck Scan\", \"Run Security Rating\"], \"dependabot merger\": [] }'
+          excluded-check-runs: |
+            { 
+              \"Continuous Integration\": [\"Run BlackDuck Scan\", \"Run Security Rating\"], 
+              \"dependabot merger\": [] 
+            }
 
       - name: "Check Code Release Commit Continuous Integration"
         if: ${{ inputs.skip-pr-merge != 'true' }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -55,7 +55,9 @@ jobs:
           echo "CODE_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "DOCS_BRANCH_NAME=$DOCS_BRANCH" >> $GITHUB_OUTPUT
           echo "RELEASE_NOTES_BRANCH_NAME=$RELEASE_NOTES_BRANCH" >> $GITHUB_OUTPUT
-          echo "RELEASE_COMMIT=$(gh release view '$RELEASE_TAG' --repo "${{ github.repository }}" --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
+          echo "RELEASE_COMMIT=$(gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
+          
+          echo "[DEBUG] Current GITHUB_OUTPUT: '$(cat $GITHUB_OUTPUT)'"
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -71,8 +71,8 @@ jobs:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
           excluded-check-runs: |
             {
-              "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"],
-              "dependabot merger": []
+              'Continuous Integration': ['Run BlackDuck Scan', 'Run Security Rating'],
+              'dependabot merger': []
             }
 
       - name: "Check Code Release Commit Continuous Integration"

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -26,6 +26,7 @@ jobs:
       code-branch: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
       docs-branch: ${{ steps.determine-branch-names.outputs.DOCS_BRANCH_NAME }}
       release-notes-branch: ${{ steps.determine-branch-names.outputs.RELEASE_NOTES_BRANCH_NAME }}
+      release-commit: ${{ steps.determine-branch-names.outputs.RELEASE_COMMIT }}
     permissions:
       pull-requests: read
     runs-on: ubuntu-latest
@@ -53,6 +54,7 @@ jobs:
           echo "CODE_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "DOCS_BRANCH_NAME=$DOCS_BRANCH" >> $GITHUB_OUTPUT
           echo "RELEASE_NOTES_BRANCH_NAME=$RELEASE_NOTES_BRANCH" >> $GITHUB_OUTPUT
+          echo "RELEASE_COMMIT=$(gh release view '$RELEASE_TAG' --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 
@@ -66,6 +68,18 @@ jobs:
         uses: ./.github/actions/pr-is-mergeable
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
+          excluded-check-runs: |
+            {
+              "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"],
+              "dependabot merger": []
+            }
+
+      - name: "Check Code Release Commit Continuous Integration"
+        if: ${{ inputs.skip-pr-merge != 'true' }}
+        uses: ./.github/actions/workflow-succeeded
+        with:
+          workflow: "Continuous Integration"
+          sha: ${{ steps.determine-branch-names.outputs.RELEASE_COMMIT }}
 
       - name: "Check Whether Docs PR Can Be Merged"
         if: ${{ inputs.skip-pr-merge != 'true' }}
@@ -83,108 +97,108 @@ jobs:
           repo: ${{ env.DOCS_REPO }}
           token: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
 
-  release:
-    name: "Release"
-    needs: [ prerequisites ]
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write # needed to modify the release draft
-      pull-requests: write # needed to merge the release PR
-    steps:
-      - name: "Setup java"
-        uses: actions/setup-java@v4
-        with:
-          distribution: "temurin"
-          java-version: "17"
-          server-id: ossrh
-          server-username: MAVEN_CENTRAL_USER # env variable for username in deploy
-          server-password: MAVEN_CENTRAL_PASSWORD # env variable for token in deploy
-
-      - name: "Download Release Asset"
-        id: download-asset
-        run: |
-          gh release download ${{ needs.prerequisites.outputs.release-tag }} --dir ./ --repo "${{ github.repository }}"
-          # x=extract v=verbose z=decompress f=file C=destination directory
-          tar -xvzf apidocs-*.tar.gz -C .
-          tar -xvzf release-*.tar.gz -C .
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-
-      - name: "Import GPG Key"
-        run: |
-          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
-        env:
-          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-
-      - name: "Perform Release"
-        run: >
-          mvn
-          $MVN_CLI_ARGS
-          -DrepositoryId=local
-          -Durl=file:./temp_local_repo
-          -Dmaven.install.skip=true
-          -Dgpg.passphrase="$GPG_PASSPHRASE"
-          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
-          deploy
-
-          mvn
-          $MVN_CLI_ARGS
-          org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository
-          -DserverId=ossrh
-          -DnexusUrl=https://oss.sonatype.org
-          -DrepositoryDirectory=./temp_local_repo
-          -DstagingProfileId=$MAVEN_CENTRAL_PROFILE_ID
-        env:
-          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-          MAVEN_CENTRAL_PROFILE_ID: ${{ secrets.MAVEN_CENTRAL_PROFILE_ID }}
-          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-
-      - name: "Merge Code PR"
-        if: ${{ inputs.skip-pr-merge != 'true' }}
-        run: gh pr merge --squash "${{ needs.prerequisites.outputs.code-branch }}" --delete-branch --repo "${{ github.repository }}"
-        env:
-          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-
-      - name: "Publish the Draft Release"
-        run: gh release edit ${{ needs.prerequisites.outputs.release-tag }} --draft=false --repo "${{ github.repository }}"
-        env:
-          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-
-      - name: "Merge Docs PR"
-        if: ${{ inputs.skip-pr-merge != 'true' }}
-        run: gh pr merge --squash "${{ needs.prerequisites.outputs.docs-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"
-        env:
-          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-
-      - name: "Merge Release Notes PR"
-        if: ${{ inputs.skip-pr-merge != 'true' }}
-        run: |
-          # https://github.com/cli/cli/issues/8092#issuecomment-1814439651
-          # The Release Notes mergeability computation hasn't completed yet
-          # Because the base branch just changed from merging the Javadoc.
-          # Sleep and retry to work around "Base branch was modified." error.
-          for i in {1..3}; do
-            sleep 5
-            if gh pr merge --squash "${{ needs.prerequisites.outputs.release-notes-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"; then
-              exit 0
-            fi
-          done
-          exit 1
-        env:
-          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-
-  notify-job:
-    runs-on: ubuntu-latest
-    needs: [ prerequisites, release ]
-    if: ${{ failure() }}
-    steps:
-      - name: "Checkout"
-        uses: actions/checkout@v4
-      - name: "Notify"
-        run: python .pipeline/scripts/notify.py
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          WORKFLOW: ${{ github.workflow }}
-          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
-          BRANCH_NAME: ${{ needs.prerequisites.outputs.code-branch }}
+#  release:
+#    name: "Release"
+#    needs: [ prerequisites ]
+#    runs-on: ubuntu-latest
+#    permissions:
+#      contents: write # needed to modify the release draft
+#      pull-requests: write # needed to merge the release PR
+#    steps:
+#      - name: "Setup java"
+#        uses: actions/setup-java@v4
+#        with:
+#          distribution: "temurin"
+#          java-version: "17"
+#          server-id: ossrh
+#          server-username: MAVEN_CENTRAL_USER # env variable for username in deploy
+#          server-password: MAVEN_CENTRAL_PASSWORD # env variable for token in deploy
+#
+#      - name: "Download Release Asset"
+#        id: download-asset
+#        run: |
+#          gh release download ${{ needs.prerequisites.outputs.release-tag }} --dir ./ --repo "${{ github.repository }}"
+#          # x=extract v=verbose z=decompress f=file C=destination directory
+#          tar -xvzf apidocs-*.tar.gz -C .
+#          tar -xvzf release-*.tar.gz -C .
+#        env:
+#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+#
+#      - name: "Import GPG Key"
+#        run: |
+#          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
+#        env:
+#          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+#
+#      - name: "Perform Release"
+#        run: >
+#          mvn
+#          $MVN_CLI_ARGS
+#          -DrepositoryId=local
+#          -Durl=file:./temp_local_repo
+#          -Dmaven.install.skip=true
+#          -Dgpg.passphrase="$GPG_PASSPHRASE"
+#          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
+#          deploy
+#
+#          mvn
+#          $MVN_CLI_ARGS
+#          org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository
+#          -DserverId=ossrh
+#          -DnexusUrl=https://oss.sonatype.org
+#          -DrepositoryDirectory=./temp_local_repo
+#          -DstagingProfileId=$MAVEN_CENTRAL_PROFILE_ID
+#        env:
+#          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+#          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+#          MAVEN_CENTRAL_PROFILE_ID: ${{ secrets.MAVEN_CENTRAL_PROFILE_ID }}
+#          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+#
+#      - name: "Merge Code PR"
+#        if: ${{ inputs.skip-pr-merge != 'true' }}
+#        run: gh pr merge --squash "${{ needs.prerequisites.outputs.code-branch }}" --delete-branch --repo "${{ github.repository }}"
+#        env:
+#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+#
+#      - name: "Publish the Draft Release"
+#        run: gh release edit ${{ needs.prerequisites.outputs.release-tag }} --draft=false --repo "${{ github.repository }}"
+#        env:
+#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+#
+#      - name: "Merge Docs PR"
+#        if: ${{ inputs.skip-pr-merge != 'true' }}
+#        run: gh pr merge --squash "${{ needs.prerequisites.outputs.docs-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"
+#        env:
+#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+#
+#      - name: "Merge Release Notes PR"
+#        if: ${{ inputs.skip-pr-merge != 'true' }}
+#        run: |
+#          # https://github.com/cli/cli/issues/8092#issuecomment-1814439651
+#          # The Release Notes mergeability computation hasn't completed yet
+#          # Because the base branch just changed from merging the Javadoc.
+#          # Sleep and retry to work around "Base branch was modified." error.
+#          for i in {1..3}; do
+#            sleep 5
+#            if gh pr merge --squash "${{ needs.prerequisites.outputs.release-notes-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"; then
+#              exit 0
+#            fi
+#          done
+#          exit 1
+#        env:
+#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+#
+#  notify-job:
+#    runs-on: ubuntu-latest
+#    needs: [ prerequisites, release ]
+#    if: ${{ failure() }}
+#    steps:
+#      - name: "Checkout"
+#        uses: actions/checkout@v4
+#      - name: "Notify"
+#        run: python .pipeline/scripts/notify.py
+#        env:
+#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+#          WORKFLOW: ${{ github.workflow }}
+#          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
+#          BRANCH_NAME: ${{ needs.prerequisites.outputs.code-branch }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -71,8 +71,8 @@ jobs:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
           excluded-check-runs: |
             {
-              'Continuous Integration': ['Run BlackDuck Scan', 'Run Security Rating'],
-              'dependabot merger': []
+              "Continuous Integration": ["Run BlackDuck Scan", "Run Security Rating"],
+              "dependabot merger": []
             }
 
       - name: "Check Code Release Commit Continuous Integration"

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -70,7 +70,7 @@ jobs:
         with:
           pr-ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
           excluded-check-runs: |
-            { 
+            {
               \"Continuous Integration\": [\"Run BlackDuck Scan\", \"Run Security Rating\"], 
               \"dependabot merger\": [] 
             }
@@ -89,6 +89,10 @@ jobs:
           pr-ref: ${{ steps.determine-branch-names.outputs.DOCS_BRANCH_NAME }}
           repo: ${{ env.DOCS_REPO }}
           token: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+          excluded-check-runs: |
+            {
+              \"Build Cloud SDK Documentation\": [\"dependabot\"]
+            }
 
       - name: "Check Whether Release Notes PR Can Be Merged"
         if: ${{ inputs.skip-pr-merge != 'true' }}
@@ -97,6 +101,10 @@ jobs:
           pr-ref: ${{ steps.determine-branch-names.outputs.RELEASE_NOTES_BRANCH_NAME }}
           repo: ${{ env.DOCS_REPO }}
           token: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+          excluded-check-runs: |
+            {
+              \"Build Cloud SDK Documentation\": [\"dependabot\"]
+            }
 
 #  release:
 #    name: "Release"

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -63,8 +63,6 @@ jobs:
 
       - name: "Checkout Repository"
         uses: actions/checkout@v4
-#        with:
-#          ref: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
 
       - name: "Check Whether Code PR Can Be Merged"
         if: ${{ inputs.skip-pr-merge != 'true' }}

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -54,7 +54,7 @@ jobs:
           echo "CODE_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "DOCS_BRANCH_NAME=$DOCS_BRANCH" >> $GITHUB_OUTPUT
           echo "RELEASE_NOTES_BRANCH_NAME=$RELEASE_NOTES_BRANCH" >> $GITHUB_OUTPUT
-          echo "RELEASE_COMMIT=$(gh release view '$RELEASE_TAG' --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
+          echo "RELEASE_COMMIT=$(gh release view '$RELEASE_TAG' --repo "${{ github.repository }}" --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
         env:
           GH_TOKEN: ${{ github.token }}
 

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -106,108 +106,108 @@ jobs:
               \"Build Cloud SDK Documentation\": [\"dependabot\"]
             }
 
-#  release:
-#    name: "Release"
-#    needs: [ prerequisites ]
-#    runs-on: ubuntu-latest
-#    permissions:
-#      contents: write # needed to modify the release draft
-#      pull-requests: write # needed to merge the release PR
-#    steps:
-#      - name: "Setup java"
-#        uses: actions/setup-java@v4
-#        with:
-#          distribution: "temurin"
-#          java-version: "17"
-#          server-id: ossrh
-#          server-username: MAVEN_CENTRAL_USER # env variable for username in deploy
-#          server-password: MAVEN_CENTRAL_PASSWORD # env variable for token in deploy
-#
-#      - name: "Download Release Asset"
-#        id: download-asset
-#        run: |
-#          gh release download ${{ needs.prerequisites.outputs.release-tag }} --dir ./ --repo "${{ github.repository }}"
-#          # x=extract v=verbose z=decompress f=file C=destination directory
-#          tar -xvzf apidocs-*.tar.gz -C .
-#          tar -xvzf release-*.tar.gz -C .
-#        env:
-#          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-#
-#      - name: "Import GPG Key"
-#        run: |
-#          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
-#        env:
-#          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-#
-#      - name: "Perform Release"
-#        run: >
-#          mvn
-#          $MVN_CLI_ARGS
-#          -DrepositoryId=local
-#          -Durl=file:./temp_local_repo
-#          -Dmaven.install.skip=true
-#          -Dgpg.passphrase="$GPG_PASSPHRASE"
-#          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
-#          deploy
-#
-#          mvn
-#          $MVN_CLI_ARGS
-#          org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository
-#          -DserverId=ossrh
-#          -DnexusUrl=https://oss.sonatype.org
-#          -DrepositoryDirectory=./temp_local_repo
-#          -DstagingProfileId=$MAVEN_CENTRAL_PROFILE_ID
-#        env:
-#          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
-#          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
-#          MAVEN_CENTRAL_PROFILE_ID: ${{ secrets.MAVEN_CENTRAL_PROFILE_ID }}
-#          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
-#
-#      - name: "Merge Code PR"
-#        if: ${{ inputs.skip-pr-merge != 'true' }}
-#        run: gh pr merge --squash "${{ needs.prerequisites.outputs.code-branch }}" --delete-branch --repo "${{ github.repository }}"
-#        env:
-#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-#
-#      - name: "Publish the Draft Release"
-#        run: gh release edit ${{ needs.prerequisites.outputs.release-tag }} --draft=false --repo "${{ github.repository }}"
-#        env:
-#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-#
-#      - name: "Merge Docs PR"
-#        if: ${{ inputs.skip-pr-merge != 'true' }}
-#        run: gh pr merge --squash "${{ needs.prerequisites.outputs.docs-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"
-#        env:
-#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-#
-#      - name: "Merge Release Notes PR"
-#        if: ${{ inputs.skip-pr-merge != 'true' }}
-#        run: |
-#          # https://github.com/cli/cli/issues/8092#issuecomment-1814439651
-#          # The Release Notes mergeability computation hasn't completed yet
-#          # Because the base branch just changed from merging the Javadoc.
-#          # Sleep and retry to work around "Base branch was modified." error.
-#          for i in {1..3}; do
-#            sleep 5
-#            if gh pr merge --squash "${{ needs.prerequisites.outputs.release-notes-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"; then
-#              exit 0
-#            fi
-#          done
-#          exit 1
-#        env:
-#          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-#
-#  notify-job:
-#    runs-on: ubuntu-latest
-#    needs: [ prerequisites, release ]
-#    if: ${{ failure() }}
-#    steps:
-#      - name: "Checkout"
-#        uses: actions/checkout@v4
-#      - name: "Notify"
-#        run: python .pipeline/scripts/notify.py
-#        env:
-#          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-#          WORKFLOW: ${{ github.workflow }}
-#          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
-#          BRANCH_NAME: ${{ needs.prerequisites.outputs.code-branch }}
+  release:
+    name: "Release"
+    needs: [ prerequisites ]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed to modify the release draft
+      pull-requests: write # needed to merge the release PR
+    steps:
+      - name: "Setup java"
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: "17"
+          server-id: ossrh
+          server-username: MAVEN_CENTRAL_USER # env variable for username in deploy
+          server-password: MAVEN_CENTRAL_PASSWORD # env variable for token in deploy
+
+      - name: "Download Release Asset"
+        id: download-asset
+        run: |
+          gh release download ${{ needs.prerequisites.outputs.release-tag }} --dir ./ --repo "${{ github.repository }}"
+          # x=extract v=verbose z=decompress f=file C=destination directory
+          tar -xvzf apidocs-*.tar.gz -C .
+          tar -xvzf release-*.tar.gz -C .
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: "Import GPG Key"
+        run: |
+          echo "${{ secrets.PGP_PRIVATE_KEY }}" | gpg --batch --passphrase "$PASSPHRASE" --import
+        env:
+          PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+
+      - name: "Perform Release"
+        run: >
+          mvn
+          $MVN_CLI_ARGS
+          -DrepositoryId=local
+          -Durl=file:./temp_local_repo
+          -Dmaven.install.skip=true
+          -Dgpg.passphrase="$GPG_PASSPHRASE"
+          -Dgpg.keyname="$MAVEN_CENTRAL_USER"
+          deploy
+
+          mvn
+          $MVN_CLI_ARGS
+          org.sonatype.plugins:nexus-staging-maven-plugin:1.6.13:deploy-staged-repository
+          -DserverId=ossrh
+          -DnexusUrl=https://oss.sonatype.org
+          -DrepositoryDirectory=./temp_local_repo
+          -DstagingProfileId=$MAVEN_CENTRAL_PROFILE_ID
+        env:
+          MAVEN_CENTRAL_USER: ${{ secrets.MAVEN_CENTRAL_USER }}
+          MAVEN_CENTRAL_PASSWORD: ${{ secrets.MAVEN_CENTRAL_PASSWORD }}
+          MAVEN_CENTRAL_PROFILE_ID: ${{ secrets.MAVEN_CENTRAL_PROFILE_ID }}
+          GPG_PASSPHRASE: ${{ secrets.PGP_PASSPHRASE }}
+
+      - name: "Merge Code PR"
+        if: ${{ inputs.skip-pr-merge != 'true' }}
+        run: gh pr merge --squash "${{ needs.prerequisites.outputs.code-branch }}" --delete-branch --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+
+      - name: "Publish the Draft Release"
+        run: gh release edit ${{ needs.prerequisites.outputs.release-tag }} --draft=false --repo "${{ github.repository }}"
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+
+      - name: "Merge Docs PR"
+        if: ${{ inputs.skip-pr-merge != 'true' }}
+        run: gh pr merge --squash "${{ needs.prerequisites.outputs.docs-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+
+      - name: "Merge Release Notes PR"
+        if: ${{ inputs.skip-pr-merge != 'true' }}
+        run: |
+          # https://github.com/cli/cli/issues/8092#issuecomment-1814439651
+          # The Release Notes mergeability computation hasn't completed yet
+          # Because the base branch just changed from merging the Javadoc.
+          # Sleep and retry to work around "Base branch was modified." error.
+          for i in {1..3}; do
+            sleep 5
+            if gh pr merge --squash "${{ needs.prerequisites.outputs.release-notes-branch }}" --delete-branch --repo "${{ env.DOCS_REPO }}"; then
+              exit 0
+            fi
+          done
+          exit 1
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+
+  notify-job:
+    runs-on: ubuntu-latest
+    needs: [ prerequisites, release ]
+    if: ${{ failure() }}
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+      - name: "Notify"
+        run: python .pipeline/scripts/notify.py
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          WORKFLOW: ${{ github.workflow }}
+          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
+          BRANCH_NAME: ${{ needs.prerequisites.outputs.code-branch }}


### PR DESCRIPTION
This PR fixes [our `Perform Release`](https://github.com/SAP/cloud-sdk-java/actions/workflows/perform-release.yml) workflow in the following ways:

1. When we are checking, whether the Code PR (e.g. #408) is mergeable, we are now excluding the `BlackDuck Scan` and the `Run Security Rating` steps from the checks.
This is because the regular PR CI (which will be triggered on the commit that bumps the SDK's version to the next SNAPSHOT, i.e. the commit **after** the one that is to be released) won't run BlackDuck and the Security Rating.
Therefore, those steps will be skipped and should not be considered when we are verifying whether the PR is mergeable.
2. We are introducing a dedicated check to see whether [our `Continuous Integration`](https://github.com/SAP/cloud-sdk-java/actions/workflows/continuous-integration.yaml) workflow that was triggered **on the release commit** was successful.
In contrast to the CI run that is triggered on the "post release commit" (see above), this CI run **will execute** BlackDuck and Security Rating checks.
So it is crucial that all steps of that particular run succeed and nothing is (unexpectedly)  skipped.
3. We added a few excluded check runs (i.e. the `dependabot` part of [the `Build Cloud SDK Documentation`](https://github.com/SAP/cloud-sdk/actions/workflows/build_documentation.yml) workflow) when verifying whether the Docs and Release Notes PRs are mergeable.

These changes have successfully been tested (without actually performing the release) in [this run](https://github.com/SAP/cloud-sdk-java/actions/runs/8799062959/job/24147309509).