### PR TITLE
feat: Support ZTIS with XSUAA

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/SecurityLibWorkarounds.java
@@ -30,7 +30,7 @@ final class SecurityLibWorkarounds
     @Nullable
     static CredentialType getCredentialType( @Nonnull final String rawType )
     {
-        if( rawType.equals(X509_GENERATED) || rawType.equals(X509_ATTESTED) ) {
+        if( rawType.equalsIgnoreCase(X509_GENERATED) || rawType.equalsIgnoreCase(X509_ATTESTED) ) {
             // these particular credential types are only supported by the Security Client Lib > 3.3.5
             return CredentialType.X509;
         }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
@@ -52,7 +52,7 @@ class DefaultOAuth2PropertySupplierTest
 
         assertThat(convert(CredentialType.X509, CredentialType.class)).isEqualTo(CredentialType.X509);
         assertThat(convert(CredentialType.X509.toString(), CredentialType.class)).isEqualTo(CredentialType.X509);
-        assertThat(convert("X509_GENERATED", CredentialType.class)).isEqualTo(CredentialType.X509);
+        assertThat(convert("X509_GeNEratED", CredentialType.class)).isEqualTo(CredentialType.X509);
         assertThatThrownBy(() -> convert("not a valid credential type", CredentialType.class))
             .isExactlyInstanceOf(DestinationAccessException.class)
             .hasCauseExactlyInstanceOf(IllegalArgumentException.class);


### PR DESCRIPTION
## Context

This PR improves the credential type detection to deal with a lowercase variant of x509_attested, which will be used by XSUAA.

Simpler alternative to #453 which would require a minimum security library version of `3.4.0`.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] E2E tested
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~
