### PR TITLE
fix: gRPC Version

### DIFF
--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -87,6 +87,22 @@
 			<version>0.8.6</version>
 			<scope>runtime</scope>
 		</dependency>
+		<!-- Override grpc versions from spiffe -->
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-netty-shaded</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-protobuf</artifactId>
+			<scope>runtime</scope>
+		</dependency>
+		<dependency>
+			<groupId>io.grpc</groupId>
+			<artifactId>grpc-stub</artifactId>
+			<scope>runtime</scope>
+		</dependency>
 		<dependency>
 			<groupId>io.vavr</groupId>
 			<artifactId>vavr</artifactId>

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,6 +19,7 @@
 - \[OpenAPI Generator\] Setting the Maven plugin configuration property `openapi.generate.deleteOutputDirectory` to `true` will no longer result in deletion of all files from the `outputDirectory` prior to generation.
   Instead, only the `apiPackage`- and `apiPackage`-related directories will be cleaned.
   This reduces the risk of deleting files unexpectedly and allows for reusing the same `outputDirectory` for multiple generator plugin invocations.
+- Upgrade  to version `1.66.0` of `gRPC` dependencies coming in transitively when using `connectivity-ztis` 
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

The approach of only using `dependencyManagement` doesn't work, as this only affects the version within the module itself, not the version when using the module.

Unfortunately, we can only override the version by referencing transitive dependencies explicitly. We could add it to the main BOM, but that only fixes it when the BOM is used by customers. 

## Definition of Done

- [x] Functionality scope stated & covered
- [x] [Tests cover the scope above](https://sdk-v2.cpe.c.eu-de-1.cloud.sap/job/end-to-end-tests/view/Cloud%20SDK%20v5/job/v5-scp-cf-spring-ias/465/)
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated
