### PR TITLE
feat: Cron Workflow to Update Maven Dependency Cache

### DIFF
--- a/.github/workflows/cache-maven-dependencies.yaml
+++ b/.github/workflows/cache-maven-dependencies.yaml
@@ -1,6 +1,9 @@
 name: "Cache Maven Dependencies"
 
 on:
+  pull_request:
+    branches:
+      - main
   workflow_dispatch:
   schedule:
       - cron: '57 4 * * Sun'

--- a/.github/workflows/cache-maven-dependencies.yaml
+++ b/.github/workflows/cache-maven-dependencies.yaml
@@ -1,0 +1,45 @@
+name: "Cache Maven Dependencies"
+
+on:
+  workflow_dispatch:
+  schedule:
+      - cron: '57 4 * * Sun'
+
+env:
+  MAVEN_CACHE_REF: refs/heads/main
+  MAVEN_CACHE_KEY: maven-dependencies
+  MAVEN_CACHE_DIR: ~/.m2/repository
+
+jobs:
+  update-cache:
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Checkout"
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.MAVEN_CACHE_REF }}
+
+      - name: "Setup Java"
+        uses: actions/setup-java@v4
+        with:
+          distribution: "temurin"
+          java-version: 17
+
+      - name: "Download Dependencies"
+        run: mvn -B dependency:go-offline
+
+      - name: "Delete Existing Caches"
+        run: |
+          CACHE_IDS=$(gh cache list --key "${{ env.MAVEN_CACHE_KEY }}" --ref "${{ env.MAVEN_CACHE_REF }}" --json id | jq -r '.[] | .id')
+          for CACHE_ID in $CACHE_IDS; do
+              echo "Deleting cache with ID: $CACHE_ID"
+              gh cache delete "${CACHE_ID}"
+          done
+        env:
+          GH_TOKEN: ${{ secrets.BOT_SDK_JS_FOR_DOCS_REPO_PR }}
+
+      - name: "Cache Dependencies"
+        uses: actions/cache/save@v4
+        with:
+          path: ${{ env.MAVEN_CACHE_DIR }}
+          key: ${{ env.MAVEN_CACHE_KEY }}

--- a/.github/workflows/cache-maven-dependencies.yaml
+++ b/.github/workflows/cache-maven-dependencies.yaml
@@ -1,9 +1,6 @@
 name: "Cache Maven Dependencies"
 
 on:
-  pull_request:
-    branches:
-      - main
   workflow_dispatch:
   schedule:
       - cron: '57 4 * * Sun'
@@ -11,7 +8,7 @@ on:
 env:
   MAVEN_CACHE_REF: refs/heads/main
   MAVEN_CACHE_KEY: maven-dependencies
-  MAVEN_CACHE_DIR: ~/.m2/repository
+  MAVEN_CACHE_DIR: ~/.m2
 
 jobs:
   update-cache:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -40,11 +40,10 @@ env:
   SDK_TARGETS_NAME: "sdk-targets" # used for the SDK's target directories
   SDK_TARGETS_PATH: |
     ./**/target/**
-  DEPENDENCIES_CACHE_KEY: "dependencies"
-  DEPENDENCIES_PATH: |
-    ~/.m2/repository/**
-    !~/.m2/repository/archetype-catalog.xml
-    !~/.m2/repository/com/sap/cloud/sdk/**
+
+  # keep the following two variables in sync with our 'cache-maven-dependencies.yaml' workflow
+  MAVEN_CACHE_KEY: maven-dependencies
+  MAVEN_CACHE_DIR: ~/.m2/repository
 
   MVN_MULTI_THREADED_ARGS: --batch-mode --fail-at-end --show-version --threads 1C
   MVN_SINGLE_THREADED_ARGS: --batch-mode --fail-at-end --show-version --threads 1
@@ -117,8 +116,8 @@ jobs:
         id: restore-dependencies
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
-          path: ${{ env.DEPENDENCIES_PATH }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
+          path: ${{ env.MAVEN_CACHE_DIR }}
 
       - name: "Build SDK"
         run: |
@@ -153,8 +152,8 @@ jobs:
         if: ${{ steps.restore-dependencies.outputs.cache-hit != 'true' }}
         uses: actions/cache/save@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
-          path: ${{ env.DEPENDENCIES_PATH }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
+          path: ${{ env.MAVEN_CACHE_DIR }}
 
       - name: "Build Module Inventory"
         run: >
@@ -212,7 +211,7 @@ jobs:
         id: restore-dependencies
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
           path: ${{ env.M2_ROOT }}
       - name: "Restore SDK M2"
         uses: actions/download-artifact@v4
@@ -275,7 +274,7 @@ jobs:
         id: restore-dependencies
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
           path: ${{ env.M2_ROOT }}
       - name: "Restore SDK M2"
         uses: actions/download-artifact@v4
@@ -314,8 +313,8 @@ jobs:
         id: restore-dependencies
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
-          path: ${{ env.DEPENDENCIES_PATH }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
+          path: ${{ env.MAVEN_CACHE_DIR }}
 
       - name: "Initialize CodeQL"
         uses: github/codeql-action/init@v3
@@ -357,8 +356,8 @@ jobs:
         id: restore-dependencies
         uses: actions/cache/restore@v4
         with:
-          key: ${{ env.DEPENDENCIES_CACHE_KEY }}
-          path: ${{ env.DEPENDENCIES_PATH }}
+          key: ${{ env.MAVEN_CACHE_KEY }}
+          path: ${{ env.MAVEN_CACHE_DIR }}
       - name: "Restore SDK M2"
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -43,10 +43,10 @@ env:
 
   # keep the following two variables in sync with our 'cache-maven-dependencies.yaml' workflow
   MAVEN_CACHE_KEY: maven-dependencies
-  MAVEN_CACHE_DIR: ~/.m2/repository
+  MAVEN_CACHE_DIR: ~/.m2
 
-  MVN_MULTI_THREADED_ARGS: --batch-mode --fail-at-end --show-version --threads 1C
-  MVN_SINGLE_THREADED_ARGS: --batch-mode --fail-at-end --show-version --threads 1
+  MVN_MULTI_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1C
+  MVN_SINGLE_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1
   MVN_SKIP_CI_PLUGINS: -DskipFormatting -Denforcer.skip -Djacoco.skip -Dmdep.analyze.skip
 
 jobs:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -148,13 +148,6 @@ jobs:
             echo "[DEBUG] Skipping release artifact generation"
           fi
 
-      - name: "Cache Dependencies"
-        if: ${{ steps.restore-dependencies.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v4
-        with:
-          key: ${{ env.MAVEN_CACHE_KEY }}
-          path: ${{ env.MAVEN_CACHE_DIR }}
-
       - name: "Build Module Inventory"
         run: >
           python ./scripts/create_module_inventory_file.py 

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
 		<wiremock.version>3.5.4</wiremock.version>
 		<checkstyle.version>8.41</checkstyle.version>
 		<kotlin.version>1.9.23</kotlin.version>
-		<byte-buddy.version>1.14.13</byte-buddy.version>
+		<byte-buddy.version>1.14.14</byte-buddy.version>
 		<jsr305.optional>true</jsr305.optional>
 	</properties>
 	<dependencyManagement>


### PR DESCRIPTION
This PR introduces a new GH workflow that periodically (once per week) updates our cached Maven Dependencies.
That way, we are making sure that our cache is never older than 1 week, which reduces the amount of non-up-to-date dependencies in our `Continuous Integration` runs.