### PR TITLE
feat: [OpenAPI] Improved OneOf Support

### DIFF
--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOf.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOf.java
@@ -16,13 +16,14 @@
 
 package com.sap.cloud.sdk.datamodel.openapi.sample.model;
 
+import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 /**
  * OneOf
  */
-
-@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "", visible = true )
+@JsonTypeInfo( use = JsonTypeInfo.Id.DEDUCTION )
+@JsonSubTypes( { @JsonSubTypes.Type( value = Cola.class ), @JsonSubTypes.Type( value = Fanta.class ), } )
 
 public interface OneOf
 {

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOfWithDiscriminator.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOfWithDiscriminator.java
@@ -22,13 +22,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 /**
  * OneOfWithDiscriminator
  */
-
-@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true )
+@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true )
 @JsonSubTypes( {
     @JsonSubTypes.Type( value = Cola.class, name = "Cola" ),
     @JsonSubTypes.Type( value = Fanta.class, name = "Fanta" ), } )
 
 public interface OneOfWithDiscriminator
 {
-    public String getSodaType();
+    String getSodaType();
 }

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOfWithDiscriminatorAndMapping.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/OneOfWithDiscriminatorAndMapping.java
@@ -22,13 +22,14 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 /**
  * OneOfWithDiscriminatorAndMapping
  */
-
-@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true )
+@JsonTypeInfo( use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true )
 @JsonSubTypes( {
+    @JsonSubTypes.Type( value = Cola.class, name = "cool_cola" ),
+    @JsonSubTypes.Type( value = Fanta.class, name = "fancy_fanta" ),
     @JsonSubTypes.Type( value = Cola.class, name = "Cola" ),
     @JsonSubTypes.Type( value = Fanta.class, name = "Fanta" ), } )
 
 public interface OneOfWithDiscriminatorAndMapping
 {
-    public String getSodaType();
+    String getSodaType();
 }

--- a/datamodel/openapi/openapi-api-sample/src/main/resources/sodastore.yaml
+++ b/datamodel/openapi/openapi-api-sample/src/main/resources/sodastore.yaml
@@ -99,8 +99,8 @@ components:
       discriminator:
         propertyName: sodaType
         mapping:
-          Cola: '#/components/schemas/Cola'
-          Fanta: '#/components/schemas/Fanta'
+          cool_cola: '#/components/schemas/Cola'
+          fancy_fanta: '#/components/schemas/Fanta'
     OneOfWithDiscriminator:
       oneOf:
         - $ref: '#/components/schemas/Cola'

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
@@ -1,7 +1,7 @@
 package com.sap.cloud.sdk.datamodel.openapi.sample.api;
 
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 
 import javax.annotation.Nonnull;
 
@@ -11,8 +11,8 @@ import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
 import com.fasterxml.jackson.annotation.PropertyAccessor;
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.exc.InvalidTypeIdException;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.AllOf;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.AnyOf;
@@ -22,84 +22,150 @@ import com.sap.cloud.sdk.datamodel.openapi.sample.model.OneOf;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.OneOfWithDiscriminator;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.OneOfWithDiscriminatorAndMapping;
 
