### PR TITLE
chore: [Destinations] Improve Header Provider Error Handling

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -194,7 +194,7 @@ public final class DefaultHttpDestination implements HttpDestination
         final DestinationRequestContext requestContext = new DestinationRequestContext(this, requestUri);
 
         final List<Header> result = new ArrayList<>();
-        for( DestinationHeaderProvider headerProvider : aggregatedHeaderProviders ) {
+        for( final DestinationHeaderProvider headerProvider : aggregatedHeaderProviders ) {
             try {
                 result.addAll(headerProvider.getHeaders(requestContext));
             }

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -17,7 +17,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.function.Function;
-import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
@@ -194,11 +193,19 @@ public final class DefaultHttpDestination implements HttpDestination
 
         final DestinationRequestContext requestContext = new DestinationRequestContext(this, requestUri);
 
-        return aggregatedHeaderProviders
-            .stream()
-            .map(headerProvider -> headerProvider.getHeaders(requestContext))
-            .flatMap(List::stream)
-            .collect(Collectors.toList());
+        final List<Header> result = new ArrayList<>();
+        for( DestinationHeaderProvider headerProvider : aggregatedHeaderProviders ) {
+            try {
+                result.addAll(headerProvider.getHeaders(requestContext));
+            }
+            catch( Exception e ) {
+                final String err =
+                    "Header provider '%s' threw an exception: %s"
+                        .formatted(headerProvider.getClass().getSimpleName(), e.getMessage());
+                throw new DestinationAccessException(err, e);
+            }
+        }
+        return result;
     }
 
     private Collection<Header> getHeadersForAuthType()

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -198,7 +198,7 @@ public final class DefaultHttpDestination implements HttpDestination
             try {
                 result.addAll(headerProvider.getHeaders(requestContext));
             }
-            catch( Exception e ) {
+            catch( final Exception e ) {
                 final String err =
                     "Header provider '%s' threw an exception: %s"
                         .formatted(headerProvider.getClass().getSimpleName(), e.getMessage());

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProviderTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProviderTest.java
@@ -5,6 +5,7 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import java.net.URI;
 import java.util.ArrayList;
@@ -16,6 +17,8 @@ import java.util.List;
 import javax.annotation.Nonnull;
 
 import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 
 import io.vavr.control.Option;
 
@@ -66,6 +69,24 @@ class DestinationHeaderProviderTest
         final Collection<Header> actualHeader = destination.getHeaders();
 
         assertThat(actualHeader).contains(TEST_HEADER);
+    }
+
+    @Test
+    void testExceptionsAreHandled()
+    {
+        final DestinationHeaderProvider failingProvider = ( any ) -> {
+            throw new RuntimeException("Test exception");
+        };
+
+        final DefaultHttpDestination sut =
+            DefaultHttpDestination.builder("bar").headerProviders(failingProvider).build();
+
+        assertThatThrownBy(sut::getHeaders)
+            .isInstanceOf(DestinationAccessException.class)
+            .hasRootCauseInstanceOf(RuntimeException.class)
+            .hasMessage(
+                "Header provider '%s' threw an exception: Test exception",
+                failingProvider.getClass().getSimpleName());
     }
 
     public static class TestDestinationHeaderProvider implements DestinationHeaderProvider

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
-import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -37,7 +36,7 @@ import com.google.common.collect.ImmutableMap;
 import com.sap.cloud.environment.servicebinding.api.DefaultServiceBindingBuilder;
 import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.ServiceIdentifier;
-import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceRuntimeException;
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.security.AuthToken;
 import com.sap.cloud.sdk.cloudplatform.security.ClientCredentials;
 import com.sap.cloud.sdk.testutil.TestContext;

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectivityServiceTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 
 import javax.annotation.Nonnull;
 
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.RegisterExtension;
@@ -231,8 +232,8 @@ class ConnectivityServiceTest
         assertThat(dest).isNotNull();
 
         assertThatCode(dest::getHeaders)
+            .isInstanceOf(DestinationAccessException.class)
             .hasMessageEndingWith("Failed to resolve access token.")
-            .isInstanceOf(ResilienceRuntimeException.class)
             .hasRootCauseInstanceOf(OAuth2ServiceException.class);
     }
 

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServicePrincipalPropagationTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServicePrincipalPropagationTest.java
@@ -124,8 +124,9 @@ class DestinationServicePrincipalPropagationTest
         // assertions
         assertThat(result).isInstanceOf(DefaultHttpDestination.class);
         assertThatThrownBy(((DefaultHttpDestination) result)::getHeaders)
-            .isInstanceOf(AuthTokenAccessException.class)
-            .hasMessage("Failed to get current authorization token.");
+            .isInstanceOf(DestinationAccessException.class)
+            .hasMessageContaining("Failed to get current authorization token.")
+            .hasCauseInstanceOf(AuthTokenAccessException.class);
 
         // assert mocks
         verify(destinationServiceAdapter)
@@ -184,8 +185,9 @@ class DestinationServicePrincipalPropagationTest
         // assertion
         assertThat(result).isInstanceOf(DefaultHttpDestination.class);
         assertThatThrownBy(((DefaultHttpDestination) result)::getHeaders)
-            .isInstanceOf(IllegalStateException.class)
-            .hasMessage(
+            .isInstanceOf(DestinationAccessException.class)
+            .hasCauseInstanceOf(IllegalStateException.class)
+            .hasMessageContaining(
                 "Tenant ID of destination 'test' does not match the current tenant ID. Destination was created specifically for tenant '', but the current tenant is 'subscriber'.");
 
         // assert mocks
@@ -297,7 +299,7 @@ class DestinationServicePrincipalPropagationTest
             final Consumer<Try<Collection<Header>>> assertHeaders = headers -> {
                 final String descr = "Expecting header error for dest tenant %s, runtime tenant %s and strategy %s.";
                 assertThat(headers).describedAs(descr, destinationTenant, runtimeTenant, strategy).isEmpty();
-                assertThat(headers.getCause()).isInstanceOf(IllegalStateException.class);
+                assertThat(headers.getCause()).hasCauseInstanceOf(IllegalStateException.class);
             };
             return new Case(destinationTenant, runtimeTenant, options.build(), assertDestination, assertHeaders);
         }


### PR DESCRIPTION
## Context

Minor improvement to the readability of stack traces produced by errors from header providers (e.g. on-prem headers failed)


<details><summary>Before:</summary>

```
java.lang.RuntimeException: Test exception

	at com.sap.cloud.sdk.cloudplatform.connectivity.DestinationHeaderProviderTest.lambda$testExceptionsAreHandled$4(DestinationHeaderProviderTest.java:75)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.lambda$getHeadersFromHeaderProviders$1(DefaultHttpDestination.java:199)
	at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:197)
	at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1625)
	at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:509)
	at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:499)
	at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:921)
	at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)
	at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:682)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.getHeadersFromHeaderProviders(DefaultHttpDestination.java:201)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.getHeaders(DefaultHttpDestination.java:175)
	at com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestinationProperties.getHeaders(HttpDestinationProperties.java:52)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DestinationHeaderProviderTest.testExceptionsAreHandled(DestinationHeaderProviderTest.java:81)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
```

</details>

<details><summary>After:</summary>

```
com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException: Header provider 'DestinationHeaderProviderTest$$Lambda$368/0x000000080014e130' threw an exception: Test exception
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.getHeadersFromHeaderProviders(DefaultHttpDestination.java:205)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.getHeaders(DefaultHttpDestination.java:174)
	at com.sap.cloud.sdk.cloudplatform.connectivity.HttpDestinationProperties.getHeaders(HttpDestinationProperties.java:52)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DestinationHeaderProviderTest.testExceptionsAreHandled(DestinationHeaderProviderTest.java:84)
	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
	at java.base/java.util.ArrayList.forEach(ArrayList.java:1511)
Caused by: java.lang.RuntimeException: Test exception
	at com.sap.cloud.sdk.cloudplatform.connectivity.DestinationHeaderProviderTest.lambda$testExceptionsAreHandled$4(DestinationHeaderProviderTest.java:78)
	at com.sap.cloud.sdk.cloudplatform.connectivity.DefaultHttpDestination.getHeadersFromHeaderProviders(DefaultHttpDestination.java:199)
	... 6 more
```

</details>

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

