### PR TITLE
Improve naming of secret in main-build-workflow.

### DIFF
--- a/.github/workflows/main-build.yaml
+++ b/.github/workflows/main-build.yaml
@@ -58,7 +58,7 @@ jobs:
           ci-run-id: ${{ needs.run-ci.outputs.ci-run-id }}
           repository-url: "https://common.repositories.cloud.sap/artifactory/build-snapshots-cloudsdk"
           repository-username: ${{ secrets.ARTIFACTORY_USER }}
-          repository-password: ${{ secrets.ARTIFACTORY_TOKEN }}
+          repository-password: ${{ secrets.ARTIFACTORY_PASSWORD }}
           release-artifact-name: ${{ env.RELEASE_ARTIFACT_NAME }}
 
   notify-job:


### PR DESCRIPTION
## Context

The repo secret formally known as `ARTIFACTORY_TOKEN` was in fact just a password. Update this to a more fitting name.

### Feature scope:
 
- [x] Updated secret name to `ARTIFACTORY_PASSWORD`. (And added the new secret to the repo settings.)

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