-public class OneOfDeserializationTest
+class OneOfDeserializationTest
 {
-    String cola = """
+    private static final ObjectMapper objectMapper = newDefaultObjectMapper();
+
+    private static final Cola COLA_OBJECT = Cola.create().caffeine(true).sodaType("Cola");
+    private static final Fanta FANTA_OBJECT = Fanta.create().color("orange").sodaType("Fanta");
+    private static final String COLA_JSON = """
         {
           "sodaType": "Cola",
           "caffeine": true
         }""";
-    String fanta = """
+    private static final String FANTA_JSON = """
         {
           "sodaType": "Fanta",
           "color": "orange"
         }""";
+    private static final String UNKNOWN_JSON = """
+        {
+          "sodaType": "Sprite",
+          "someProperty": "someValue"
+        }""";
 
     @Test
     void oneOf()
+        throws JsonProcessingException
     {
-        // useOneOfInterfaces is enabled and no discriminator is present, the deserialization will fail
-        // The fix is to use set a mixIn in the ObjectMapper
-        assertThatThrownBy(() -> newDefaultObjectMapper().readValue(cola, OneOf.class))
-            .isInstanceOf(InvalidTypeIdException.class)
-            .hasMessageContaining("Could not resolve subtype");
-        assertThatThrownBy(() -> newDefaultObjectMapper().readValue(fanta, OneOf.class))
-            .isInstanceOf(InvalidTypeIdException.class)
-            .hasMessageContaining("Could not resolve subtype");
+        var actual = objectMapper.readValue(COLA_JSON, OneOf.class);
+        assertThat(actual)
+            .describedAs("Object should automatically be deserialized as Cola with JSON subtype deduction")
+            .isInstanceOf(Cola.class)
+            .isEqualTo(COLA_OBJECT);
+
+        actual = objectMapper.readValue(FANTA_JSON, OneOf.class);
+        assertThat(actual)
+            .describedAs("Object should automatically be deserialized as Fanta with JSON subtype deduction")
+            .isInstanceOf(Fanta.class)
+            .isEqualTo(FANTA_OBJECT);
+
+        assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOf.class))
+            .isInstanceOf(JsonProcessingException.class);
     }
 
     @Test
     void oneOfWithDiscriminator()
         throws JsonProcessingException
     {
-        Cola oneOfCola = (Cola) newDefaultObjectMapper().readValue(cola, OneOfWithDiscriminator.class);
-        assertThat(oneOfCola.getSodaType()).isEqualTo("Cola");
-        assertThat(oneOfCola.isCaffeine()).isTrue();
+        var actual = objectMapper.readValue(COLA_JSON, OneOfWithDiscriminator.class);
+        assertThat(actual)
+            .describedAs(
+                "Object should automatically be deserialized as Cola using the class names as discriminator mapping values")
+            .isInstanceOf(Cola.class)
+            .isEqualTo(COLA_OBJECT);
 
-        Fanta oneOfFanta = (Fanta) newDefaultObjectMapper().readValue(fanta, OneOfWithDiscriminator.class);
-        assertThat(oneOfFanta.getSodaType()).isEqualTo("Fanta");
-        assertThat(oneOfFanta.getColor()).isEqualTo("orange");
+        actual = objectMapper.readValue(FANTA_JSON, OneOfWithDiscriminator.class);
+        assertThat(actual)
+            .describedAs(
+                "Object should automatically be deserialized as Fanta using the class names as discriminator mapping values")
+            .isInstanceOf(Fanta.class)
+            .isEqualTo(FANTA_OBJECT);
+
+        assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminator.class));
     }
 
     @Test
     void oneOfWithDiscriminatorAndMapping()
         throws JsonProcessingException
     {
-        Cola oneOfCola = (Cola) newDefaultObjectMapper().readValue(cola, OneOfWithDiscriminatorAndMapping.class);
-        assertThat(oneOfCola.getSodaType()).isEqualTo("Cola");
-        assertThat(oneOfCola.isCaffeine()).isTrue();
+        var jsonWithCustomMapping = """
+            {
+              "sodaType": "cool_cola",
+              "caffeine": true
+            }""";
+        var actual = objectMapper.readValue(jsonWithCustomMapping, OneOfWithDiscriminatorAndMapping.class);
+        assertThat(actual)
+            .describedAs(
+                "Object should automatically be deserialized as Cola using the explicit discriminator mapping values")
+            .isInstanceOf(Cola.class)
+            .isEqualTo(Cola.create().caffeine(true).sodaType("cool_cola"));
 
-        Fanta oneOfFanta = (Fanta) newDefaultObjectMapper().readValue(fanta, OneOfWithDiscriminatorAndMapping.class);
-        assertThat(oneOfFanta.getSodaType()).isEqualTo("Fanta");
-        assertThat(oneOfFanta.getColor()).isEqualTo("orange");
+        jsonWithCustomMapping = """
+            {
+              "sodaType": "fancy_fanta",
+              "color": "orange"
+            }""";
+        actual = objectMapper.readValue(jsonWithCustomMapping, OneOfWithDiscriminatorAndMapping.class);
+        assertThat(actual)
+            .describedAs(
+                "Object should automatically be deserialized as Fanta using the explicit discriminator mapping values")
+            .isInstanceOf(Fanta.class)
+            .isEqualTo(Fanta.create().color("orange").sodaType("fancy_fanta"));
+
+        assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminatorAndMapping.class))
+                .isInstanceOf(JsonProcessingException.class);
+
     }
 
     @Test
     void anyOf()
         throws JsonProcessingException
     {
-        AnyOf anyOfCola = newDefaultObjectMapper().readValue(cola, AnyOf.class);
+        AnyOf anyOfCola = objectMapper.readValue(COLA_JSON, AnyOf.class);
         assertThat(anyOfCola.getSodaType()).isEqualTo("Cola");
         assertThat(anyOfCola.isCaffeine()).isTrue();
+        assertThat(anyOfCola.getColor()).isNull();
 
-        AnyOf anyOfFanta = newDefaultObjectMapper().readValue(fanta, AnyOf.class);
+        AnyOf anyOfFanta = objectMapper.readValue(FANTA_JSON, AnyOf.class);
         assertThat(anyOfFanta.getSodaType()).isEqualTo("Fanta");
         assertThat(anyOfFanta.getColor()).isEqualTo("orange");
+        assertThat(anyOfFanta.isCaffeine()).isNull();
     }
 
     @Test
     void allOf()
         throws JsonProcessingException
     {
-        AllOf allOfCola = newDefaultObjectMapper().readValue(cola, AllOf.class);
+        AllOf allOfCola = objectMapper.readValue(COLA_JSON, AllOf.class);
         assertThat(allOfCola.getSodaType()).isEqualTo("Cola");
         assertThat(allOfCola.isCaffeine()).isTrue();
         assertThat(allOfCola.getColor()).isNull();
 
-        AllOf allOfFanta = newDefaultObjectMapper().readValue(fanta, AllOf.class);
+        AllOf allOfFanta = objectMapper.readValue(FANTA_JSON, AllOf.class);
         assertThat(allOfFanta.getSodaType()).isEqualTo("Fanta");
         assertThat(allOfFanta.getColor()).isEqualTo("orange");
         assertThat(allOfFanta.isCaffeine()).isNull();
+    }
+
+    @Test
+    void testColaSerialization()
+        throws JsonProcessingException
+    {
+        var expected = objectMapper.readValue(COLA_JSON, JsonNode.class);
+        var actual = objectMapper.valueToTree(expected);
+
+        assertThat(actual).isEqualTo(expected);
+    }
+
+    @Test
+    void testFantaSerialization()
+        throws JsonProcessingException
+    {
+        var expected = objectMapper.readValue(FANTA_JSON, JsonNode.class);
+        var actual = objectMapper.valueToTree(expected);
+
+        assertThat(actual).isEqualTo(expected);
     }
 
     /**

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
@@ -114,7 +114,7 @@ class OneOfDeserializationTest
             .isEqualTo(Fanta.create().color("orange").sodaType("fancy_fanta"));
 
         assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminatorAndMapping.class))
-                .isInstanceOf(JsonProcessingException.class);
+            .isInstanceOf(JsonProcessingException.class);
 
     }
 

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -104,6 +104,9 @@ class GenerationConfigurationConverter
         if( configuration.isGenerateModels() ) {
             GlobalSettings.setProperty(CodegenConstants.MODELS, "");
         }
+        if( configuration.isDebugModels() ) {
+            GlobalSettings.setProperty("debugModels", "true");
+        }
         GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, Boolean.FALSE.toString());
         GlobalSettings.setProperty(CodegenConstants.MODEL_DOCS, Boolean.FALSE.toString());
         GlobalSettings.setProperty(CodegenConstants.API_TESTS, Boolean.FALSE.toString());

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/model/GenerationConfiguration.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/model/GenerationConfiguration.java
@@ -62,6 +62,9 @@ public class GenerationConfiguration
     @Builder.Default
     boolean generateApis = true;
 
+    @Builder.Default
+    boolean debugModels = false;
+
     /**
      * Indicates whether to use the default SAP copyright header for generated files.
      *

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/oneof_interface.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/oneof_interface.mustache
@@ -6,6 +6,6 @@
 {{>additionalOneOfTypeAnnotations}}{{>typeInfoAnnotation}}{{>xmlAnnotation}}
 public interface {{classname}} {{#vendorExtensions.x-implements}}{{#-first}}extends {{{.}}}{{/-first}}{{^-first}}, {{{.}}}{{/-first}}{{/vendorExtensions.x-implements}} {
     {{#discriminator}}
-    public {{propertyType}} {{propertyGetter}}();
+    {{propertyType}} {{propertyGetter}}();
     {{/discriminator}}
 }

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/typeInfoAnnotation.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/typeInfoAnnotation.mustache
@@ -1,13 +1,18 @@
 {{#jackson}}
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "{{{discriminator.propertyBaseName}}}", visible = true)
-{{#discriminator.mappedModels}}
-{{#-first}}
+{{#discriminator}}
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "{{{discriminator.propertyBaseName}}}", visible = true)
+{{/discriminator}}
+{{^discriminator}}
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+{{/discriminator}}
 @JsonSubTypes({
-{{/-first}}
-  @JsonSubTypes.Type(value = {{modelName}}.class, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"),
-{{#-last}}
-})
-{{/-last}}
+{{#discriminator.mappedModels}}
+  @JsonSubTypes.Type(value = {{modelName}}.class{{#discriminator}}, name = "{{^vendorExtensions.x-discriminator-value}}{{mappingName}}{{/vendorExtensions.x-discriminator-value}}{{#vendorExtensions.x-discriminator-value}}{{{vendorExtensions.x-discriminator-value}}}{{/vendorExtensions.x-discriminator-value}}"{{/discriminator}}),
 {{/discriminator.mappedModels}}
+{{^discriminator.mappedModels}}
+{{#model.oneOf}}
+    @JsonSubTypes.Type(value = {{.}}.class),
+{{/model.oneOf}}
+{{/discriminator.mappedModels}}
+})
 {{/jackson}}

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -163,6 +163,7 @@ class DataModelGeneratorIntegrationTest
         final var generationConfiguration =
             GenerationConfiguration
                 .builder()
+                // .debugModels(true) enable this for better mustache file debugging
                 .apiPackage(testCase.apiPackageName)
                 .generateApis(testCase.generateApis)
                 .modelPackage(testCase.modelPackageName)

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/generate-apis/output/test/OneOfWithDiscriminator.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/generate-apis/output/test/OneOfWithDiscriminator.java
@@ -43,8 +43,7 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminator
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/generate-apis/output/test/OneOfWithDiscriminatorAndMapping.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/generate-apis/output/test/OneOfWithDiscriminatorAndMapping.java
@@ -43,8 +43,7 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminatorAndMapping
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-disabled/output/test/OneOfWithDiscriminator.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-disabled/output/test/OneOfWithDiscriminator.java
@@ -43,8 +43,7 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminator
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-disabled/output/test/OneOfWithDiscriminatorAndMapping.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-disabled/output/test/OneOfWithDiscriminatorAndMapping.java
@@ -43,8 +43,7 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminatorAndMapping
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/input/sodastore.yaml
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/input/sodastore.yaml
@@ -26,8 +26,8 @@ components:
       discriminator:
         propertyName: sodaType
         mapping:
-          Cola: '#/components/schemas/Cola'
-          Fanta: '#/components/schemas/Fanta'
+          cool_cola: '#/components/schemas/Cola'
+          fancy_fanta: '#/components/schemas/Fanta'
     OneOfWithDiscriminator:
       oneOf:
         - $ref: '#/components/schemas/Cola'

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOf.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOf.java
@@ -43,8 +43,11 @@ import javax.annotation.Nullable;
 /**
  * OneOf
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.DEDUCTION)
+@JsonSubTypes({
+    @JsonSubTypes.Type(value = Cola.class),
+    @JsonSubTypes.Type(value = Fanta.class),
+})
 
 public interface OneOf  {
 }

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOfWithDiscriminator.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOfWithDiscriminator.java
@@ -43,14 +43,13 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminator
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),
 })
 
 public interface OneOfWithDiscriminator  {
-    public String getSodaType();
+    String getSodaType();
 }
 

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOfWithDiscriminatorAndMapping.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/oneof-interfaces-enabled/output/test/OneOfWithDiscriminatorAndMapping.java
@@ -43,14 +43,15 @@ import javax.annotation.Nullable;
 /**
  * OneOfWithDiscriminatorAndMapping
  */
-
-@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, include = JsonTypeInfo.As.PROPERTY, property = "sodaType", visible = true)
+@JsonTypeInfo(use = JsonTypeInfo.Id.NAME, property = "sodaType", visible = true)
 @JsonSubTypes({
+  @JsonSubTypes.Type(value = Cola.class, name = "cool_cola"),
+  @JsonSubTypes.Type(value = Fanta.class, name = "fancy_fanta"),
   @JsonSubTypes.Type(value = Cola.class, name = "Cola"),
   @JsonSubTypes.Type(value = Fanta.class, name = "Fanta"),
 })
 
 public interface OneOfWithDiscriminatorAndMapping  {
-    public String getSodaType();
+    String getSodaType();
 }
 


### PR DESCRIPTION
## Context

Follow up to #647, see [this comment](https://github.com/SAP/cloud-sdk-java/pull/647#discussion_r1860833002) 

### Feature scope:

- [x] `oneOf` deserialization support without discriminators
- [x] remove `@Type` property from serialization
- [x] serialization test
- [x] general template improvements
- [x] easier template debugging via property

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

