### PR TITLE
feat: Support ZTIS with XSUAA

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -111,7 +111,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
     @Nonnull
     public URI getTokenUri()
     {
-        final String tokenUrlProperty = switch(getCredentialType()) {
+        final String tokenUrlProperty = switch( getCredentialType() ) {
             case X509, X509_GENERATED, X509_PROVIDED, X509_ATTESTED -> "certurl";
             case BINDING_SECRET, INSTANCE_SECRET -> "url";
         };
@@ -129,7 +129,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
             case X509_ATTESTED -> getZtisIdentity(clientid);
             case BINDING_SECRET, INSTANCE_SECRET -> getSecretIdentity(clientid);
             case X509_PROVIDED -> throw new DestinationAccessException(
-                "Credential type X509_PROVIDED is not supported. Please use X509_ATTESTED instead.");
+                "Credential type X509_PROVIDED is not supported. Please use X509_GENERATED or X509_ATTESTED instead.");
         };
     }
 
@@ -189,8 +189,11 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
     CredentialType getCredentialType()
     {
         return getOAuthCredential(CredentialType.class, "credential-type")
-                .onEmpty(() -> log.warn("Credential type not found or not recognised in service binding. Defaulting to BINDING_SECRET."))
-                .getOrElse(CredentialType.BINDING_SECRET);
+            .onEmpty(
+                () -> log
+                    .warn(
+                        "Credential type not found or not recognised in service binding. Defaulting to BINDING_SECRET."))
+            .getOrElse(CredentialType.BINDING_SECRET);
     }
 
     /**

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -110,6 +110,9 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
     public URI getTokenUri()
     {
         final String tokenUrlProperty = switch( getCredentialType() ) {
+            // note: this is for XSUAA only and does not apply for IAS (check the overridden method in the property supplier for IAS)
+            // currently XSUAA only recognizes X509 and X509_ATTESTED, so we don't necessarily have to list X509_PROVIDED and X509_GENERATED here
+            // still, doesn't hurt and is more future-proof in case XSUAA ever starts adopting these identifiers
             case X509, X509_GENERATED, X509_PROVIDED, X509_ATTESTED -> "certurl";
             case BINDING_SECRET, INSTANCE_SECRET -> "url";
         };

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -4,8 +4,6 @@
 
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import static com.sap.cloud.sdk.cloudplatform.connectivity.SecurityLibWorkarounds.X509_ATTESTED;
-
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.security.KeyStore;
@@ -125,9 +123,9 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
         final String clientid = getOAuthCredentialOrThrow(String.class, "clientid");
 
         return switch( getCredentialType() ) {
+            case BINDING_SECRET, INSTANCE_SECRET -> getSecretIdentity(clientid);
             case X509, X509_GENERATED -> getCertificateIdentity(clientid);
             case X509_ATTESTED -> getZtisIdentity(clientid);
-            case BINDING_SECRET, INSTANCE_SECRET -> getSecretIdentity(clientid);
             case X509_PROVIDED -> throw new DestinationAccessException(
                 "Credential type X509_PROVIDED is not supported. Please use X509_GENERATED or X509_ATTESTED instead.");
         };

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -139,7 +139,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
         final String clientid = getOAuthCredentialOrThrow(String.class, "clientid");
 
         final Option<String> exactCredentialType = getOAuthCredential(String.class, "credential-type");
-        if( exactCredentialType.contains(X509_ATTESTED) ) {
+        if( exactCredentialType.isDefined() && X509_ATTESTED.equalsIgnoreCase(exactCredentialType.get()) ) {
             return getZtisClientIdentity(clientid);
         }
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
@@ -39,7 +39,6 @@ final class SecurityLibWorkarounds
         if( rawType.equalsIgnoreCase(X509_GENERATED)
             || rawType.equalsIgnoreCase(X509_ATTESTED)
             || rawType.equalsIgnoreCase(X509_PROVIDED) ) {
-            // these particular credential types are only supported by the Security Client Lib > 3.3.5
             return CredentialType.X509;
         }
         return null;

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
@@ -21,6 +21,7 @@ final class SecurityLibWorkarounds
 {
     private static final String X509_GENERATED = "X509_GENERATED";
     static final String X509_ATTESTED = "X509_ATTESTED";
+    static final String X509_PROVIDED = "X509_PROVIDED";
 
     private SecurityLibWorkarounds()
     {
@@ -30,12 +31,18 @@ final class SecurityLibWorkarounds
     @Nullable
     static CredentialType getCredentialType( @Nonnull final String rawType )
     {
-        if( rawType.equals(X509_GENERATED) || rawType.equals(X509_ATTESTED) ) {
+        final CredentialType maybeType = CredentialType.from(rawType);
+        if( maybeType != null ) {
+            return maybeType;
+        }
+        // Workaround for the Security Client Lib <= 3.3.5 which does not recognise X509_GENERATED, X509_PROVIDED and X509_ATTESTED.
+        if( rawType.equalsIgnoreCase(X509_GENERATED)
+            || rawType.equalsIgnoreCase(X509_ATTESTED)
+            || rawType.equalsIgnoreCase(X509_PROVIDED) ) {
             // these particular credential types are only supported by the Security Client Lib > 3.3.5
             return CredentialType.X509;
         }
-
-        return CredentialType.from(rawType);
+        return null;
     }
 
     @Getter

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -116,7 +116,7 @@ class BtpServicePropertySuppliersTest
         private static final ServiceBinding X509_BINDING =
             bindingWithCredentials(
                 ServiceIdentifier.of("xsuaa"),
-                entry("credential-type", "x509"),
+                entry("credential-type", "x509_generated"),
                 entry("clientid", "client-id"),
                 entry("key", "key"),
                 entry("certificate", "certificate"),

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
@@ -157,7 +157,7 @@ class DefaultOAuth2PropertySupplierTest
     {
         final ServiceBinding binding =
             new ServiceBindingBuilder(ServiceIdentifier.of("testX509_attested"))
-                .with("credentials.uaa.credential-type", "X509_ATTESTED")
+                .with("credentials.uaa.credential-type", "X509_AttEsTEd") // should be case-insensitive
                 .with("credentials.uaa.clientid", "id")
                 .build();
         final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
@@ -52,7 +52,7 @@ class DefaultOAuth2PropertySupplierTest
 
         assertThat(convert(CredentialType.X509, CredentialType.class)).isEqualTo(CredentialType.X509);
         assertThat(convert(CredentialType.X509.toString(), CredentialType.class)).isEqualTo(CredentialType.X509);
-        assertThat(convert("X509_GENERATED", CredentialType.class)).isEqualTo(CredentialType.X509);
+        assertThat(convert("X509_GENERATED", CredentialType.class)).isEqualTo(CredentialType.X509_GENERATED);
         assertThatThrownBy(() -> convert("not a valid credential type", CredentialType.class))
             .isExactlyInstanceOf(DestinationAccessException.class)
             .hasCauseExactlyInstanceOf(IllegalArgumentException.class);
@@ -153,6 +153,45 @@ class DefaultOAuth2PropertySupplierTest
     }
 
     @Test
+    void testCredentialTypeX509Generated()
+    {
+        final ServiceBinding binding =
+            new ServiceBindingBuilder(ServiceIdentifier.of("testX509"))
+                .with("credentials.uaa.credential-type", "X509_GENERATED")
+                .with("credentials.uaa.clientid", "id")
+                .with("credentials.uaa.certificate", "cert")
+                .with("credentials.uaa.key", "key")
+                .build();
+        final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();
+
+        sut = new DefaultOAuth2PropertySupplier(options);
+
+        assertThat(sut.getCredentialType()).isEqualTo(CredentialType.X509_GENERATED);
+        assertThat(sut.getClientIdentity()).isInstanceOfSatisfying(ClientCertificate.class, cc -> {
+            assertThat(cc.getId()).isEqualTo("id");
+            assertThat(cc.getCertificate()).isEqualTo("cert");
+            assertThat(cc.getKey()).isEqualTo("key");
+        });
+    }
+
+    @Test
+    void testCredentialTypeX509Provided()
+    {
+        final ServiceBinding binding =
+            new ServiceBindingBuilder(ServiceIdentifier.of("testX509"))
+                .with("credentials.uaa.credential-type", "X509_PROVIDED")
+                .with("credentials.uaa.clientid", "id")
+                .build();
+        final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();
+
+        sut = new DefaultOAuth2PropertySupplier(options);
+
+        assertThatThrownBy(sut::getClientIdentity)
+            .isInstanceOf(DestinationAccessException.class)
+            .hasMessageContaining("not supported");
+    }
+
+    @Test
     void testCredentialTypeX509_ATTESTED()
     {
         final ServiceBinding binding =
@@ -164,7 +203,7 @@ class DefaultOAuth2PropertySupplierTest
 
         sut = new DefaultOAuth2PropertySupplier(options);
 
-        assertThat(sut.getCredentialType()).isEqualTo(CredentialType.X509);
+        assertThat(sut.getCredentialType()).isEqualTo(CredentialType.X509_ATTESTED);
         assertThatThrownBy(sut::getClientIdentity)
             .isInstanceOf(CloudPlatformException.class)
             .describedAs("We are not mocking the Zero Trust Identity Service here, so this should be a failure")

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkaroundsTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkaroundsTest.java
@@ -8,6 +8,7 @@ import java.security.KeyStore;
 import org.junit.jupiter.api.Test;
 
 import com.sap.cloud.sdk.cloudplatform.connectivity.SecurityLibWorkarounds.ZtisClientIdentity;
+import com.sap.cloud.security.config.CredentialType;
 
 class SecurityLibWorkaroundsTest
 {
@@ -20,5 +21,25 @@ class SecurityLibWorkaroundsTest
         assertThat(sut).hasSameHashCodeAs(new ZtisClientIdentity("id", mock(KeyStore.class)));
         assertThat(sut).isNotEqualTo(new ZtisClientIdentity("id2", mock(KeyStore.class)));
         assertThat(sut).doesNotHaveSameHashCodeAs(new ZtisClientIdentity("id2", mock(KeyStore.class)));
+    }
+
+    @Test
+    void testGetCredentialType()
+    {
+        assertThat(SecurityLibWorkarounds.getCredentialType("binding-secret")).isEqualTo(CredentialType.BINDING_SECRET);
+        assertThat(SecurityLibWorkarounds.getCredentialType("Binding-Secret")).isEqualTo(CredentialType.BINDING_SECRET);
+        assertThat(SecurityLibWorkarounds.getCredentialType("instance-secret"))
+            .isEqualTo(CredentialType.INSTANCE_SECRET);
+        assertThat(SecurityLibWorkarounds.getCredentialType("Instance-Secret"))
+            .isEqualTo(CredentialType.INSTANCE_SECRET);
+        assertThat(SecurityLibWorkarounds.getCredentialType("X509_GENERATED")).isEqualTo(CredentialType.X509_GENERATED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("x509_generated")).isEqualTo(CredentialType.X509_GENERATED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("X509_ATTESTED")).isEqualTo(CredentialType.X509_ATTESTED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("x509_attested")).isEqualTo(CredentialType.X509_ATTESTED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("X509_PROVIDED")).isEqualTo(CredentialType.X509_PROVIDED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("x509_provided")).isEqualTo(CredentialType.X509_PROVIDED);
+        assertThat(SecurityLibWorkarounds.getCredentialType("X509")).isEqualTo(CredentialType.X509);
+        assertThat(SecurityLibWorkarounds.getCredentialType("x509")).isEqualTo(CredentialType.X509);
+        assertThat(SecurityLibWorkarounds.getCredentialType("foo")).isNull();
     }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,11 +8,11 @@
 
 ### 🔧 Compatibility Notes
 
-- 
+- Using the `X509_ATTESTED` credential type now requires a version >= `3.4.0` of the [BTP Security Library](https://github.com/SAP/cloud-security-services-integration-library).
 
 ### ✨ New Functionality
 
-- 
+- Support the `X509_ATTESTED` credential type for XSUAA service bindings.
 
 ### 📈 Improvements
 


### PR DESCRIPTION
## Context

This PR improves the credential type detection to deal with a lowercase variant of `x509_attested`, which will be used by XSUAA.

- [x] E2E tested

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated
