### PR TITLE
feat: [OAuth2] Enable OAuth Timeout Customization

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -188,18 +188,18 @@ class BtpServicePropertySuppliers
         @Override
         public OAuth2Options getOAuth2Options()
         {
-            final OAuth2Options.Builder oAuth2OptionsBuilder = OAuth2Options.builder();
+            final OAuth2Options.Builder builder = OAuth2Options.builder();
+            options.getOption(OAuth2Options.TokenRetrievalTimeout.class).peek(builder::withTimeLimiter);
 
             if( skipTokenRetrieval() ) {
-                oAuth2OptionsBuilder.withSkipTokenRetrieval(true);
+                builder.withSkipTokenRetrieval(true);
             } else {
-                attachIasCommunicationOptions(oAuth2OptionsBuilder);
-                oAuth2OptionsBuilder
-                    .withTokenRetrievalParameter("app_tid", getCredentialOrThrow(String.class, "app_tid"));
+                attachIasCommunicationOptions(builder);
+                builder.withTokenRetrievalParameter("app_tid", getCredentialOrThrow(String.class, "app_tid"));
             }
-            attachClientKeyStore(oAuth2OptionsBuilder);
+            attachClientKeyStore(builder);
 
-            return oAuth2OptionsBuilder.build();
+            return builder.build();
         }
 
         private void attachIasCommunicationOptions( @Nonnull final OAuth2Options.Builder optionsBuilder )

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -134,6 +134,15 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
         };
     }
 
+    @Nonnull
+    @Override
+    public OAuth2Options getOAuth2Options()
+    {
+        final OAuth2Options.Builder builder = OAuth2Options.builder();
+        options.getOption(OAuth2Options.TokenRetrievalTimeout.class).peek(builder::withTimeLimiter);
+        return builder.build();
+    }
+
     /**
      * Get the path under which the oauth properties are stored in the service binding credentials.
      *

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
@@ -31,6 +31,8 @@ public final class OAuth2Options
 {
     /**
      * The default timeout of 10 seconds for token retrieval.
+     *
+     * @since 5.12.0
      */
     public static final TimeLimiterConfiguration DEFAULT_TIMEOUT = TimeLimiterConfiguration.of(Duration.ofSeconds(10));
     /**
@@ -44,6 +46,8 @@ public final class OAuth2Options
     private final Map<String, String> additionalTokenRetrievalParameters;
     /**
      * A timeout to be applied for token retrieval.
+     *
+     * @since 5.12.0
      */
     @Nonnull
     @Getter
@@ -168,6 +172,7 @@ public final class OAuth2Options
          * @param timeLimiter
          *            The custom timeout configuration.
          * @return This {@link Builder}.
+         * @since 5.12.0
          */
         @Nonnull
         public Builder withTimeLimiter( @Nonnull final TimeLimiterConfiguration timeLimiter )
