### PR TITLE
[OpenAPI Generator] When deleting files, only consider specific packages

### DIFF
--- a/datamodel/openapi/openapi-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojo.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojo.java
@@ -107,7 +107,7 @@ public class DataModelGeneratorMojo extends AbstractMojo
     private Boolean sapCopyrightHeader;
 
     /**
-     * Defines whether to delete the output directory prior to the generation.
+     * Defines whether to delete the generated files form output directory prior to the generation.
      */
     @Parameter( property = "openapi.generate.deleteOutputDirectory", defaultValue = "false" )
     private boolean deleteOutputDirectory;

--- a/datamodel/openapi/openapi-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojo.java
+++ b/datamodel/openapi/openapi-generator-maven-plugin/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorMojo.java
@@ -107,7 +107,7 @@ public class DataModelGeneratorMojo extends AbstractMojo
     private Boolean sapCopyrightHeader;
 
     /**
-     * Defines whether to delete the generated files form output directory prior to the generation.
+     * Defines whether to delete the generated files from output directory prior to the generation.
      */
     @Parameter( property = "openapi.generate.deleteOutputDirectory", defaultValue = "false" )
     private boolean deleteOutputDirectory;

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGenerator.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGenerator.java
@@ -4,6 +4,8 @@
 
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
+import static org.apache.commons.io.filefilter.TrueFileFilter.TRUE;
+
 import java.io.BufferedReader;
 import java.io.BufferedWriter;
 import java.io.File;
@@ -17,7 +19,6 @@ import java.util.function.Consumer;
 import javax.annotation.Nonnull;
 
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.io.filefilter.TrueFileFilter;
 import org.apache.commons.io.function.IOConsumer;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.DefaultGenerator;
@@ -121,9 +122,9 @@ public class DataModelGenerator
             log.info("Deleting output directory \"{}\".", outputDirectory.getAbsolutePath());
 
             // create set of directories that can be deleted
-            HashSet<File> allowedDirs = new HashSet<>();
+            final var allowedDirs = new HashSet<File>();
             allowedDirs.add(outputDirectory);
-            Consumer<String> addDirs = pckg -> {
+            final Consumer<String> addDirs = pckg -> {
                 File d = outputDirectory;
                 for( final String ns : pckg.split("\\.") ) {
                     d = new File(d, ns);
@@ -138,7 +139,7 @@ public class DataModelGenerator
 
             // recursively list files that are going to be deleted, safety check:
             // throw if unexpected file (non-java or non-ignore file) or unexpected folder (non-package)
-            var deleteFiles = FileUtils.listFilesAndDirs(outputDirectory, TrueFileFilter.TRUE, TrueFileFilter.TRUE);
+            final var deleteFiles = FileUtils.listFilesAndDirs(outputDirectory, TRUE, TRUE);
             deleteFiles.removeIf(f -> f.isDirectory() && allowedDirs.contains(f));
             deleteFiles.removeIf(f -> f.isFile() && (f.getName().startsWith(".") || f.getName().endsWith(".java")));
             if( !deleteFiles.isEmpty() ) {
@@ -146,7 +147,7 @@ public class DataModelGenerator
             }
 
             // get non-ignore files from outputDirectory folder (non-recursive)
-            var nonIgnoreFiles = outputDirectory.listFiles(( dir, file ) -> !file.startsWith("."));
+            final var nonIgnoreFiles = outputDirectory.listFiles(( dir, file ) -> !file.startsWith("."));
             // delete the files (recursively)
             IOConsumer.forAll(FileUtils::forceDelete, nonIgnoreFiles);
         }

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGenerator.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGenerator.java
@@ -11,7 +11,7 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Paths;
 import java.util.List;
-import java.util.regex.Pattern;
+import java.util.function.Predicate;
 
 import javax.annotation.Nonnull;
 
@@ -151,20 +151,20 @@ public class DataModelGenerator
         classPathResourceValidator.assertTemplatesAvailableOnClasspath(templateDirectory, libraryName);
     }
 
-    private void assertRequiredFieldsAreFilled( final GenerationConfiguration config )
+    private void assertRequiredFieldsAreFilled( final GenerationConfiguration configuration )
     {
-        if( config.getInputSpec() == null || config.getInputSpec().isEmpty() ) {
+        if( configuration.getInputSpec() == null || configuration.getInputSpec().isEmpty() ) {
             throw new IllegalArgumentException("Input file path is null or empty.");
         }
-        if( config.getOutputDirectory() == null || config.getOutputDirectory().isEmpty() ) {
+        if( configuration.getOutputDirectory() == null || configuration.getOutputDirectory().isEmpty() ) {
             throw new IllegalArgumentException("Output directory is null or empty.");
         }
 
-        final var packagePattern = Pattern.compile("[a-z_$][a-z0-9_$]+(\\.[a-z0-9_$]+)*");
-        if( config.getApiPackage() == null || !packagePattern.matcher(config.getApiPackage()).matches() ) {
+        final Predicate<String> goodPackage = p -> !p.isEmpty() && !p.startsWith(".") && !p.contains(File.separator);
+        if( configuration.getApiPackage() == null || !goodPackage.test(configuration.getApiPackage()) ) {
             throw new IllegalArgumentException("API package is null or empty or invalid.");
         }
-        if( config.getModelPackage() == null || !packagePattern.matcher(config.getModelPackage()).matches() ) {
+        if( configuration.getModelPackage() == null || !goodPackage.test(configuration.getModelPackage()) ) {
             throw new IllegalArgumentException("Model package is null or empty or invalid.");
         }
     }

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/model/GenerationConfiguration.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/model/GenerationConfiguration.java
@@ -66,10 +66,10 @@ public class GenerationConfiguration
     }
 
     /**
-     * Indicates whether to delete the output directory prior to the generation.
+     * Indicates whether to delete the generated files from output directory prior to the generation.
      *
-     * @return {@code true} if the output directory should be deleted before generating the OpenAPI client,
-     *         {@code false} otherwise.
+     * @return {@code true} if the generated files should be deleted from output directory before generating the OpenAPI
+     *         client, {@code false} otherwise.
      */
     public boolean deleteOutputDirectory()
     {

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorUnitTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorUnitTest.java
@@ -306,9 +306,15 @@ class DataModelGeneratorUnitTest
     @SneakyThrows
     void testCleanOutputDirectory()
     {
-        final File classFile = Files.createTempFile(outputDirectory, null, "myclass.java").toFile();
-        final File ignoreFile = Files.createTempFile(outputDirectory, ".ignore", null).toFile();
-        assertThat(classFile.exists()).isTrue();
+        final Path modelDir = Files.createDirectory(outputDirectory.resolve("model"));
+        final Path apiDir = Files.createDirectory(outputDirectory.resolve("api"));
+
+        final File modelFile = Files.createFile(modelDir.resolve("mymodel.java")).toFile();
+        final File apiFile = Files.createFile(apiDir.resolve("myapi.java")).toFile();
+        final File ignoreFile = Files.createFile(outputDirectory.resolve(".ignore")).toFile();
+
+        assertThat(modelFile.exists()).isTrue();
+        assertThat(apiFile.exists()).isTrue();
         assertThat(ignoreFile.exists()).isTrue();
 
         final GenerationConfiguration configuration =
@@ -325,8 +331,9 @@ class DataModelGeneratorUnitTest
 
         assertThat(generationResult.isSuccess()).isTrue();
 
-        // assert that the class file was deleted
-        assertThat(classFile.exists()).isFalse();
+        // assert that the java files are deleted
+        assertThat(modelFile.exists()).isFalse();
+        assertThat(apiFile.exists()).isFalse();
         // assert that the ignore file remains
         assertThat(ignoreFile.exists()).isTrue();
     }

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorUnitTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorUnitTest.java
@@ -306,11 +306,10 @@ class DataModelGeneratorUnitTest
     @SneakyThrows
     void testCleanOutputDirectory()
     {
-        final File existingFile =
-            Files
-                .createTempFile(outputDirectory, "dummyFile", DataModelGeneratorUnitTest.class.getSimpleName())
-                .toFile();
-        assertThat(existingFile.exists()).isTrue();
+        final File classFile = Files.createTempFile(outputDirectory, null, "myclass.java").toFile();
+        final File ignoreFile = Files.createTempFile(outputDirectory, ".ignore", null).toFile();
+        assertThat(classFile.exists()).isTrue();
+        assertThat(ignoreFile.exists()).isTrue();
 
         final GenerationConfiguration configuration =
             GenerationConfiguration
@@ -326,8 +325,10 @@ class DataModelGeneratorUnitTest
 
         assertThat(generationResult.isSuccess()).isTrue();
 
-        // assert that the file was deleted
-        assertThat(existingFile.exists()).isFalse();
+        // assert that the class file was deleted
+        assertThat(classFile.exists()).isFalse();
+        // assert that the ignore file remains
+        assertThat(ignoreFile.exists()).isTrue();
     }
 
     @Test

--- a/release_notes.md
+++ b/release_notes.md
@@ -16,7 +16,9 @@
 
 ### 📈 Improvements
 
-- 
+- \[OpenAPI Generator\] Setting the Maven plugin configuration property `openapi.generate.deleteOutputDirectory` to `true` will no longer result in deletion of all files from the `outputDirectory` prior to generation.
+  Instead, only the `apiPackage`- and `apiPackage`-related directories will be cleaned.
+  This reduces the risk of deleting files unexpectedly and allows for reusing the same `outputDirectory` for multiple generator plugin invocations.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
~It would be good if we checked for any unexpected files before blindly deleting user-provided paths.~
To stay safe, we should only delete what was being generated, according to the configuration provided.


\* Also I want us to retain "hidden" files (with `.`-prefix), to keep custom files like `.gitignore` or `.openapi-generator-ignore`)