### PR TITLE
Deprecate non functional IAS option

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -220,7 +220,7 @@ public final class BtpServiceOptions
          * Creates an {@link OptionsEnhancer} that instructs an IAS-based destination to use the given application
          * provider name when performing token retrievals. This is needed in <b>App-To-App</b> communication scenarios.
          * <p>
-         * <b>Hint:</b> This option is <b>mutually exclusive</b> with {@link #withConsumerClient(String, String)}.
+         * <b>Hint:</b> This option is <b>mutually exclusive</b> with {@link #withConsumerClient(String)}.
          *
          * @param applicationName
          *            The name of the application provider to be used. This is the name that was used to register the
@@ -267,7 +267,9 @@ public final class BtpServiceOptions
          *            IAS authentication token sent by the consumer application upon calling this application.
          * @return An instance of {@link OptionsEnhancer} that will lead to the given consumer client ID and tenant ID
          *         being used when retrieving an authentication token from the IAS service.
+         * @deprecated since 5.11.0. Use {@link #withConsumerClient(String)} instead.
          */
+        @Deprecated
         @Nonnull
         public static
             OptionsEnhancer<?>
@@ -310,7 +312,7 @@ public final class BtpServiceOptions
         /**
          * An {@link OptionsEnhancer} that contains the communication options for an IAS-based destination. Also refer
          * to {@link #withoutTokenForTechnicalProviderUser()}, {@link #withApplicationName(String)}, and
-         * {@link #withConsumerClient(String, String)}.
+         * {@link #withConsumerClient(String)}.
          */
         @Value
         @AllArgsConstructor( access = AccessLevel.PRIVATE )

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -566,7 +566,7 @@ class BtpServicePropertySuppliersTest
         @Test
         void testClientIdWithTenantId()
         {
-            @SuppressWarnings("deprecation")
+            @SuppressWarnings( "deprecation" )
             final ServiceBindingDestinationOptions options =
                 ServiceBindingDestinationOptions
                     .forService(BINDING)
@@ -711,7 +711,7 @@ class BtpServicePropertySuppliersTest
                 IasOptions.withApplicationName("application-name");
             final ServiceBindingDestinationOptions.OptionsEnhancer<?> clientId =
                 IasOptions.withConsumerClient("client-id");
-            @SuppressWarnings("deprecation")
+            @SuppressWarnings( "deprecation" )
             final ServiceBindingDestinationOptions.OptionsEnhancer<?> clientIdAndTenantId =
                 IasOptions.withConsumerClient("client-id", "tenant-id");
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -566,6 +566,7 @@ class BtpServicePropertySuppliersTest
         @Test
         void testClientIdWithTenantId()
         {
+            @SuppressWarnings("deprecation")
             final ServiceBindingDestinationOptions options =
                 ServiceBindingDestinationOptions
                     .forService(BINDING)
@@ -710,6 +711,7 @@ class BtpServicePropertySuppliersTest
                 IasOptions.withApplicationName("application-name");
             final ServiceBindingDestinationOptions.OptionsEnhancer<?> clientId =
                 IasOptions.withConsumerClient("client-id");
+            @SuppressWarnings("deprecation")
             final ServiceBindingDestinationOptions.OptionsEnhancer<?> clientIdAndTenantId =
                 IasOptions.withConsumerClient("client-id", "tenant-id");
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,6 +9,7 @@
 ### 🔧 Compatibility Notes
 
 - Using the `X509_ATTESTED` credential type now requires a version >= `3.4.0` of the [BTP Security Library](https://github.com/SAP/cloud-security-services-integration-library).
+- Deprecate the IAS communication option `withConsumerClient(clientid, tenantid)`. The option is non-functional. Use `withConsumerClientId(clientid)` instead, the tenant will automatically be inferred from the context upon execution.
 
 ### ✨ New Functionality
 


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#454

IAS doesn't allow for sending `clientid:client-id:apptid:tenant-id`. We might have built this based on some older documentation from IAS that in the meanwhile got updated. Or I made a copy/paste mistake when copying the requirements for the parameters into our ticket 😅

Anyhow, deprecating the non-functional option.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] [Documentation updated](https://github.com/SAP/cloud-sdk/pull/1828)
- [x] Release notes updated

