### PR TITLE
Remove `//NOPMD` on OpenAPI generated imports

### DIFF
--- a/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/test/resources/DataModelGeneratorMojoIntegrationTest/sodastore/output/com/sap/cloud/sdk/datamodel/rest/sodastore/api/DefaultApi.java
@@ -9,9 +9,9 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.datamodel.rest.sodastore.model.NewSoda ; //NOPMD
-import com.sap.cloud.sdk.datamodel.rest.sodastore.model.Soda ; //NOPMD
-import com.sap.cloud.sdk.datamodel.rest.sodastore.model.UpdateSoda ; //NOPMD
+import com.sap.cloud.sdk.datamodel.rest.sodastore.model.NewSoda;
+import com.sap.cloud.sdk.datamodel.rest.sodastore.model.Soda;
+import com.sap.cloud.sdk.datamodel.rest.sodastore.model.UpdateSoda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/resttemplate/api.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/resttemplate/api.mustache
@@ -9,7 +9,7 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-{{#imports}}import {{import}} ; //NOPMD
+{{#imports}}import {{import}};
 {{/imports}}
 
 import java.util.HashMap;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
@@ -9,8 +9,8 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.NewSoda ; //NOPMD
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda ; //NOPMD
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.NewSoda;
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
@@ -9,7 +9,7 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda ; //NOPMD
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -9,8 +9,8 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda ; //NOPMD
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.UpdateSoda ; //NOPMD
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.UpdateSoda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -9,9 +9,9 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.NewSoda ; //NOPMD
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda ; //NOPMD
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.UpdateSoda ; //NOPMD
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.NewSoda;
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.UpdateSoda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/api/DefaultApi.java
@@ -9,7 +9,7 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.anyofoneof.model.RootObject ; //NOPMD
+import com.sap.cloud.sdk.services.anyofoneof.model.RootObject;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/AwesomeSodaApi.java
@@ -9,8 +9,8 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.uppercasefileextension.model.NewSoda ; //NOPMD
-import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda ; //NOPMD
+import com.sap.cloud.sdk.services.uppercasefileextension.model.NewSoda;
+import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/AwesomeSodasApi.java
@@ -9,7 +9,7 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda ; //NOPMD
+import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-uppercase-file-extension/output/com/sap/cloud/sdk/services/uppercasefileextension/api/DefaultApi.java
@@ -9,8 +9,8 @@ import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
 import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
 import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
 
-import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda ; //NOPMD
-import com.sap.cloud.sdk.services.uppercasefileextension.model.UpdateSoda ; //NOPMD
+import com.sap.cloud.sdk.services.uppercasefileextension.model.Soda;
+import com.sap.cloud.sdk.services.uppercasefileextension.model.UpdateSoda;
 
 import java.util.HashMap;
 import java.util.List;

--- a/release_notes.md
+++ b/release_notes.md
@@ -9,7 +9,6 @@
 ### 🔧 Compatibility Notes
 
 - The OpenAPI generator doesn't add `//NOPMD` after imports anymore.
-  This makes it compatible with `google-java-format`.
 
 ### ✨ New Functionality
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,8 @@
 
 ### 🔧 Compatibility Notes
 
-- 
+- The OpenAPI generator doesn't add `//NOPMD` after imports anymore.
+  This makes it compatible with `google-java-format`.
 
 ### ✨ New Functionality
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

[`google-java-format` cannot format files that have comments in imports](https://github.tools.sap/AI/ai-core-sdk-java/pull/59), furthermore [OpenAPI doesn't specify this comment in their api.mustache file](https://github.com/OpenAPITools/openapi-generator/blob/master/modules/openapi-generator/src/main/resources/JavaSpring/api.mustache#L8).

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Remove `//NOPMD` on OpenAPI generated imports

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
