### PR TITLE
feat: [DestinationService] Allow optional retrieval-strategy (tenant) in getAllDestinationProperties

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -174,6 +174,26 @@ public class DestinationService implements DestinationLoader
     }
 
     /**
+     * Fetches all destination properties from the BTP Destination Service on behalf of current tenant.
+     * <p>
+     * <strong>Caution: This will not perform any authorization flows for the destinations.</strong> Destinations
+     * obtained this way should only be used for accessing the properties of the destination configuration. For
+     * obtaining full destination objects, use {@link #tryGetDestination(String, DestinationOptions)} instead.
+     * </p>
+     * In case there exists a destination with the same name on service instance and on sub-account level, the
+     * destination at service instance level takes precedence.
+     *
+     * @return A list of destination properties.
+     * @see DestinationService#getAllDestinationProperties(DestinationServiceRetrievalStrategy)
+     * @since 5.1.0
+     */
+    @Nonnull
+    public List<DestinationProperties> getAllDestinationProperties()
+    {
+        return getAllDestinationProperties(DestinationServiceRetrievalStrategy.CURRENT_TENANT);
+    }
+
+    /**
      * Fetches all destination properties from the BTP Destination Service.
      * <p>
      * <strong>Caution: This will not perform any authorization flows for the destinations.</strong> Destinations
@@ -184,21 +204,22 @@ public class DestinationService implements DestinationLoader
      * destination at service instance level takes precedence.
      *
      * @return A list of destination properties.
-     * @since 5.1.0
+     * @param retrievalStrategy
+     *            Strategy for loading destinations in a multi-tenant application.
+     * @since 5.12.0
      */
     @Nonnull
-    public Collection<DestinationProperties> getAllDestinationProperties()
+    public List<DestinationProperties> getAllDestinationProperties(
+        @Nonnull final DestinationServiceRetrievalStrategy retrievalStrategy )
     {
+        final var augmenter = DestinationServiceOptionsAugmenter.augmenter().retrievalStrategy(retrievalStrategy);
+        final var options = DestinationOptions.builder().augmentBuilder(augmenter).build();
         return new ArrayList<>(
-            Cache
-                .getOrComputeAllDestinations(
-                    DestinationOptions.builder().build(),
-                    this::getAllDestinationsByRetrievalStrategy)
-                .get());
+            Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get());
     }
 
     /**
-     * Fetches the properties of a specific destination from the BTP Destination Service.
+     * Fetches the properties of a specific destination from the BTP Destination Service on behalf of current tenant.
      * <p>
      * <strong>Caution: This will not perform any authorization flows for the destination.</strong> Destinations
      * obtained this way should only be used for accessing the properties of the destination configuration. For
@@ -235,7 +256,8 @@ public class DestinationService implements DestinationLoader
      * @param options
      *            Destination configuration object.
      * @return A Try iterable of CF destinations.
-     * @deprecated since 5.1.0. Use {@link #getAllDestinationProperties()} instead.
+     * @deprecated since 5.1.0. Use {@link #getAllDestinationProperties()} and
+     *             {@link #getAllDestinationProperties(DestinationServiceRetrievalStrategy)} instead.
      */
     @Nonnull
     @Deprecated
@@ -264,7 +286,7 @@ public class DestinationService implements DestinationLoader
             DestinationRetrievalStrategyResolver
                 .forAllDestinations(adapter::getProviderTenantId, this::loadAndParseAllDestinations);
 
-        return Try.success(options).map(resolver::prepareSupplierAllDestinations).map(Supplier::get);
+        return Try.of(() -> resolver.prepareSupplierAllDestinations(options).get());
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -174,7 +174,7 @@ public class DestinationService implements DestinationLoader
     }
 
     /**
-     * Fetches all destination properties from the BTP Destination Service on behalf of current tenant.
+     * Fetches all destination properties from the BTP Destination Service on behalf of the current tenant.
      * <p>
      * <strong>Caution: This will not perform any authorization flows for the destinations.</strong> Destinations
      * obtained this way should only be used for accessing the properties of the destination configuration. For
@@ -188,7 +188,7 @@ public class DestinationService implements DestinationLoader
      * @since 5.1.0
      */
     @Nonnull
-    public List<DestinationProperties> getAllDestinationProperties()
+    public Collection<DestinationProperties> getAllDestinationProperties()
     {
         return getAllDestinationProperties(DestinationServiceRetrievalStrategy.CURRENT_TENANT);
     }
@@ -209,7 +209,7 @@ public class DestinationService implements DestinationLoader
      * @since 5.12.0
      */
     @Nonnull
