### PR TITLE
fix: issue #557: DwC Auth Token not available (DwC + IAS)

### DIFF
--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -150,7 +150,9 @@ public class DwcHeaderUtils
         return doGetNonEmptyDwcHeaderValue(container, key);
     }
 
-    private static String doGetNonEmptyDwcHeaderValue( @Nonnull final RequestHeaderContainer container, final String key )
+    private static
+        String
+        doGetNonEmptyDwcHeaderValue( @Nonnull final RequestHeaderContainer container, final String key )
     {
         return container
             .getHeaderValues(key)

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -126,12 +126,12 @@ public class DwcHeaderUtils
                 .tryGetHeaderContainer()
                 .getOrElseThrow(e -> new DwcHeaderNotFoundException("Unable to get current request headers.", e));
 
-        if(!container.containsHeader(DWC_JWT_HEADER) && !container.containsHeader(DWC_IAS_JWT_HEADER)) {
+        if( !container.containsHeader(DWC_JWT_HEADER) && !container.containsHeader(DWC_IAS_JWT_HEADER) ) {
             throw new DwcHeaderNotFoundException(
                 "Unable to find the " + DWC_JWT_HEADER + " or " + DWC_IAS_JWT_HEADER + " in header.");
         }
 
-        if(container.containsHeader(DWC_IAS_JWT_HEADER)) {
+        if( container.containsHeader(DWC_IAS_JWT_HEADER) ) {
             return doGetNonEmptyDwcHeaderValue(container, DWC_IAS_JWT_HEADER);
         }
 

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -121,21 +121,21 @@ public class DwcHeaderUtils
     @Nonnull
     public static String getDwcJwtOrThrow()
     {
-        final String errMsg = "Unable to find the " + DWC_JWT_HEADER + " or " + DWC_IAS_JWT_HEADER + " header value.";
         final RequestHeaderContainer container =
             RequestHeaderAccessor
                 .tryGetHeaderContainer()
-                .getOrElseThrow(e -> new DwcHeaderNotFoundException(errMsg, e));
+                .getOrElseThrow(e -> new DwcHeaderNotFoundException("Unable to get current request headers.", e));
 
-        if( !container.containsHeader(DWC_JWT_HEADER) && !container.containsHeader(DWC_IAS_JWT_HEADER) ) {
-            throw new DwcHeaderNotFoundException(errMsg);
+        if(!container.containsHeader(DWC_JWT_HEADER) && !container.containsHeader(DWC_IAS_JWT_HEADER)) {
+            throw new DwcHeaderNotFoundException(
+                "Unable to find the " + DWC_JWT_HEADER + " or " + DWC_IAS_JWT_HEADER + " in header.");
         }
 
-        if( container.containsHeader(DWC_IAS_JWT_HEADER) ) {
-            return getNonEmptyDwcHeaderValue(DWC_IAS_JWT_HEADER);
+        if(container.containsHeader(DWC_IAS_JWT_HEADER)) {
+            return doGetNonEmptyDwcHeaderValue(container, DWC_IAS_JWT_HEADER);
         }
 
-        return getNonEmptyDwcHeaderValue(DWC_JWT_HEADER);
+        return doGetNonEmptyDwcHeaderValue(container, DWC_JWT_HEADER);
     }
 
     @Nonnull
@@ -147,6 +147,11 @@ public class DwcHeaderUtils
                 .tryGetHeaderContainer()
                 .getOrElseThrow(e -> new DwcHeaderNotFoundException("Unable to read the " + key + " header value.", e));
 
+        return doGetNonEmptyDwcHeaderValue(container, key);
+    }
+
+    private static String doGetNonEmptyDwcHeaderValue( @Nonnull RequestHeaderContainer container, final String key )
+    {
         return container
             .getHeaderValues(key)
             .stream()

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -150,7 +150,7 @@ public class DwcHeaderUtils
         return doGetNonEmptyDwcHeaderValue(container, key);
     }
 
-    private static String doGetNonEmptyDwcHeaderValue( @Nonnull RequestHeaderContainer container, final String key )
+    private static String doGetNonEmptyDwcHeaderValue( @Nonnull final RequestHeaderContainer container, final String key )
     {
         return container
             .getHeaderValues(key)

--- a/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
+++ b/cloudplatform/connectivity-dwc/src/main/java/com/sap/cloud/sdk/cloudplatform/DwcHeaderUtils.java
@@ -41,6 +41,10 @@ public class DwcHeaderUtils
      * The name of the header that contains the Deploy with Confidence JWT token.
      */
     public static final String DWC_JWT_HEADER = "dwc-jwt";
+    /**
+     * The name of the header that contains the Deploy with Confidence JWT token issued by IAS.
+     */
+    public static final String DWC_IAS_JWT_HEADER = "dwc-ias-jwt";
 
     /**
      * This method fetches the value of the {@link #DWC_TENANT_HEADER} header or throws an
@@ -117,6 +121,20 @@ public class DwcHeaderUtils
     @Nonnull
     public static String getDwcJwtOrThrow()
     {
+        final String errMsg = "Unable to find the " + DWC_JWT_HEADER + " or " + DWC_IAS_JWT_HEADER + " header value.";
+        final RequestHeaderContainer container =
+            RequestHeaderAccessor
+                .tryGetHeaderContainer()
+                .getOrElseThrow(e -> new DwcHeaderNotFoundException(errMsg, e));
+
+        if( !container.containsHeader(DWC_JWT_HEADER) && !container.containsHeader(DWC_IAS_JWT_HEADER) ) {
+            throw new DwcHeaderNotFoundException(errMsg);
+        }
+
+        if( container.containsHeader(DWC_IAS_JWT_HEADER) ) {
+            return getNonEmptyDwcHeaderValue(DWC_IAS_JWT_HEADER);
+        }
+
         return getNonEmptyDwcHeaderValue(DWC_JWT_HEADER);
     }
 

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.sdk.cloudplatform.security;
 
+import static com.sap.cloud.sdk.cloudplatform.DwcHeaderUtils.DWC_IAS_JWT_HEADER;
 import static com.sap.cloud.sdk.cloudplatform.DwcHeaderUtils.DWC_JWT_HEADER;
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -29,10 +30,21 @@ class DwcAuthTokenFacadeTest
     @Test
     void testSuccessfulAuthTokenRetrieval()
     {
+        this.doTestSuccessfulAuthTokenRetrieval(DWC_JWT_HEADER);
+    }
+
+    @Test
+    void testSuccessfulIasAuthTokenRetrieval()
+    {
+        this.doTestSuccessfulAuthTokenRetrieval(DWC_IAS_JWT_HEADER);
+    }
+
+    void doTestSuccessfulAuthTokenRetrieval(String dwcHeaderKey)
+    {
         final String token = JWT.create().sign(Algorithm.none());
 
         final AuthToken expectedToken = new AuthToken(JWT.decode(token));
-        final Map<String, String> headers = ImmutableMap.of(DWC_JWT_HEADER, token);
+        final Map<String, String> headers = ImmutableMap.of(dwcHeaderKey, token);
 
         RequestHeaderAccessor.executeWithHeaderContainer(headers, () -> {
             final ThreadContext currentContext = ThreadContextAccessor.getCurrentContext();

--- a/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
+++ b/cloudplatform/connectivity-dwc/src/test/java/com/sap/cloud/sdk/cloudplatform/security/DwcAuthTokenFacadeTest.java
@@ -39,7 +39,7 @@ class DwcAuthTokenFacadeTest
         this.doTestSuccessfulAuthTokenRetrieval(DWC_IAS_JWT_HEADER);
     }
 
-    void doTestSuccessfulAuthTokenRetrieval(String dwcHeaderKey)
+    void doTestSuccessfulAuthTokenRetrieval( String dwcHeaderKey )
     {
         final String token = JWT.create().sign(Algorithm.none());
 
@@ -71,7 +71,7 @@ class DwcAuthTokenFacadeTest
             final ThreadContext currentContext = ThreadContextAccessor.getCurrentContext();
             final AuthToken currentToken = AuthTokenAccessor.getCurrentToken();
             final Try<AuthToken> maybeTokenFromContext =
-                    currentContext.getPropertyValue(AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN);
+                currentContext.getPropertyValue(AuthTokenThreadContextListener.PROPERTY_AUTH_TOKEN);
 
             assertThat(currentToken).isEqualTo(expectedToken);
             assertThat(maybeTokenFromContext).contains(expectedToken);

--- a/release_notes.md
+++ b/release_notes.md
@@ -31,5 +31,5 @@
   In case of an error a potential response body will now be logged with the error message.
 
 ### 🐛 Fixed Issues
+- fix: issue [#557](https://github.com/SAP/cloud-sdk-java/issues/557) :  DwC Auth Token not available (DwC + IAS) by @jingweiz2017 in #568
 
-- 


### PR DESCRIPTION
This PR is for fixing the issue SAP#557. The code change is mainly an enhancement on top of SAP#337 to include dwc-ias-jwt in header as auth token as well. dwc-ias-jwt is the key used for auth token when dwc is integrated with ias for authentication.

## Context
https://github.com/SAP/cloud-sdk-java/issues/557

Please provide a short description of what your change does and why it is needed.
The scenario is to propagate user principal from DwC+IAS to an xsuaa based reused service. 
Under such case, the authorization token attached to DwC headers used the key "dwc_ias_jwt". It is different from what approuter would attach (which is Authorization) or DwC+XSUAA would attach(which is dwc_jwt).

This fix is built on top of the fix [#337](https://github.com/SAP/cloud-sdk-java/pull/337). The fix #337 handles auth token retrieving for dwc_jwt for the DwC+xsuaa setup. This fix enhanced that auth token retrieving logic by also looking for "dwc_ias_jwt" header in case of DwC+IAS setup.

### Feature scope:


## Definition of Done
- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated
