### PR TITLE
feat: [Destinations] Support Fragments

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategy.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategy.java
@@ -28,6 +28,8 @@ final class DestinationRetrievalStrategy
     @Nullable
     @ToString.Exclude
     private final String token;
+    @Nullable
+    private String fragment;
 
     static DestinationRetrievalStrategy withoutToken( @Nonnull final OnBehalfOf behalf )
     {
@@ -51,6 +53,19 @@ final class DestinationRetrievalStrategy
             throw new IllegalArgumentException("Refresh token must not be empty.");
         }
         return new DestinationRetrievalStrategy(behalf, REFRESH_TOKEN, token);
+    }
+
+    DestinationRetrievalStrategy withFragmentName( @Nonnull final String fragmentName )
+    {
+        if( fragmentName.isBlank() ) {
+            throw new IllegalArgumentException("Fragment name must not be empty");
+        }
+        // sanity check to enforce this is only ever set once
+        if( fragment != null ) {
+            throw new IllegalStateException("Attempted to change an already set fragment name");
+        }
+        fragment = fragmentName;
+        return this;
     }
 
     enum TokenForwarding

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapter.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapter.java
@@ -200,6 +200,9 @@ class DestinationServiceAdapter
         if( headerName != null ) {
             request.addHeader(headerName, strategy.token());
         }
+        if( strategy.fragment() != null ) {
+            request.addHeader("x-fragment-name", strategy.fragment());
+        }
         return request;
     }
 

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceOptionsAugmenter.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceOptionsAugmenter.java
@@ -24,6 +24,7 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
     static final String DESTINATION_RETRIEVAL_STRATEGY_KEY = "scp.cf.destinationRetrievalStrategy";
     static final String DESTINATION_TOKEN_EXCHANGE_STRATEGY_KEY = "scp.cf.destinationTokenExchangeStrategy";
     static final String X_REFRESH_TOKEN_KEY = "x-refresh-token";
+    static final String X_FRAGMENT_KEY = "X-fragment-name";
 
     private final Map<String, Object> parameters = new HashMap<>();
 
@@ -86,6 +87,31 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
         return this;
     }
 
+    /**
+     * Fragment that should enhance the destination to be fetched.
+     *
+     * @param fragmentName
+     *            The fragment name.
+     * @return The same augmenter that called this method.
+     * @since 5.11.0
+     */
+    @Beta
+    @Nonnull
+    public DestinationServiceOptionsAugmenter fragmentName( @Nonnull final String fragmentName )
+    {
+        parameters.put(X_FRAGMENT_KEY, fragmentName);
+        if( DestinationService.Cache.isEnabled() && DestinationService.Cache.isChangeDetectionEnabled() ) {
+            log
+                .warn(
+                    """
+                        A fragment was requested while change detection caching is enabled.\
+                        This is not recommended, as fragment-based destinations will effectively not be cached with this strategy.\
+                        Consider disabling change detection, if you frequently use destination fragments.
+                        """);
+        }
+        return this;
+    }
+
     @Override
     public void augmentBuilder( @Nonnull final DestinationOptions.Builder builder )
     {
@@ -144,5 +170,11 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
     static Option<String> getRefreshToken( @Nonnull final DestinationOptions options )
     {
         return options.get(X_REFRESH_TOKEN_KEY).filter(String.class::isInstance).map(String.class::cast);
+    }
+
+    @Nonnull
+    static Option<String> getFragmentName( @Nonnull final DestinationOptions options )
+    {
+        return options.get(X_FRAGMENT_KEY).filter(String.class::isInstance).map(String.class::cast);
     }
 }

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationRetrievalStrategyResolverTest.java
@@ -213,7 +213,7 @@ class DestinationRetrievalStrategyResolverTest
                     .executeWithTenant(
                         c._3(),
                         () -> softly
-                            .assertThatThrownBy(() -> sut.prepareSupplier(c._1(), c._2(), null))
+                            .assertThatThrownBy(() -> sut.prepareSupplier(c._1(), c._2(), null, null))
                             .as("Expecting '%s' with '%s' and '%s' to throw.", c._1(), c._2(), c._3())
                             .isInstanceOf(DestinationAccessException.class)));
 
@@ -234,7 +234,12 @@ class DestinationRetrievalStrategyResolverTest
     {
         doAnswer(( any ) -> true).when(sut).doesDestinationConfigurationRequireUserTokenExchange(any());
         final DestinationRetrieval supplier =
-            sut.prepareSupplier(ALWAYS_PROVIDER, DestinationServiceTokenExchangeStrategy.LOOKUP_THEN_EXCHANGE, null);
+            sut
+                .prepareSupplier(
+                    ALWAYS_PROVIDER,
+                    DestinationServiceTokenExchangeStrategy.LOOKUP_THEN_EXCHANGE,
+                    null,
+                    null);
 
         TenantAccessor
             .executeWithTenant(
@@ -259,7 +264,7 @@ class DestinationRetrievalStrategyResolverTest
         sut.prepareSupplier(DestinationOptions.builder().build());
         sut.prepareSupplierAllDestinations(DestinationOptions.builder().build());
 
-        verify(sut).prepareSupplier(CURRENT_TENANT, FORWARD_USER_TOKEN, null);
+        verify(sut).prepareSupplier(CURRENT_TENANT, FORWARD_USER_TOKEN, null, null);
         verify(sut).prepareSupplierAllDestinations(CURRENT_TENANT);
     }
 
@@ -272,7 +277,8 @@ class DestinationRetrievalStrategyResolverTest
         sut.prepareSupplier(DestinationOptions.builder().build());
         sut.prepareSupplierAllDestinations(DestinationOptions.builder().build());
 
-        verify(sut).prepareSupplier(CURRENT_TENANT, DestinationServiceTokenExchangeStrategy.LOOKUP_THEN_EXCHANGE, null);
+        verify(sut)
+            .prepareSupplier(CURRENT_TENANT, DestinationServiceTokenExchangeStrategy.LOOKUP_THEN_EXCHANGE, null, null);
         verify(sut).prepareSupplierAllDestinations(CURRENT_TENANT);
     }
 
