### PR TITLE
Revert openapi-generator to 7.4.0

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: "Verify Local Changes"
         run: |
           CHANGED_FILES="$(git --no-pager diff --name-only)"
-          if [[ "$CHANGED_FILES" ]]; then
+          if [[ ! -n "$CHANGED_FILES" ]]; then
               echo "There are local changes in the following files:"
               echo "$CHANGED_FILES"
               echo "Printing the git diff:"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: "Verify Local Changes"
         run: |
           CHANGED_FILES="$(git --no-pager diff --name-only)"
-          if [[ ! -z "$CHANGED_FILES" ]]; then
+          if [[ "$CHANGED_FILES" ]]; then
               echo "There are local changes in the following files:"
               echo "$CHANGED_FILES"
               echo "Printing the git diff:"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: "Verify Local Changes"
         run: |
           CHANGED_FILES="$(git --no-pager diff --name-only)"
-          if [[ -n "$CHANGED_FILES" ]]; then
+          if [ -n "$CHANGED_FILES" ]; then
               echo "There are local changes in the following files:"
               echo "$CHANGED_FILES"
               echo "Printing the git diff:"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -158,7 +158,7 @@ jobs:
       - name: "Verify Local Changes"
         run: |
           CHANGED_FILES="$(git --no-pager diff --name-only)"
-          if [[ ! -n "$CHANGED_FILES" ]]; then
+          if [[ -n "$CHANGED_FILES" ]]; then
               echo "There are local changes in the following files:"
               echo "$CHANGED_FILES"
               echo "Printing the git diff:"

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/model/RootObject.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/model/RootObject.java
@@ -50,7 +50,7 @@ public class RootObject
 // CHECKSTYLE:ON
 {
   @JsonProperty("questions")
-  private List<RootObjectQuestionsInner> questions = new ArrayList<>();
+  private List<RootObjectQuestionsInner> questions;
 
   @JsonAnySetter
   @JsonAnyGetter
@@ -67,11 +67,11 @@ public class RootObject
     return this;
   }
   /**
-  * Add one questions instance to this {@link RootObject}.
-  * @param questionsItem The questions that should be added
+  * Add one Questions instance to this {@link RootObject}.
+  * @param questionsItem The Questions that should be added
   * @return The same instance of type {@link RootObject}
   */
-  @Nonnull public RootObject addquestionsItem( @Nonnull final RootObjectQuestionsInner questionsItem) {
+  @Nonnull public RootObject addQuestionsItem( @Nonnull final RootObjectQuestionsInner questionsItem) {
     if (this.questions == null) {
       this.questions = new ArrayList<>();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<caffeine.version>3.1.8</caffeine.version>
-		<openapi-generator.version>7.4.0</openapi-generator.version>
+		<openapi-generator.version>7.5.0</openapi-generator.version>
 		<io-swagger-core-v3.version>2.1.13</io-swagger-core-v3.version>
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<caffeine.version>3.1.8</caffeine.version>
-		<openapi-generator.version>7.5.0</openapi-generator.version>
+		<openapi-generator.version>7.4.0</openapi-generator.version>
 		<io-swagger-core-v3.version>2.1.13</io-swagger-core-v3.version>
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,7 +109,7 @@
 		<maven-plugin-annotations.version>3.13.0</maven-plugin-annotations.version>
 		<maven-plugin-testing.version>3.3.0</maven-plugin-testing.version>
 		<caffeine.version>3.1.8</caffeine.version>
-		<openapi-generator.version>7.6.0</openapi-generator.version>
+		<openapi-generator.version>7.5.0</openapi-generator.version>
 		<io-swagger-core-v3.version>2.1.13</io-swagger-core-v3.version>
 		<io-swagger-core.version>1.6.11</io-swagger-core.version>
 		<!--  sync plexus version with transitive dependency coming from "org.twadata.maven:mojo-executor"  -->


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#447

The last OpenAPI update introduced breaking changes on generated files.
The pipeline step "Verify Local Changes" did not notice the changes, meaning the 5.9.0 release introduced breaking changes

### Feature scope:

- [x] Revert openapi-generator from 7.6.0 to 7.4.0
- [ ] Fix "Verify Local Changes" step in pipeline: it now fails
