### PR TITLE
Issue 582: Replace query parameters encoder

### DIFF
--- a/datamodel/openapi/openapi-core/src/main/java/com/sap/cloud/sdk/services/openapi/apiclient/ApiClient.java
+++ b/datamodel/openapi/openapi-core/src/main/java/com/sap/cloud/sdk/services/openapi/apiclient/ApiClient.java
@@ -4,10 +4,8 @@
 
 package com.sap.cloud.sdk.services.openapi.apiclient;
 
-import java.io.UnsupportedEncodingException;
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLEncoder;
 import java.text.DateFormat;
 import java.text.ParseException;
 import java.util.ArrayList;
@@ -40,6 +38,7 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestTemplate;
 import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.web.util.UriUtils;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
@@ -699,14 +698,7 @@ public final class ApiClient
             //encode the query parameters in case they contain unsafe characters
             for( final List<String> values : queryParams.values() ) {
                 if( values != null ) {
-                    for( int i = 0; i < values.size(); i++ ) {
-                        try {
-                            values.set(i, URLEncoder.encode(values.get(i), "utf8"));
-                        }
-                        catch( final UnsupportedEncodingException e ) {
-                            throw new OpenApiRequestException(e);
-                        }
-                    }
+                    values.replaceAll(queryParam -> UriUtils.encodeQueryParam(queryParam, "utf8"));
                 }
             }
             builder.queryParams(queryParams);

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,4 @@
 
 ### 🐛 Fixed Issues
 
-- https://github.com/SAP/cloud-sdk-java/issues/582 Replaced QueryParameters encoder with better version
+- OpenAPI QueryParameters are now encoded

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- https://github.com/SAP/cloud-sdk-java/issues/582 Replaced QueryParameters encoder with better version


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://github.com/SAP/cloud-sdk-java/issues/582

Please provide a short description of what your change does and why it is needed.
ApiClient class is using incorrect encoder class for Query parameters encoding.
Current version is based on URLEncoder.encode((String)values.get(i), "utf8")) which is meant to encode URI (i.e path variables), but does not work well for query parameters because the encoding requirements there are different (i.e. whitespace should not be encoded as "+", but with %20).
The intent is to change the encoding to org.springframework.web.util.UriUtils.encodeQueryParam((String)values.get(i), "utf8"))

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Functionality scope stated & covered
- [x] Tests created / updated _according to the scope_ above
- [x] ~Release notes updated~ 

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
