### PR TITLE
[OpenAPI Generator] Enable custom `operationId -> name` mapping

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -17,7 +17,6 @@ import javax.annotation.Nonnull;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.config.GeneratorSettings;
 import org.openapitools.codegen.config.GlobalSettings;
 import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.model.ModelMap;


### PR DESCRIPTION
Usage:
* In `additionalProperties` define `operationIdNames`. Use `<space>` or `,` as entry delimiter. Use `=` to separate key value.
```xml
<plugin>
  <groupId>com.sap.cloud.sdk.datamodel</groupId>
  <artifactId>openapi-generator-maven-plugin</artifactId>
  <configuration>
    <additionalProperties>
      <operationIdNames>
        getSodaById=getById
      </operationIdNames>
    </additionalProperties>
```