### PR TITLE
refactor: Dependabot Auto Merge GH Workflow

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -33,6 +33,8 @@ jobs:
           echo "PR_NUMBERS=$PR_NUMBERS" >> $GITHUB_OUTPUT
           
           echo "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
 
       - name: Approve and Merge Dependabot PRs
         run: |

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -1,41 +1,44 @@
 name: dependabot merger
 
 on:
-  pull_request:
-    branches: [ main ]
+  workflow_dispatch:
+  schedule:
+    - cron: '13 10 * * Mon' # trigger every Monday at 10:13, as our dependabot is configured to raise PRs every Monday at 8:00 a.m.
 
+env:
+  DEPENDABOT_GROUPS: |
+    production-minor-patch group
+    plugins group
+    test group
+    github-actions group
 jobs:
-  review-pr:
+  review-prs:
     runs-on: ubuntu-latest
-    if: ${{ github.actor == 'dependabot[bot]' &&
-      github.event_name == 'pull_request' }}
     permissions:
       pull-requests: write
       contents: write
     steps:
-      - name: dependabot metadata
-        id: metadata
-        uses: dependabot/fetch-metadata@v2.0.0
-        with:
-          github-token: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-      - name: "Prepare git"
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Find Dependabot PRs
+        id: find-prs
         run: |
-          git config --global user.email "cloudsdk@sap.com"
-          git config --global user.name "SAP Cloud SDK Bot"
-      - name: comment major updates
-        if : ${{steps.metadata.outputs.update-type == 'version-update:semver-major' }}
+          PRS=$(gh pr list --app "dependabot" --state "open" --json number,title)
+          PR_NUMBERS=
+          while IFS= read -r GROUP; do
+            MATCHES=$(jq -r --arg group "$GROUP" '.[] | select(.title | contains($group)) | .number' <<< "$PRS")
+            PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
+          done <<< "${{ env.DEPENDABOT_GROUPS }}"
+          echo "PR_NUMBERS=$PR_NUMBERS" >> $GITHUB_OUTPUT
+          
+          echo "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
+
+      - name: Approve and Merge Dependabot PRs
         run: |
-          gh pr comment $PR_URL --body "PR **not approved** because it includes a major update of a dependency"
-          gh pr edit $PR_URL --add-label "please review"
+          while IFS= read -r PR_NUMBER; do
+            gh pr merge "$PR_NUMBER" --auto --squash
+            gh pr review "$PR_NUMBER" --approve
+          done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '${{ steps.find-prs.outputs.PR_NUMBERS }}')"
         env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR}}
-      - name: approve and merge
-        if: ${{steps.metadata.outputs.update-type == 'version-update:semver-patch' ||
-          steps.metadata.outputs.update-type == 'version-update:semver-minor'}}
-        run: |
-          gh pr review --approve "$PR_URL"
-          gh pr merge --auto --squash "$PR_URL"
-        env:
-          PR_URL: ${{github.event.pull_request.html_url}}
-          GH_TOKEN: ${{secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR}}
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -35,7 +35,7 @@ jobs:
           
             PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
-          echo "[DEBUG] Approving and Merging following PRs: $(tr '\n' ' ' <<< '$PR_NUMBERS')"
+          echo "[DEBUG] Approving and Merging following PRs: '$PR_NUMBERS'"
           
           while IFS= read -r PR_NUMBER; do
             if [[ -z "$PR_NUMBER" ]]; then

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -21,8 +21,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Find Dependabot PRs
-        id: find-prs
+      - name: Approve and Merge PRs
         run: |
           PRS=$(gh pr list --app "dependabot" --state "open" --json number,title)
           PR_NUMBERS=
@@ -31,12 +30,7 @@ jobs:
             PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
           PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
-          echo "PR_NUMBERS='$PR_NUMBERS'" >> $GITHUB_OUTPUT
-        env:
-          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
-
-      - name: Approve and Merge Dependabot PRs
-        run: |
+          
           while IFS= read -r PR_NUMBER; do
             if [[ -z "$PR_NUMBER" ]]; then
               continue
@@ -44,6 +38,6 @@ jobs:
           
             gh pr merge "$PR_NUMBER" --auto --squash
             gh pr review "$PR_NUMBER" --approve
-          done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '${{ steps.find-prs.outputs.PR_NUMBERS }}')"
+          done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '$PR_NUMBERS')"
         env:
           GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -30,7 +30,8 @@ jobs:
             MATCHES=$(jq -r --arg group "$GROUP" '.[] | select(.title | contains($group)) | .number' <<< "$PRS")
             PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
