### PR TITLE
fix: AuthToken Regression

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -32,3 +32,4 @@
 ### 🐛 Fixed Issues
 
 - Fix a regression that was introduced with the SAP Cloud SDK 5.0 release where the principal would no longer be derived from a `Basic` authorization header, in cases where neither a JWT nor an OIDC token was present.
+- Fix a regression that was introduced with the SAP Cloud SDK 5.0 release where auth tokens sent by the Destination service would no longer be stored in the `cloudsdk.authTokens` destination property for non-HTTP destinations.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

fixes #428 


This PR fixes a regression where auth token sent by the Destination service wouldn't be stored in the `cloudsdk.authTokens` (`DestinationProperty.AUTH_TOKENS`) property for non-HTTP destinations.

### Feature scope:
 
- [x] fix regression

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