@@ -289,5 +295,20 @@ class DestinationRetrievalStrategyResolverTest
         sut.prepareSupplier(opts);
 
         verify(sut).resolveSingleRequestStrategy(eq(CURRENT_TENANT), eq(LOOKUP_ONLY), eq(refreshToken));
+    }
+
+    @Test
+    void testFragmentName()
+    {
+        final String fragmentName = "my-fragment";
+        final DestinationOptions opts =
+            DestinationOptions
+                .builder()
+                .augmentBuilder(DestinationServiceOptionsAugmenter.augmenter().fragmentName(fragmentName))
+                .build();
+
+        sut.prepareSupplier(opts);
+
+        verify(sut).prepareSupplier(any(), any(), eq(null), eq(fragmentName));
     }
 }

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapterTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapterTest.java
@@ -245,6 +245,31 @@ class DestinationServiceAdapterTest
     }
 
     @Test
+    void testFragmentName()
+    {
+        final DestinationServiceAdapter adapterToTest = createSut(DEFAULT_SERVICE_BINDING);
+
+        final String fragment = "my-fragment";
+
+        final String destinationResponse =
+            adapterToTest
+                .getConfigurationAsJson(
+                    "/",
+                    DestinationRetrievalStrategy
+                        .withoutToken(TECHNICAL_USER_CURRENT_TENANT)
+                        .withFragmentName(fragment));
+
+        assertThat(destinationResponse).isEqualTo(DESTINATION_RESPONSE);
+
+        verify(
+            1,
+            getRequestedFor(urlEqualTo(DESTINATION_SERVICE_URL))
+                .withHeader("Authorization", equalTo("Bearer " + xsuaaToken))
+                .withHeader("x-fragment-name", equalTo(fragment))
+                .withoutHeader("x-user-token"));
+    }
+
+    @Test
     void getDestinationServiceProviderTenantShouldReturnProviderTenantFromServiceBinding()
     {
         final DestinationServiceAdapter adapterToTest = createSut(DEFAULT_SERVICE_BINDING);

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -1648,7 +1648,9 @@ class DestinationServiceTest
 
         assertThat(d.get("FragmentName")).isEmpty();
 
-        assertThat(dA).isSameAs(loader.tryGetDestination("destination", optsBuilder.apply("a-fragment")).get());
+        assertThat(dA)
+            .describedAs("Destinations with fragments should be cached")
+            .isSameAs(loader.tryGetDestination("destination", optsBuilder.apply("a-fragment")).get());
         verify(destinationServiceAdapter, times(3)).getConfigurationAsJson(any(), any());
     }
 

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -1599,7 +1599,6 @@ class DestinationServiceTest
                 withUserToken(TECHNICAL_USER_CURRENT_TENANT, userToken));
     }
 
-    // TODO test
     @Test
     void testFragmentDestinationsAreCacheIsolated()
     {

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,9 @@
 
 ### ✨ New Functionality
 
-- 
+- Add support for [_Destination Fragments_](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/extending-destinations-with-fragments).
+  Fragment names can be passed upon requesting destinations via `DestinationServiceOptionsAugmenter.fragmentName("my-fragment-name")`.
+  For further details refer to [the documentation]().
 
 ### 📈 Improvements
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,7 @@
 
 ### ✨ New Functionality
 
-- Add support for [_Destination Fragments_](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/extending-destinations-with-fragments).
+- Add experimental support for [_Destination Fragments_](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/extending-destinations-with-fragments).
   Fragment names can be passed upon requesting destinations via `DestinationServiceOptionsAugmenter.fragmentName("my-fragment-name")`.
   For further details refer to [the documentation]().
 


### PR DESCRIPTION
## Context

This PR enhances the Cloud SDK to support [Destination Fragments](https://help.sap.com/docs/connectivity/sap-btp-connectivity-cf/extending-destinations-with-fragments).

### Feature scope:
 
- [x] Retrieve destinations with fragments
- [x] Cache based on fragments

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
    - [x] [E2E Test](https://sdk-v2.cpe.c.eu-de-1.cloud.sap/blue/organizations/jenkins/end-to-end-tests%2Fv5-scp-cf-spring/detail/v5-scp-cf-spring/410/pipeline)
    - [ ] Merge [E2E test update](https://github.tools.sap/cloudsdk/cloud-sdk-java-tests/pull/48)
- [x] ~Error handling created / updated & covered by the tests above~
- [ ] Documentation updated
- [x] Release notes updated
