### PR TITLE
[chore] Ignore Json assert update

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -35,6 +35,8 @@ updates:
       - dependency-name: 'org.apache.axis2:*'
       # updating currently doesn't work as our rules are not compatible with the latest version
       - dependency-name: 'com.puppycrawl.tools:checkstyle'
+      # latest version requires Java 21; remove once https://github.com/skyscreamer/JSONassert/issues/190 is fixed
+      - dependency-name: 'org.skyscreamer:jsonassert'
 
   # archetype updates
   # Dependabot seems to be unable to handle those, so this is disabled for now


### PR DESCRIPTION
The latest patch version updates breaks our build as it requires Java 21. 
For more details: https://github.com/skyscreamer/JSONassert/issues/190

