### PR TITLE
Fix: TLS Upgrade config propagates to RestTemplate

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Wrapper.java
@@ -8,6 +8,8 @@ import java.io.IOException;
 import java.net.URI;
 import java.net.URISyntaxException;
 
+import org.apache.hc.client5.http.config.Configurable;
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpResponse;
 import org.apache.hc.core5.http.ClassicHttpRequest;
@@ -30,11 +32,12 @@ import lombok.extern.slf4j.Slf4j;
  * and it will append the url configured in the destination.
  */
 @Slf4j
-class ApacheHttpClient5Wrapper extends CloseableHttpClient
+class ApacheHttpClient5Wrapper extends CloseableHttpClient implements Configurable
 {
     private final CloseableHttpClient httpClient;
     @Getter( AccessLevel.PACKAGE )
     private final HttpDestinationProperties destination;
+    private final RequestConfig requestConfig;
 
     @Override
     public void close()
@@ -49,7 +52,10 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         httpClient.close(closeMode);
     }
 
-    ApacheHttpClient5Wrapper( final CloseableHttpClient httpClient, final HttpDestinationProperties destination )
+    ApacheHttpClient5Wrapper(
+        final CloseableHttpClient httpClient,
+        final HttpDestinationProperties destination,
+        final RequestConfig requestConfig )
     {
         this.httpClient = httpClient;
 
@@ -62,6 +68,7 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
                 """);
         }
         this.destination = destination;
+        this.requestConfig = requestConfig;
     }
 
     @Override
@@ -86,7 +93,7 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         if( destination == this.destination ) {
             return this;
         }
-        return new ApacheHttpClient5Wrapper(httpClient, destination);
+        return new ApacheHttpClient5Wrapper(httpClient, destination, requestConfig);
     }
 
     ClassicHttpRequest wrapRequest( final ClassicHttpRequest request )
@@ -118,5 +125,11 @@ class ApacheHttpClient5Wrapper extends CloseableHttpClient
         }
 
         return requestBuilder.build();
+    }
+
+    @Override
+    public RequestConfig getConfig()
+    {
+        return requestConfig;
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
@@ -82,7 +82,7 @@ class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
             return httpClient;
         }
 
-        return new ApacheHttpClient5Wrapper(httpClient, destination);
+        return new ApacheHttpClient5Wrapper(httpClient, destination, getRequestConfig(destination));
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
@@ -77,22 +77,25 @@ class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
         throws DestinationAccessException,
             HttpClientInstantiationException
     {
-        final CloseableHttpClient httpClient = buildHttpClient(destination);
+        final var requestConfig = getRequestConfig(destination);
+        final CloseableHttpClient httpClient = buildHttpClient(destination, requestConfig);
         if( destination == null ) {
             return httpClient;
         }
 
-        return new ApacheHttpClient5Wrapper(httpClient, destination, getRequestConfig(destination));
+        return new ApacheHttpClient5Wrapper(httpClient, destination, requestConfig);
     }
 
     @Nonnull
-    private CloseableHttpClient buildHttpClient( @Nullable final HttpDestinationProperties destination )
+    private CloseableHttpClient buildHttpClient(
+        @Nullable final HttpDestinationProperties destination,
+        @Nonnull final RequestConfig requestConfig )
     {
         final HttpClientBuilder builder =
             HttpClients
                 .custom()
                 .setConnectionManager(getConnectionManager(destination))
-                .setDefaultRequestConfig(getRequestConfig(destination))
+                .setDefaultRequestConfig(requestConfig)
                 .setProxy(getProxy(destination));
 
         if( requestInterceptor != null ) {

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientWrapperTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientWrapperTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.mock;
 
 import java.util.List;
 
+import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.junit.jupiter.api.Test;
 
@@ -21,7 +22,7 @@ class HttpClientWrapperTest
             DefaultHttpDestination.builder("http://foo.com").headerProviders(c -> List.of()).build();
         final DefaultHttpDestination thirdDestination = DefaultHttpDestination.builder("http://bar.com").build();
         final ApacheHttpClient5Wrapper sut =
-            new ApacheHttpClient5Wrapper(mock(CloseableHttpClient.class), firstDestination);
+            new ApacheHttpClient5Wrapper(mock(CloseableHttpClient.class), firstDestination, mock(RequestConfig.class));
 
         assertThat(sut.withDestination(firstDestination)).isSameAs(sut);
         assertThat(sut.withDestination(firstDestination)).isNotSameAs(sut.withDestination(secondDestination));

--- a/release_notes.md
+++ b/release_notes.md
@@ -24,4 +24,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fix ApacheHttpClient5Wrapper to propagate the configuration to Spring RestTemplate.


### PR DESCRIPTION
## Context

#659

### Feature scope:
 
- [x] ApacheHttpClient5Wrapper RequestConfig propagates to RestTemplate

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Documentation updated~
- [x] Release notes updated