-    public List<DestinationProperties> getAllDestinationProperties(
+    public Collection<DestinationProperties> getAllDestinationProperties(
         @Nonnull final DestinationServiceRetrievalStrategy retrievalStrategy )
     {
         final var augmenter = DestinationServiceOptionsAugmenter.augmenter().retrievalStrategy(retrievalStrategy);
@@ -219,7 +219,8 @@ public class DestinationService implements DestinationLoader
     }
 
     /**
-     * Fetches the properties of a specific destination from the BTP Destination Service on behalf of current tenant.
+     * Fetches the properties of a specific destination from the BTP Destination Service on behalf of the current
+     * tenant.
      * <p>
      * <strong>Caution: This will not perform any authorization flows for the destination.</strong> Destinations
      * obtained this way should only be used for accessing the properties of the destination configuration. For
@@ -286,7 +287,7 @@ public class DestinationService implements DestinationLoader
             DestinationRetrievalStrategyResolver
                 .forAllDestinations(adapter::getProviderTenantId, this::loadAndParseAllDestinations);
 
-        return Try.of(() -> resolver.prepareSupplierAllDestinations(options).get());
+        return Try.success(options).map(resolver::prepareSupplierAllDestinations).map(Supplier::get);
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -481,12 +481,6 @@ class DestinationServiceTest
         assertThat(destinationList)
             .extracting(d -> d.get(DestinationProperty.NAME).get())
             .containsExactly("CC8-HTTP-BASIC", "CC8-HTTP-CERT1", "CC8-HTTP-CERT");
-
-        // verify all results are cached
-        verify(destinationServiceAdapter, times(1))
-            .getConfigurationAsJson("/instanceDestinations", withoutToken(TECHNICAL_USER_PROVIDER));
-        verify(destinationServiceAdapter, times(1))
-            .getConfigurationAsJson("/subaccountDestinations", withoutToken(TECHNICAL_USER_PROVIDER));
     }
 
     @Test
@@ -503,12 +497,6 @@ class DestinationServiceTest
         assertThat(destinationList)
             .extracting(d -> d.get(DestinationProperty.NAME).get())
             .containsExactly("CC8-HTTP-BASIC", "CC8-HTTP-CERT1", "CC8-HTTP-CERT");
-
-        // verify all results are cached
-        verify(destinationServiceAdapter, times(1))
-            .getConfigurationAsJson("/instanceDestinations", withoutToken(TECHNICAL_USER_CURRENT_TENANT));
-        verify(destinationServiceAdapter, times(1))
-            .getConfigurationAsJson("/subaccountDestinations", withoutToken(TECHNICAL_USER_CURRENT_TENANT));
     }
 
     @Test

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -620,16 +620,11 @@ class DestinationServiceTest
     @DisplayName( "Test getting Destination Properties can enforce a subscriber tenant" )
     void testGetAllDestinationPropertiesOnlySubscriberStrategyReadsSubscriberDestinations()
     {
-        // set current tenant to be the provider tenant
-        context.clearTenant();
-
-        TenantAccessor
-            .executeWithTenant(
-                providerTenant,
-                () -> assertThatThrownBy(() -> loader.getAllDestinationProperties(ONLY_SUBSCRIBER))
-                    .isInstanceOf(DestinationAccessException.class)
-                    .hasMessageContaining(
-                        "The current tenant is the provider tenant, which should not be the case with the option OnlySubscriber. Cannot retrieve destination."));
+        context.setTenant(providerTenant);
+        assertThatThrownBy(() -> loader.getAllDestinationProperties(ONLY_SUBSCRIBER))
+            .isInstanceOf(DestinationAccessException.class)
+            .hasMessageContaining(
+                "The current tenant is the provider tenant, which should not be the case with the option OnlySubscriber. Cannot retrieve destination.");
     }
 
     @Test

--- a/release_notes.md
+++ b/release_notes.md
@@ -15,6 +15,10 @@
 - Timeouts for OAuth2 token retrievals can now be customized.
   As part of `ServiceBindingDestinationOptions` the new option `OAuth2Options.TokenRetrievalTimeout` can now be passed to set a custom timeout.
   Refer to [this documentation](https://sap.github.io/cloud-sdk/docs/java/features/connectivity/service-bindings#about-the-options) for more details.
+- In `DestinationService` class allow for optional argument `DestinationServiceRetrievalStrategy` in method `getAllDestinationProperties`.
+  This additional API allows for ensuring tenant-specific destination lookups.
+  Available values are: `CURRENT_TENANT` (default), `ALWAYS_PROVIDER` and `ONLY_SUBSCRIBER`.
+  
 
 ### 📈 Improvements
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

#558

We deprecated public `DestinationService` method `public Try<Iterable<Destination>> tryGetAllDestinations( @Nonnull final DestinationOptions options )`. The user wants an alternative to ensure the destination lookup happens for correct tenant.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
