### PR TITLE
Reduce unnecessary exception in `ThreadContextExecutor`

### DIFF
--- a/cloudplatform/cloudplatform-core/src/main/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutor.java
+++ b/cloudplatform/cloudplatform-core/src/main/java/com/sap/cloud/sdk/cloudplatform/thread/ThreadContextExecutor.java
@@ -286,7 +286,7 @@ public final class ThreadContextExecutor
                         "No " + ThreadContextFacade.class.getSimpleName() + " defined.",
                         failure));
 
-        final ThreadContext initialContext = facade.tryGetCurrentContext().getOrNull();
+        final ThreadContext initialContext = facade.getCurrentContextOrNull();
         final ThreadContext executionThreadContext = threadContext.duplicate();
 
         notifyBeforeInitialize(executionThreadContext);


### PR DESCRIPTION
Found it by surprise.