### PR TITLE
Use SAPMachine for building in CI

### DIFF
--- a/.github/actions/deploy-snapshot/action.yaml
+++ b/.github/actions/deploy-snapshot/action.yaml
@@ -29,7 +29,7 @@ runs:
     - name: "Setup java"
       uses: actions/setup-java@v4
       with:
-        distribution: "temurin"
+        distribution: "sapmachine"
         java-version: "17"
         server-id: artifactory-snapshots
         server-username: DEPLOYMENT_USER

--- a/.github/workflows/cache-maven-dependencies.yaml
+++ b/.github/workflows/cache-maven-dependencies.yaml
@@ -22,7 +22,7 @@ jobs:
       - name: "Setup Java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Download Dependencies"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -83,7 +83,7 @@ jobs:
       - name: "Setup Java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Run Maven Plugins"
@@ -110,7 +110,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Restore Dependencies"
@@ -201,7 +201,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Restore Dependencies"
@@ -262,7 +262,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Restore Dependencies"
@@ -303,7 +303,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Restore Dependencies"
@@ -346,7 +346,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: 17
 
       - name: "Restore Dependencies"

--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -117,7 +117,7 @@ jobs:
       - name: "Setup java"
         uses: actions/setup-java@v4
         with:
-          distribution: "temurin"
+          distribution: "sapmachine"
           java-version: "17"
           server-id: ossrh
           server-username: MAVEN_CENTRAL_USER # env variable for username in deploy


### PR DESCRIPTION
The setup-java action now supports setting up SAPMachine as the openJDK distribution of choice, so we should use it 🚀 
