### PR TITLE
Removed `Test Report` step

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -218,16 +218,11 @@ jobs:
 
       - name: "Run Unit Tests"
         run: |
-          MVN_ARGS="${{ env.MVN_SINGLE_THREADED_ARGS }} org.jacoco:jacoco-maven-plugin:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:report"
+          MVN_ARGS="${{ env.MVN_SINGLE_THREADED_ARGS }} org.jacoco:jacoco-maven-plugin:prepare-agent surefire:test org.jacoco:jacoco-maven-plugin:report --fail-at-end"
 
           echo "[DEBUG] Running Maven with arguments: $MVN_ARGS"
           mvn $MVN_ARGS
 
-      - name: "Test Report"
-        #Surefire reports are failing on pull requests created from forks and from GitHub Apps like dependabot
-        #https://docs.github.com/en/code-security/dependabot/working-with-dependabot/automating-dependabot-with-github-actions#responding-to-events
-        if: github.event.pull_request.head.repo.full_name == 'SAP/cloud-sdk-java' && github.actor != 'dependabot[bot]'
-        uses: scacap/action-surefire-report@v1
       - name: "Coverage Report"
         run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"
 
@@ -281,7 +276,7 @@ jobs:
 
       - name: "Run ${{ matrix.task.name }} Analysis"
         run: |
-          MVN_ARGS="${{ env.MVN_SINGLE_THREADED_ARGS }} ${{ env.MVN_SKIP_CI_PLUGINS }} ${{ matrix.task.mvn_goal }}"
+          MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} ${{ env.MVN_SKIP_CI_PLUGINS }} ${{ matrix.task.mvn_goal }}"
 
           echo "[DEBUG] Running Maven with arguments: $MVN_ARGS"
           mvn $MVN_ARGS


### PR DESCRIPTION
## Context

Improvement discovered while working on [Added test coverage](https://github.tools.sap/AI/ai-core-sdk-java/pull/62#top) in the AI SDK

This step was used to [create a Jacoco badge](https://github.com/SAP/cloud-sdk-java/commit/4419cc5539b4aad1367c0c2d2cc77c6a160d0be7#diff-d0777657fa3fd81d23aaf7273e58aee453b04e67882517900c56daeef9b3e4c1R124) which we no longer need.
The functionality of the `Coverage` step is not affected since the `Run Unit Tests` step is unchanged.

### Feature scope:

- [x] Removed `Test Report` step

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
