### PR TITLE
chore: Add nonnull test case assertions for `DefaultRequestHeaderContainer`

### DIFF
--- a/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/requestheader/DefaultRequestHeaderContainerTest.java
+++ b/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/requestheader/DefaultRequestHeaderContainerTest.java
@@ -86,7 +86,6 @@ class DefaultRequestHeaderContainerTest
 
         assertThat(sut.getHeaderNames()).doesNotContain("key2", "key3").containsExactlyInAnyOrder("key1");
         assertThat(sut.getHeaderValues("Key1")).containsExactlyInAnyOrder("Value1");
-        assertThat(sut.getHeaderValues("Key1")).containsExactlyInAnyOrder("Value1");
         assertThat(sut.getHeaderValues("Key2")).isNotNull().isEmpty();
         assertThat(sut.getHeaderValues("Key3")).isNotNull().isEmpty();
         assertThat(sut.getHeaderValues("Key4")).isNotNull().isEmpty();

--- a/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/requestheader/DefaultRequestHeaderContainerTest.java
+++ b/cloudplatform/cloudplatform-core/src/test/java/com/sap/cloud/sdk/cloudplatform/requestheader/DefaultRequestHeaderContainerTest.java
@@ -84,8 +84,12 @@ class DefaultRequestHeaderContainerTest
 
         final RequestHeaderContainer sut = DefaultRequestHeaderContainer.fromMultiValueMap(input);
 
-        assertThat(sut.getHeaderNames()).containsExactlyInAnyOrder("key1");
+        assertThat(sut.getHeaderNames()).doesNotContain("key2", "key3").containsExactlyInAnyOrder("key1");
         assertThat(sut.getHeaderValues("Key1")).containsExactlyInAnyOrder("Value1");
+        assertThat(sut.getHeaderValues("Key1")).containsExactlyInAnyOrder("Value1");
+        assertThat(sut.getHeaderValues("Key2")).isNotNull().isEmpty();
+        assertThat(sut.getHeaderValues("Key3")).isNotNull().isEmpty();
+        assertThat(sut.getHeaderValues("Key4")).isNotNull().isEmpty();
     }
 
     @Test


### PR DESCRIPTION
When writing [the response here](https://github.com/SAP/cloud-sdk-java/pull/568#discussion_r1736040166) I was wondering how we check for (non-)nullability for `getHeaderValues(String)` returned object.