@@ -202,6 +207,8 @@ public final class OAuth2Options
 
     /**
      * Configure the timeout applied to token retrieval.
+     *
+     * @since 5.12.0
      */
     @Getter
     @RequiredArgsConstructor( staticName = "of" )

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
@@ -1,6 +1,7 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import java.security.KeyStore;
+import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 
@@ -8,11 +9,14 @@ import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.google.common.annotations.Beta;
+import com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingDestinationOptions.OptionsEnhancer;
+import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration.TimeLimiterConfiguration;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -26,14 +30,24 @@ import lombok.extern.slf4j.Slf4j;
 public final class OAuth2Options
 {
     /**
+     * The default timeout of 10 seconds for token retrieval.
+     */
+    public static final TimeLimiterConfiguration DEFAULT_TIMEOUT = TimeLimiterConfiguration.of(Duration.ofSeconds(10));
+    /**
      * The default {@link OAuth2Options} instance that does not alter the token retrieval process and does not use mTLS
      * for the target system connection.
      */
-    public static final OAuth2Options DEFAULT = new OAuth2Options(false, Map.of(), null);
+    public static final OAuth2Options DEFAULT = new OAuth2Options(false, Map.of(), DEFAULT_TIMEOUT, null);
 
     private final boolean skipTokenRetrieval;
     @Nonnull
     private final Map<String, String> additionalTokenRetrievalParameters;
+    /**
+     * A timeout to be applied for token retrieval.
+     */
+    @Nonnull
+    @Getter
+    private final TimeLimiterConfiguration timeLimiter;
     /**
      * The {@link KeyStore} to use for building an mTLS connection towards the <b>target system</b>. This
      * {@link KeyStore} <b>is not used</b> to build an mTLS connection towards the OAuth2 token service.
@@ -85,6 +99,7 @@ public final class OAuth2Options
         private boolean skipTokenRetrieval = false;
         private final Map<String, String> additionalTokenRetrievalParameters = new HashMap<>();
         private KeyStore clientKeyStore;
+        private TimeLimiterConfiguration timeLimiter = DEFAULT_TIMEOUT;
 
         /**
          * Indicates whether to skip the OAuth2 token flow.
@@ -148,6 +163,20 @@ public final class OAuth2Options
         }
 
         /**
+         * Set a custom timeout for token retrieval. {@link #DEFAULT_TIMEOUT} by default.
+         *
+         * @param timeLimiter
+         *            The custom timeout configuration.
+         * @return This {@link Builder}.
+         */
+        @Nonnull
+        public Builder withTimeLimiter( @Nonnull final TimeLimiterConfiguration timeLimiter )
+        {
+            this.timeLimiter = timeLimiter;
+            return this;
+        }
+
+        /**
          * Creates a new {@link OAuth2Options} instance.
          *
          * @return A new {@link OAuth2Options} instance.
@@ -166,7 +195,19 @@ public final class OAuth2Options
             return new OAuth2Options(
                 skipTokenRetrieval,
                 new HashMap<>(additionalTokenRetrievalParameters),
+                timeLimiter,
                 clientKeyStore);
         }
+    }
+
+    /**
+     * Configure the timeout applied to token retrieval.
+     */
+    @Getter
+    @RequiredArgsConstructor( staticName = "of" )
+    public static class TokenRetrievalTimeout implements OptionsEnhancer<TimeLimiterConfiguration>
+    {
+        @Nonnull
+        private final TimeLimiterConfiguration value;
     }
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -7,7 +7,6 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static com.sap.cloud.security.xsuaa.util.UriUtil.expandPath;
 
 import java.net.URI;
-import java.time.Duration;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -314,7 +313,6 @@ class OAuth2Service
     static class Builder
     {
         private static final String XSUAA_TOKEN_PATH = "/oauth/token";
-        private static final Duration DEFAULT_TIME_OUT = Duration.ofSeconds(10);
 
         /**
          * {@link ServiceIdentifier#IDENTITY_AUTHENTICATION} referenced indirectly for backwards compatibility.
@@ -326,8 +324,7 @@ class OAuth2Service
         private OnBehalfOf onBehalfOf = OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT;
         private TenantPropagationStrategy tenantPropagationStrategy = TenantPropagationStrategy.ZID_HEADER;
         private final Map<String, String> additionalParameters = new HashMap<>();
-        private ResilienceConfiguration.TimeLimiterConfiguration timeLimiter =
-            ResilienceConfiguration.TimeLimiterConfiguration.of(DEFAULT_TIME_OUT);
+        private ResilienceConfiguration.TimeLimiterConfiguration timeLimiter = OAuth2Options.DEFAULT_TIMEOUT;
 
         @Nonnull
         Builder withTokenUri( @Nonnull final String tokenUri )

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -331,6 +331,7 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
                 .withOnBehalfOf(behalf)
                 .withTenantPropagationStrategyFrom(serviceIdentifier)
                 .withAdditionalParameters(oAuth2Options.getAdditionalTokenRetrievalParameters())
+                .withTimeLimiter(oAuth2Options.getTimeLimiter())
                 .build();
         return new OAuth2HeaderProvider(oAuth2Service, authHeader);
     }

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,9 @@
 
 ### ✨ New Functionality
 
-- 
+- Timeouts for OAuth2 token retrievals can now be customized.
+  As part of `ServiceBindingDestinationOptions` the new option `OAuth2Options.TokenRetrievalTimeout` can now be passed to set a custom timeout.
+  Refer to [this documentation](https://sap.github.io/cloud-sdk/docs/java/features/connectivity/service-bindings#about-the-options) for more details.
 
 ### 📈 Improvements
 


### PR DESCRIPTION
## Context

Allows for customizing the timeout for token retrieval.

**API Design**

```java
var opts = ServiceBindingDestinationOptions
                .forService(...)
                .withOption(
                    OAuth2Options.TokenRetrievalTimeout.of(TimeLimiterConfiguration.of(Duration.ofSeconds(100))))
                .build();
ServiceBindingDestinationLoader.defaultLoaderChain().getDestination(opts);
```
 
## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [ ] Documentation updated
- [x] Release notes updated
