### PR TITLE
feat: Add `getCardinality()` to `DestinationHeaderProvider`

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -215,16 +215,16 @@ public final class DefaultHttpDestination implements HttpDestination
         final var result = new LinkedList<T>();
         final var retain = new AtomicInteger();
         for( T provider : providers ) {
+            result.add(provider);
             if( provider.getCardinality() != Integer.MAX_VALUE ) {
-                retain.set(provider.getCardinality() - 1);
+                retain.set(provider.getCardinality());
                 final var iter = result.descendingIterator();
                 while( iter.hasNext() ) {
-                    if( provider.getClass().isInstance(iter.next()) && retain.decrementAndGet() < 0 ) {
+                    if( iter.next().getClass().isInstance(provider) && retain.decrementAndGet() < 0 ) {
                         iter.remove();
                     }
                 }
             }
-            result.add(provider);
         }
         return result;
     }

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestination.java
@@ -214,7 +214,7 @@ public final class DefaultHttpDestination implements HttpDestination
     {
         final var result = new LinkedList<T>();
         final var retain = new AtomicInteger();
-        for( T provider : providers ) {
+        for( final T provider : providers ) {
             result.add(provider);
             if( provider.getCardinality() != Integer.MAX_VALUE ) {
                 retain.set(provider.getCardinality());

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationBuilderProxyHandler.java
@@ -19,6 +19,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationNotFoun
 import com.sap.cloud.sdk.cloudplatform.security.AuthTokenAccessor;
 
 import io.vavr.control.Option;
+import lombok.Getter;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
@@ -154,6 +155,9 @@ class DefaultHttpDestinationBuilderProxyHandler
     {
         private static final String HEADER_NAME = "SAP-Connectivity-Authentication";
 
+        @Getter
+        private final int cardinality = 1;
+
         @Nonnull
         @Override
         public List<Header> getHeaders( @Nonnull final DestinationRequestContext requestContext )
@@ -168,6 +172,9 @@ class DefaultHttpDestinationBuilderProxyHandler
      */
     static class SapConnectivityLocationIdHeaderProvider implements DestinationHeaderProvider
     {
+        @Getter
+        private final int cardinality = 1;
+
         @Nonnull
         @Override
         public List<Header> getHeaders( @Nonnull final DestinationRequestContext requestContext )

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProvider.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProvider.java
@@ -22,4 +22,20 @@ public interface DestinationHeaderProvider
      */
     @Nonnull
     List<Header> getHeaders( @Nonnull final DestinationRequestContext requestContext );
+
+    /**
+     * Defines the header provider cardinality: how many instances the header provider class can be attached to a single
+     * destination.
+     * <ul>
+     * <li>&lt;1: undefined</li>
+     * <li>1: consider only last attached instance</li>
+     * <li>n&gt;1: last n attached instances.</li>
+     * </ul>
+     *
+     * @return The header provider cardinality.
+     */
+    default int getCardinality()
+    {
+        return Integer.MAX_VALUE;
+    }
 }

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProvider.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationHeaderProvider.java
@@ -27,9 +27,10 @@ public interface DestinationHeaderProvider
      * Defines the header provider cardinality: how many instances the header provider class can be attached to a single
      * destination.
      * <ul>
-     * <li>&lt;1: undefined</li>
-     * <li>1: consider only last attached instance</li>
-     * <li>n&gt;1: last n attached instances.</li>
+     * <li>&lt;0: undefined</li>
+     * <li>0: no instance attached to destination.</li>
+     * <li>1: consider only last instance attached to destination</li>
+     * <li>n&gt;1: last n instances attached to destination.</li>
      * </ul>
      *
      * @return The header provider cardinality.

--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ErpDestinationHeaderProvider.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ErpDestinationHeaderProvider.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import com.google.common.annotations.Beta;
 import com.sap.cloud.sdk.cloudplatform.servlet.LocaleAccessor;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -27,6 +28,9 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 public class ErpDestinationHeaderProvider implements DestinationHeaderProvider
 {
+    @Getter
+    private final int cardinality = 1;
+
     @Nonnull
     @Override
     public List<Header> getHeaders( @Nonnull final DestinationRequestContext requestContext )

--- a/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationTest.java
+++ b/cloudplatform/cloudplatform-connectivity/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpDestinationTest.java
@@ -769,5 +769,20 @@ class DefaultHttpDestinationTest
                     MyHeaderProviderCardinatlity3.class,
                     MyHeaderProviderCardinatlityDefault.class);
         }
+
+        // extension: remove
+        {
+            final var all =
+                asList(
+                    new ErpDestinationHeaderProvider(),
+                    new ErpDestinationHeaderProvider(),
+                    new ErpDestinationHeaderProvider()
+                    {
+                        @Getter
+                        private final int cardinality = 0;
+                    });
+            final var retained = DefaultHttpDestination.refineHeaderProviders(all);
+            assertThat(retained).isEmpty();
+        }
     }
 }

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AuthTokenHeaderProvider.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AuthTokenHeaderProvider.java
@@ -19,6 +19,7 @@ import org.apache.http.HttpHeaders;
 import com.google.common.base.Strings;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 
+import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 
 /**
@@ -27,8 +28,11 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 class AuthTokenHeaderProvider implements DestinationHeaderProvider
 {
-    private static final String SECURITY_SESSION_HEADER = "x-sap-security-session";
     private static final String CREATE_SESSION_VALUE = "create";
+    private static final String SECURITY_SESSION_HEADER = "x-sap-security-session";
+
+    @Getter
+    private final int cardinality = 1;
 
     @Nonnull
     @Override

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DwcHeaderProvider.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DwcHeaderProvider.java
@@ -25,6 +25,9 @@ import lombok.extern.slf4j.Slf4j;
 public class DwcHeaderProvider implements DestinationHeaderProvider
 {
     @Getter
+    private final int cardinality = 1;
+
+    @Getter
     private static final DwcHeaderProvider instance = new DwcHeaderProvider();
 
     @Nonnull

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteConnectivityProxyInformationResolver.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteConnectivityProxyInformationResolver.java
@@ -45,6 +45,10 @@ class MegacliteConnectivityProxyInformationResolver implements DestinationHeader
     // see https://github.com/SAP/cloud-sdk-java-backlog/issues/209
     private static final String CONNECTIVITY_SERVICE_PATH = "/config/v1/connectivity/token";
     private static final Gson GSON = new Gson();
+
+    @Getter
+    private final int cardinality = 1;
+
     @Nonnull
     @Getter
     private static final MegacliteConnectivityProxyInformationResolver instance =

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/MegacliteServiceBindingDestinationLoaderTest.java
@@ -269,6 +269,7 @@ class MegacliteServiceBindingDestinationLoaderTest
         when(mock.getProxyUrl()).thenReturn(proxyUrl);
         when(mock.getAuthorizationToken()).thenReturn("proxy-auth");
         when(mock.getHeaders(any())).thenCallRealMethod();
+        when(mock.getCardinality()).thenCallRealMethod();
 
         sut.setConnectivityResolver(mock);
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
@@ -14,11 +14,14 @@ import com.sap.cloud.sdk.cloudplatform.tenant.Tenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 
 import io.vavr.control.Option;
+import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
 class OAuth2HeaderProvider implements DestinationHeaderProvider
 {
+    @Getter
+    private final int cardinality = 1;
     @Nonnull
     private final OAuth2Service oauth2service;
     @Nonnull

--- a/release_notes.md
+++ b/release_notes.md
@@ -32,4 +32,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fix an issue where multiple instances of the same `DestinationHeaderProvider` type are evaluated to a single destination unintentionally, leading to duplicate HTTP headers and broken HTTP requests consecutively. 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Related issue:
https://github.com/SAP/cloud-sdk-java/issues/550

- [x] Behavior change for _SAP Cloud SDK_ header providers.
  - [x] Implicitly fix customer issue: When transforming _destination->builder->destination_ some header providers are copied. 
- [x] No behavior/breaking change for custom header providers.
  - [x] `int getCardinality()` by default returns `Integer.MAX_VALUE`

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Allow for `0`:
  Header provider descending of type `T` will **not** be considered during header evaluation. Essentially allowing for removal.
- [x] Allow for `1`:
  Only last attached header provider descending of type `T` will be considered during header evaluation.
- [x] Allow for `n>1`:
  Last `n` attached header provider descending of type `T` will be considered during header evaluation.


## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
