### PR TITLE
Fix incorrect camelCase when generating list accessors for OpenAPI

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
@@ -93,7 +93,7 @@ public class {{classname}} {{#parent}}extends {{{parent}}} {{/parent}}{{#parcela
   * @param {{name}}Item The {{nameInCamelCase}} that should be added
   * @return The same instance of type {@link {{classname}}}
   */
-  @Nonnull public {{classname}} add{{nameInCamelCase}}Item( @Nonnull final {{{items.datatypeWithEnum}}} {{name}}Item) {
+  @Nonnull public {{classname}} add{{nameInPascalCase}}Item( @Nonnull final {{{items.datatypeWithEnum}}} {{name}}Item) {
     if (this.{{name}} == null) {
       this.{{name}} = {{{defaultValue}}}{{^defaultValue}}new {{#uniqueItems}}LinkedHashSet{{/uniqueItems}}{{^uniqueItems}}ArrayList{{/uniqueItems}}<>(){{/defaultValue}};
     }

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/model/RootObject.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/input-spec-with-anyof-oneof/output/com/sap/cloud/sdk/services/anyofoneof/model/RootObject.java
@@ -71,7 +71,7 @@ public class RootObject
   * @param questionsItem The questions that should be added
   * @return The same instance of type {@link RootObject}
   */
-  @Nonnull public RootObject addquestionsItem( @Nonnull final RootObjectQuestionsInner questionsItem) {
+  @Nonnull public RootObject addQuestionsItem( @Nonnull final RootObjectQuestionsInner questionsItem) {
     if (this.questions == null) {
       this.questions = new ArrayList<>();
     }

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,6 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- The OpenAPI Generator uses correct camelCase again, when creating methods to _add items_ to a collections.
+  Version `5.10.0` used incorrect `addfooItems(Foo)` instead of `addFooItems(Foo)`.
+  This is fixed now.


### PR DESCRIPTION
Fix a bug introduced in https://github.com/SAP/cloud-sdk-java/pull/441 (released as `5.10.0`)