### PR TITLE
Add comment about `ConnectionManager` cardinality in `AbstractHttpClientFactory`

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientFactory.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientFactory.java
@@ -128,6 +128,10 @@ public abstract class AbstractHttpClientFactory implements HttpClientFactory
 
     /**
      * Get the connection manager for the HTTP client builder.
+     * <p>
+     * <strong>Note:</strong> Since the destination may have custom TLS/SSL settings, the returned connection manager
+     * shall not be cached or reused. As a result the cardinality is: One {@code HttpClient} to one
+     * {@code HttpClientConnectionManager}.
      *
      * @param destination
      *            The optional destination reference.


### PR DESCRIPTION
I was wondering why this was part of the `HttpClientWrapper`, when I realized - most likely we do not and cannot reuse connection manager between multiple instances of `HttpClient`:

https://github.com/SAP/cloud-sdk-java/blob/f0dd44016892ef1f1fbd758b83c84d00948f9854/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientWrapper.java#L38-L48

To address this in the source code, I want to add a comment.