### PR TITLE
fix: [DevOps] JavaDoc generation

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -229,7 +229,7 @@ jobs:
           mvn $MVN_ARGS
 
       - name: "Coverage Report"
-        run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/reports/jacoco/jacoco.csv"
+        run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"
 
   static-code-analysis:
     needs: [ context, build ]

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -229,7 +229,7 @@ jobs:
           mvn $MVN_ARGS
 
       - name: "Coverage Report"
-        run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/site/jacoco/jacoco.csv"
+        run: python .pipeline/scripts/print-coverage.py --jacoco-report-pattern "**/target/reports/jacoco/jacoco.csv"
 
   static-code-analysis:
     needs: [ context, build ]

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -148,7 +148,7 @@ jobs:
       - name: "Create Release"
         id: create-release
         run: |
-          tar -caf apidocs-${{ needs.bump-version.outputs.release-version }}.tar.gz -C .targets/target/site/apidocs/ .
+          tar -caf apidocs-${{ needs.bump-version.outputs.release-version }}.tar.gz -C .targets/target/reports/apidocs/ .
           tar -caf release-${{ needs.bump-version.outputs.release-version }}.tar.gz -C .release-artifacts/ .
           
           RELEASE_NAME="rel/${{ needs.bump-version.outputs.release-version }}"
@@ -209,7 +209,7 @@ jobs:
 
           rm -rf $TARGET_DIR
           mkdir -p $TARGET_DIR
-          mv ./.targets/target/site/apidocs/* $TARGET_DIR
+          mv ./.targets/target/reports/apidocs/* $TARGET_DIR
 
           cd ./.cloud-sdk-docs
           git add -A .


### PR DESCRIPTION
## Context

Probably a consequence of updating the `maven-site-plugin` recently.

5.12.0 release was successful with this fix