-          echo "PR_NUMBERS=$PR_NUMBERS" >> $GITHUB_OUTPUT
+          PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
+          echo "PR_NUMBERS='$PR_NUMBERS'" >> $GITHUB_OUTPUT
           
           echo "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
         env:
@@ -39,6 +40,10 @@ jobs:
       - name: Approve and Merge Dependabot PRs
         run: |
           while IFS= read -r PR_NUMBER; do
+            if [[ -z "$PR_NUMBER" ]]; then
+              continue
+            fi
+          
             gh pr merge "$PR_NUMBER" --auto --squash
             gh pr review "$PR_NUMBER" --approve
           done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '${{ steps.find-prs.outputs.PR_NUMBERS }}')"

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -32,8 +32,6 @@ jobs:
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
           PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
           echo "PR_NUMBERS='$PR_NUMBERS'" >> $GITHUB_OUTPUT
-          
-          echo -e "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
         env:
           GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
 

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -45,6 +45,6 @@ jobs:
             echo "[DEBUG] Approving and Merging PR #$PR_NUMBER"
             gh pr merge "$PR_NUMBER" --auto --squash
             gh pr review "$PR_NUMBER" --approve
-          done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '$PR_NUMBERS')"
+          done <<< "$PR_NUMBERS"
         env:
           GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -31,11 +31,14 @@ jobs:
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
           PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
           
+          echo "[DEBUG] Approving and Merging following PRs: $(tr '\n' ' ' <<< '$PR_NUMBERS')"
+          
           while IFS= read -r PR_NUMBER; do
             if [[ -z "$PR_NUMBER" ]]; then
               continue
             fi
-          
+            
+            echo "[DEBUG] Approving and Merging PR #$PR_NUMBER"
             gh pr merge "$PR_NUMBER" --auto --squash
             gh pr review "$PR_NUMBER" --approve
           done <<< "$(grep --extended-regexp --ignore-case '[0-9]+' <<< '$PR_NUMBERS')"

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -27,6 +27,8 @@ jobs:
           PR_NUMBERS=
           while IFS= read -r GROUP; do
             MATCHES=$(jq -r --arg group "$GROUP" '.[] | select(.title | contains($group)) | .number' <<< "$PRS")
+            echo "[DEBUG] Found PRs for group '$GROUP': '$MATCHES'"
+          
             PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
           PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -33,7 +33,7 @@ jobs:
           PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
           echo "PR_NUMBERS='$PR_NUMBERS'" >> $GITHUB_OUTPUT
           
-          echo "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
+          echo -e "[DEBUG] PR_NUMBERS='$PR_NUMBERS'"
         env:
           GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
 

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -26,13 +26,15 @@ jobs:
           PRS=$(gh pr list --app "dependabot" --state "open" --json number,title)
           PR_NUMBERS=
           while IFS= read -r GROUP; do
+            if [[ -z "$GROUP" ]]; then
+              continue
+            fi
+          
             MATCHES=$(jq -r --arg group "$GROUP" '.[] | select(.title | contains($group)) | .number' <<< "$PRS")
             echo "[DEBUG] Found PRs for group '$GROUP': '$MATCHES'"
           
             PR_NUMBERS="$MATCHES"$'\n'"$PR_NUMBERS"
           done <<< "${{ env.DEPENDABOT_GROUPS }}"
-          PR_NUMBERS=$(sort --unique <<< "$PR_NUMBERS")
-          
           echo "[DEBUG] Approving and Merging following PRs: $(tr '\n' ' ' <<< '$PR_NUMBERS')"
           
           while IFS= read -r PR_NUMBER; do


### PR DESCRIPTION
This PR refactors our automated PR merging for Dependabot PRs in a way that the workflow is triggered on a schedule (every Monday, after Dependabot might have opened new PRs) instead of triggering right after the PR creation.

The old approach has shown to be non-functioning as the workflow was triggered by an external user (i.e. Dependabot), which (we assume) prevented the workflow from accessing any our secrets.
As a consequence, the workflow always failed.

This updated approach does not run into that issue as the workflow is not triggered by an external user.
So we can safely access all of our secrets.

The updated workflow has been tested here: [Workflow Run](https://github.com/SAP/cloud-sdk-java/actions/runs/8878953514/job/24375619632)