### PR TITLE
[OData] Renamed internal variable `values` to `cloudSdkValues`

### DIFF
--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Address.java
@@ -303,68 +303,68 @@ public class Address extends VdmEntity<Address> implements VdmEntitySet
     @Override
     protected Map<java.lang.String, Object> toMapOfFields()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Street", getStreet());
-        values.put("City", getCity());
-        values.put("State", getState());
-        values.put("Country", getCountry());
-        values.put("PostalCode", getPostalCode());
-        values.put("Latitude", getLatitude());
-        values.put("Longitude", getLongitude());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Street", getStreet());
+        cloudSdkValues.put("City", getCity());
+        cloudSdkValues.put("State", getState());
+        cloudSdkValues.put("Country", getCountry());
+        cloudSdkValues.put("PostalCode", getPostalCode());
+        cloudSdkValues.put("Latitude", getLatitude());
+        cloudSdkValues.put("Longitude", getLongitude());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Street") ) {
-                final Object value = values.remove("Street");
+            if( cloudSdkValues.containsKey("Street") ) {
+                final Object value = cloudSdkValues.remove("Street");
                 if( (value == null) || (!value.equals(getStreet())) ) {
                     setStreet(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("City") ) {
-                final Object value = values.remove("City");
+            if( cloudSdkValues.containsKey("City") ) {
+                final Object value = cloudSdkValues.remove("City");
                 if( (value == null) || (!value.equals(getCity())) ) {
                     setCity(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("State") ) {
-                final Object value = values.remove("State");
+            if( cloudSdkValues.containsKey("State") ) {
+                final Object value = cloudSdkValues.remove("State");
                 if( (value == null) || (!value.equals(getState())) ) {
                     setState(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("Country") ) {
-                final Object value = values.remove("Country");
+            if( cloudSdkValues.containsKey("Country") ) {
+                final Object value = cloudSdkValues.remove("Country");
                 if( (value == null) || (!value.equals(getCountry())) ) {
                     setCountry(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("PostalCode") ) {
-                final Object value = values.remove("PostalCode");
+            if( cloudSdkValues.containsKey("PostalCode") ) {
+                final Object value = cloudSdkValues.remove("PostalCode");
                 if( (value == null) || (!value.equals(getPostalCode())) ) {
                     setPostalCode(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("Latitude") ) {
-                final Object value = values.remove("Latitude");
+            if( cloudSdkValues.containsKey("Latitude") ) {
+                final Object value = cloudSdkValues.remove("Latitude");
                 if( (value == null) || (!value.equals(getLatitude())) ) {
                     setLatitude(((Double) value));
                 }
             }
-            if( values.containsKey("Longitude") ) {
-                final Object value = values.remove("Longitude");
+            if( cloudSdkValues.containsKey("Longitude") ) {
+                final Object value = cloudSdkValues.remove("Longitude");
                 if( (value == null) || (!value.equals(getLongitude())) ) {
                     setLongitude(((Double) value));
                 }
@@ -376,7 +376,7 @@ public class Address extends VdmEntity<Address> implements VdmEntitySet
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
@@ -215,40 +215,40 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
     @Override
     protected Map<java.lang.String, Object> toMapOfFields()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("Email", getEmail());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("Email", getEmail());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("Email") ) {
-                final Object value = values.remove("Email");
+            if( cloudSdkValues.containsKey("Email") ) {
+                final Object value = cloudSdkValues.remove("Email");
                 if( (value == null) || (!value.equals(getEmail())) ) {
                     setEmail(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("AddressId") ) {
-                final Object value = values.remove("AddressId");
+            if( cloudSdkValues.containsKey("AddressId") ) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if( (value == null) || (!value.equals(getAddressId())) ) {
                     setAddressId(((Integer) value));
                 }
@@ -259,8 +259,8 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
         }
         // navigation properties
         {
-            if( (values).containsKey("Address") ) {
-                final Object value = (values).remove("Address");
+            if( (cloudSdkValues).containsKey("Address") ) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if( value instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
@@ -271,7 +271,7 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -284,11 +284,11 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toAddress != null ) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/DateRange.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/DateRange.java
@@ -84,26 +84,26 @@ public class DateRange extends VdmComplex<DateRange>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Start", getStart());
-        values.put("End", getEnd());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Start", getStart());
+        cloudSdkValues.put("End", getEnd());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Start") ) {
-                final Object value = values.remove("Start");
+            if( cloudSdkValues.containsKey("Start") ) {
+                final Object value = cloudSdkValues.remove("Start");
                 if( (value == null) || (!value.equals(getStart())) ) {
                     setStart(((OffsetDateTime) value));
                 }
             }
-            if( values.containsKey("End") ) {
-                final Object value = values.remove("End");
+            if( cloudSdkValues.containsKey("End") ) {
+                final Object value = cloudSdkValues.remove("End");
                 if( (value == null) || (!value.equals(getEnd())) ) {
                     setEnd(((OffsetDateTime) value));
                 }
@@ -115,7 +115,7 @@ public class DateRange extends VdmComplex<DateRange>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/FloorPlan.java
@@ -134,26 +134,26 @@ public class FloorPlan extends VdmEntity<FloorPlan>
     @Override
     protected Map<java.lang.String, Object> toMapOfFields()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("ImageUri", getImageUri());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("ImageUri", getImageUri());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("ImageUri") ) {
-                final Object value = values.remove("ImageUri");
+            if( cloudSdkValues.containsKey("ImageUri") ) {
+                final Object value = cloudSdkValues.remove("ImageUri");
                 if( (value == null) || (!value.equals(getImageUri())) ) {
                     setImageUri(((java.lang.String) value));
                 }
@@ -165,15 +165,15 @@ public class FloorPlan extends VdmEntity<FloorPlan>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/OpeningHours.java
@@ -195,40 +195,40 @@ public class OpeningHours extends VdmEntity<OpeningHours> implements VdmEntitySe
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("DayOfWeek", getDayOfWeek());
-        values.put("OpenTime", getOpenTime());
-        values.put("CloseTime", getCloseTime());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("DayOfWeek", getDayOfWeek());
+        cloudSdkValues.put("OpenTime", getOpenTime());
+        cloudSdkValues.put("CloseTime", getCloseTime());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("DayOfWeek") ) {
-                final Object value = values.remove("DayOfWeek");
+            if( cloudSdkValues.containsKey("DayOfWeek") ) {
+                final Object value = cloudSdkValues.remove("DayOfWeek");
                 if( (value == null) || (!value.equals(getDayOfWeek())) ) {
                     setDayOfWeek(((Integer) value));
                 }
             }
-            if( values.containsKey("OpenTime") ) {
-                final Object value = values.remove("OpenTime");
+            if( cloudSdkValues.containsKey("OpenTime") ) {
+                final Object value = cloudSdkValues.remove("OpenTime");
                 if( (value == null) || (!value.equals(getOpenTime())) ) {
                     setOpenTime(((LocalTime) value));
                 }
             }
-            if( values.containsKey("CloseTime") ) {
-                final Object value = values.remove("CloseTime");
+            if( cloudSdkValues.containsKey("CloseTime") ) {
+                final Object value = cloudSdkValues.remove("CloseTime");
                 if( (value == null) || (!value.equals(getCloseTime())) ) {
                     setCloseTime(((LocalTime) value));
                 }
@@ -240,7 +240,7 @@ public class OpeningHours extends VdmEntity<OpeningHours> implements VdmEntitySe
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
@@ -290,54 +290,54 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
     @Override
     protected Map<java.lang.String, Object> toMapOfFields()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("ShelfId", getShelfId());
-        values.put("VendorId", getVendorId());
-        values.put("Price", getPrice());
-        values.put("Categories", getCategories());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("ShelfId", getShelfId());
+        cloudSdkValues.put("VendorId", getVendorId());
+        cloudSdkValues.put("Price", getPrice());
+        cloudSdkValues.put("Categories", getCategories());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("ShelfId") ) {
-                final Object value = values.remove("ShelfId");
+            if( cloudSdkValues.containsKey("ShelfId") ) {
+                final Object value = cloudSdkValues.remove("ShelfId");
                 if( (value == null) || (!value.equals(getShelfId())) ) {
                     setShelfId(((Integer) value));
                 }
             }
-            if( values.containsKey("VendorId") ) {
-                final Object value = values.remove("VendorId");
+            if( cloudSdkValues.containsKey("VendorId") ) {
+                final Object value = cloudSdkValues.remove("VendorId");
                 if( (value == null) || (!value.equals(getVendorId())) ) {
                     setVendorId(((Integer) value));
                 }
             }
-            if( values.containsKey("Price") ) {
-                final Object value = values.remove("Price");
+            if( cloudSdkValues.containsKey("Price") ) {
+                final Object value = cloudSdkValues.remove("Price");
                 if( (value == null) || (!value.equals(getPrice())) ) {
                     setPrice(((BigDecimal) value));
                 }
             }
-            if( values.containsKey("Categories") ) {
-                final Object value = values.remove("Categories");
+            if( cloudSdkValues.containsKey("Categories") ) {
+                final Object value = cloudSdkValues.remove("Categories");
                 if( (value == null) && (getCategories() != null) ) {
                     setCategories(null);
                 }
@@ -361,8 +361,8 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
         }
         // navigation properties
         {
-            if( (values).containsKey("Vendor") ) {
-                final Object value = (values).remove("Vendor");
+            if( (cloudSdkValues).containsKey("Vendor") ) {
+                final Object value = (cloudSdkValues).remove("Vendor");
                 if( value instanceof Map ) {
                     if( toVendor == null ) {
                         toVendor = new Vendor();
@@ -372,8 +372,8 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
                     toVendor.fromMap(inputMap);
                 }
             }
-            if( (values).containsKey("Shelf") ) {
-                final Object value = (values).remove("Shelf");
+            if( (cloudSdkValues).containsKey("Shelf") ) {
+                final Object value = (cloudSdkValues).remove("Shelf");
                 if( value instanceof Map ) {
                     if( toShelf == null ) {
                         toShelf = new Shelf();
@@ -384,7 +384,7 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -397,14 +397,14 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toVendor != null ) {
-            (values).put("Vendor", toVendor);
+            (cloudSdkValues).put("Vendor", toVendor);
         }
         if( toShelf != null ) {
-            (values).put("Shelf", toShelf);
+            (cloudSdkValues).put("Shelf", toShelf);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/ProductCount.java
@@ -87,26 +87,26 @@ public class ProductCount extends VdmComplex<ProductCount>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ProductId", getProductId());
-        values.put("Quantity", getQuantity());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ProductId", getProductId());
+        cloudSdkValues.put("Quantity", getQuantity());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("ProductId") ) {
-                final Object value = values.remove("ProductId");
+            if( cloudSdkValues.containsKey("ProductId") ) {
+                final Object value = cloudSdkValues.remove("ProductId");
                 if( (value == null) || (!value.equals(getProductId())) ) {
                     setProductId(((Integer) value));
                 }
             }
-            if( values.containsKey("Quantity") ) {
-                final Object value = values.remove("Quantity");
+            if( cloudSdkValues.containsKey("Quantity") ) {
+                final Object value = cloudSdkValues.remove("Quantity");
                 if( (value == null) || (!value.equals(getQuantity())) ) {
                     setQuantity(((Integer) value));
                 }
@@ -118,7 +118,7 @@ public class ProductCount extends VdmComplex<ProductCount>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
@@ -92,20 +92,20 @@ public class PurchaseHistoryItem extends VdmComplex<PurchaseHistoryItem>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ReceiptId", getReceiptId());
-        values.put("ProductCount", getProductCount());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ReceiptId", getReceiptId());
+        cloudSdkValues.put("ProductCount", getProductCount());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("ReceiptId") ) {
-                final Object value = values.remove("ReceiptId");
+            if( cloudSdkValues.containsKey("ReceiptId") ) {
+                final Object value = cloudSdkValues.remove("ReceiptId");
                 if( (value == null) || (!value.equals(getReceiptId())) ) {
                     setReceiptId(((Integer) value));
                 }
@@ -113,8 +113,8 @@ public class PurchaseHistoryItem extends VdmComplex<PurchaseHistoryItem>
         }
         // structured properties
         {
-            if( values.containsKey("ProductCount") ) {
-                final Object value = values.remove("ProductCount");
+            if( cloudSdkValues.containsKey("ProductCount") ) {
+                final Object value = cloudSdkValues.remove("ProductCount");
                 if( value instanceof Map ) {
                     if( getProductCount() == null ) {
                         setProductCount(new ProductCount());
@@ -131,7 +131,7 @@ public class PurchaseHistoryItem extends VdmComplex<PurchaseHistoryItem>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -222,34 +222,34 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("CustomerId", getCustomerId());
-        values.put("TotalAmount", getTotalAmount());
-        values.put("ProductCounts", getProductCounts());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("CustomerId", getCustomerId());
+        cloudSdkValues.put("TotalAmount", getTotalAmount());
+        cloudSdkValues.put("ProductCounts", getProductCounts());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("CustomerId") ) {
-                final Object value = values.remove("CustomerId");
+            if( cloudSdkValues.containsKey("CustomerId") ) {
+                final Object value = cloudSdkValues.remove("CustomerId");
                 if( (value == null) || (!value.equals(getCustomerId())) ) {
                     setCustomerId(((Integer) value));
                 }
             }
-            if( values.containsKey("TotalAmount") ) {
-                final Object value = values.remove("TotalAmount");
+            if( cloudSdkValues.containsKey("TotalAmount") ) {
+                final Object value = cloudSdkValues.remove("TotalAmount");
                 if( (value == null) || (!value.equals(getTotalAmount())) ) {
                     setTotalAmount(((BigDecimal) value));
                 }
@@ -257,8 +257,8 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
         }
         // structured properties
         {
-            if( values.containsKey("ProductCounts") ) {
-                final Object value = values.remove("ProductCounts");
+            if( cloudSdkValues.containsKey("ProductCounts") ) {
+                final Object value = cloudSdkValues.remove("ProductCounts");
                 if( value instanceof Iterable ) {
                     final LinkedList<ProductCount> productCounts = new LinkedList<ProductCount>();
                     for( Object properties : ((Iterable<?>) value) ) {
@@ -279,8 +279,8 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
         }
         // navigation properties
         {
-            if( (values).containsKey("Customer") ) {
-                final Object value = (values).remove("Customer");
+            if( (cloudSdkValues).containsKey("Customer") ) {
+                final Object value = (cloudSdkValues).remove("Customer");
                 if( value instanceof Map ) {
                     if( toCustomer == null ) {
                         toCustomer = new Customer();
@@ -291,7 +291,7 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -304,11 +304,11 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toCustomer != null ) {
-            (values).put("Customer", toCustomer);
+            (cloudSdkValues).put("Customer", toCustomer);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -177,26 +177,26 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("FloorPlanId", getFloorPlanId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("FloorPlanId", getFloorPlanId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("FloorPlanId") ) {
-                final Object value = values.remove("FloorPlanId");
+            if( cloudSdkValues.containsKey("FloorPlanId") ) {
+                final Object value = cloudSdkValues.remove("FloorPlanId");
                 if( (value == null) || (!value.equals(getFloorPlanId())) ) {
                     setFloorPlanId(((Integer) value));
                 }
@@ -207,8 +207,8 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
         }
         // navigation properties
         {
-            if( (values).containsKey("FloorPlan") ) {
-                final Object value = (values).remove("FloorPlan");
+            if( (cloudSdkValues).containsKey("FloorPlan") ) {
+                final Object value = (cloudSdkValues).remove("FloorPlan");
                 if( value instanceof Map ) {
                     if( toFloorPlan == null ) {
                         toFloorPlan = new FloorPlan();
@@ -218,8 +218,8 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
                     toFloorPlan.fromMap(inputMap);
                 }
             }
-            if( (values).containsKey("Products") ) {
-                final Object value = (values).remove("Products");
+            if( (cloudSdkValues).containsKey("Products") ) {
+                final Object value = (cloudSdkValues).remove("Products");
                 if( value instanceof Iterable ) {
                     if( toProducts == null ) {
                         toProducts = Lists.newArrayList();
@@ -246,7 +246,7 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -259,14 +259,14 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toFloorPlan != null ) {
-            (values).put("FloorPlan", toFloorPlan);
+            (cloudSdkValues).put("FloorPlan", toFloorPlan);
         }
         if( toProducts != null ) {
-            (values).put("Products", toProducts);
+            (cloudSdkValues).put("Products", toProducts);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -182,33 +182,33 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected Map<java.lang.String, Object> toMapOfFields()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((java.lang.String) value));
                 }
             }
-            if( values.containsKey("AddressId") ) {
-                final Object value = values.remove("AddressId");
+            if( cloudSdkValues.containsKey("AddressId") ) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if( (value == null) || (!value.equals(getAddressId())) ) {
                     setAddressId(((Integer) value));
                 }
@@ -219,8 +219,8 @@ public class Vendor extends VdmEntity<Vendor>
         }
         // navigation properties
         {
-            if( (values).containsKey("Address") ) {
-                final Object value = (values).remove("Address");
+            if( (cloudSdkValues).containsKey("Address") ) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if( value instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
@@ -231,18 +231,18 @@ public class Vendor extends VdmEntity<Vendor>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties()
     {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toAddress != null ) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/CommonConstants.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/CommonConstants.java
@@ -6,7 +6,7 @@ package com.sap.cloud.sdk.datamodel.odatav4.generator;
 
 class CommonConstants
 {
-    static final String CLASS_NAME_FIELD_SUFFIX = "Field";
-    static final String CLASS_NAME_LINK_SUFFIX = "Link";
-    static final String INLINE_MAP_NAME = "values";
+    static final String CLASS_NAME_FIELD_SUFFIX = "cloudSdkField";
+    static final String CLASS_NAME_LINK_SUFFIX = "cloudSdkLink";
+    static final String INLINE_MAP_NAME = "cloudSdkValues";
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/CommonConstants.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/CommonConstants.java
@@ -6,7 +6,7 @@ package com.sap.cloud.sdk.datamodel.odatav4.generator;
 
 class CommonConstants
 {
-    static final String CLASS_NAME_FIELD_SUFFIX = "cloudSdkField";
-    static final String CLASS_NAME_LINK_SUFFIX = "cloudSdkLink";
+    static final String CLASS_NAME_FIELD_SUFFIX = "Field";
+    static final String CLASS_NAME_LINK_SUFFIX = "Link";
     static final String INLINE_MAP_NAME = "cloudSdkValues";
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/Address.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/Address.java
@@ -72,25 +72,25 @@ public class Address
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Street", getStreet());
-        values.put("City", getCity());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Street", getStreet());
+        cloudSdkValues.put("City", getCity());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Street")) {
-                final Object value = values.remove("Street");
+            if (cloudSdkValues.containsKey("Street")) {
+                final Object value = cloudSdkValues.remove("Street");
                 if ((value == null)||(!value.equals(getStreet()))) {
                     setStreet(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("City")) {
-                final Object value = values.remove("City");
+            if (cloudSdkValues.containsKey("City")) {
+                final Object value = cloudSdkValues.remove("City");
                 if ((value == null)||(!value.equals(getCity()))) {
                     setCity(((java.lang.String) value));
                 }
@@ -102,7 +102,7 @@ public class Address
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/FunctionResult.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/FunctionResult.java
@@ -118,25 +118,25 @@ public class FunctionResult
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("RequestId", getRequestId());
-        values.put("Message", getMessage());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("RequestId", getRequestId());
+        cloudSdkValues.put("Message", getMessage());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("RequestId")) {
-                final Object value = values.remove("RequestId");
+            if (cloudSdkValues.containsKey("RequestId")) {
+                final Object value = cloudSdkValues.remove("RequestId");
                 if ((value == null)||(!value.equals(getRequestId()))) {
                     setRequestId(((UUID) value));
                 }
             }
-            if (values.containsKey("Message")) {
-                final Object value = values.remove("Message");
+            if (cloudSdkValues.containsKey("Message")) {
+                final Object value = cloudSdkValues.remove("Message");
                 if ((value == null)||(!value.equals(getMessage()))) {
                     setMessage(((java.lang.String) value));
                 }
@@ -148,14 +148,14 @@ public class FunctionResult
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/NewComplexResult.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/NewComplexResult.java
@@ -72,25 +72,25 @@ public class NewComplexResult
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Foo", getFoo());
-        values.put("Bar", getBar());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Foo", getFoo());
+        cloudSdkValues.put("Bar", getBar());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Foo")) {
-                final Object value = values.remove("Foo");
+            if (cloudSdkValues.containsKey("Foo")) {
+                final Object value = cloudSdkValues.remove("Foo");
                 if ((value == null)||(!value.equals(getFoo()))) {
                     setFoo(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Bar")) {
-                final Object value = values.remove("Bar");
+            if (cloudSdkValues.containsKey("Bar")) {
+                final Object value = cloudSdkValues.remove("Bar");
                 if ((value == null)||(!value.equals(getBar()))) {
                     setBar(((java.lang.String) value));
                 }
@@ -102,7 +102,7 @@ public class NewComplexResult
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/SimplePerson.java
@@ -122,25 +122,25 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((java.lang.String) value));
                 }
@@ -152,7 +152,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/Relationship.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/Relationship.java
@@ -82,32 +82,32 @@ public class Relationship
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Description", getDescription());
-        values.put("FirstName", getFirstName());
-        values.put("LastName", getLastName());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Description", getDescription());
+        cloudSdkValues.put("FirstName", getFirstName());
+        cloudSdkValues.put("LastName", getLastName());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Description")) {
-                final Object value = values.remove("Description");
+            if (cloudSdkValues.containsKey("Description")) {
+                final Object value = cloudSdkValues.remove("Description");
                 if ((value == null)||(!value.equals(getDescription()))) {
                     setDescription(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("FirstName")) {
-                final Object value = values.remove("FirstName");
+            if (cloudSdkValues.containsKey("FirstName")) {
+                final Object value = cloudSdkValues.remove("FirstName");
                 if ((value == null)||(!value.equals(getFirstName()))) {
                     setFirstName(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("LastName")) {
-                final Object value = values.remove("LastName");
+            if (cloudSdkValues.containsKey("LastName")) {
+                final Object value = cloudSdkValues.remove("LastName");
                 if ((value == null)||(!value.equals(getLastName()))) {
                     setLastName(((java.lang.String) value));
                 }
@@ -119,7 +119,7 @@ public class Relationship
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/SimplePerson.java
@@ -176,27 +176,27 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("FirstName", getFirstName());
-        values.put("LastName", getLastName());
-        values.put("Relationships", getRelationships());
-        values.put("Favorite", getFavorite());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("FirstName", getFirstName());
+        cloudSdkValues.put("LastName", getLastName());
+        cloudSdkValues.put("Relationships", getRelationships());
+        cloudSdkValues.put("Favorite", getFavorite());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("FirstName")) {
-                final Object value = values.remove("FirstName");
+            if (cloudSdkValues.containsKey("FirstName")) {
+                final Object value = cloudSdkValues.remove("FirstName");
                 if ((value == null)||(!value.equals(getFirstName()))) {
                     setFirstName(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("LastName")) {
-                final Object value = values.remove("LastName");
+            if (cloudSdkValues.containsKey("LastName")) {
+                final Object value = cloudSdkValues.remove("LastName");
                 if ((value == null)||(!value.equals(getLastName()))) {
                     setLastName(((java.lang.String) value));
                 }
@@ -204,8 +204,8 @@ public class SimplePerson
         }
         // structured properties
         {
-            if (values.containsKey("Relationships")) {
-                final Object value = values.remove("Relationships");
+            if (cloudSdkValues.containsKey("Relationships")) {
+                final Object value = cloudSdkValues.remove("Relationships");
                 if (value instanceof Iterable) {
                     final LinkedList<Relationship> relationships = new LinkedList<Relationship>();
                     for (Object properties: ((Iterable<?> ) value)) {
@@ -223,8 +223,8 @@ public class SimplePerson
                     setRelationships(null);
                 }
             }
-            if (values.containsKey("Favorite")) {
-                final Object value = values.remove("Favorite");
+            if (cloudSdkValues.containsKey("Favorite")) {
+                final Object value = cloudSdkValues.remove("Favorite");
                 if (value instanceof Map) {
                     if (getFavorite() == null) {
                         setFavorite(new Relationship());
@@ -241,7 +241,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/explicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/explicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -193,46 +193,46 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        values.put("Amount", getAmount());
-        values.put("Cost", getCost());
-        values.put("SSomeday", getSSomeday());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        cloudSdkValues.put("Amount", getAmount());
+        cloudSdkValues.put("Cost", getCost());
+        cloudSdkValues.put("SSomeday", getSSomeday());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Amount")) {
-                final Object value = values.remove("Amount");
+            if (cloudSdkValues.containsKey("Amount")) {
+                final Object value = cloudSdkValues.remove("Amount");
                 if ((value == null)||(!value.equals(getAmount()))) {
                     setAmount(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("Cost")) {
-                final Object value = values.remove("Cost");
+            if (cloudSdkValues.containsKey("Cost")) {
+                final Object value = cloudSdkValues.remove("Cost");
                 if ((value == null)||(!value.equals(getCost()))) {
                     setCost(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SSomeday")) {
-                final Object value = values.remove("SSomeday");
+            if (cloudSdkValues.containsKey("SSomeday")) {
+                final Object value = cloudSdkValues.remove("SSomeday");
                 if ((value == null)||(!value.equals(getSSomeday()))) {
                     setSSomeday(((LocalTime) value));
                 }
@@ -244,7 +244,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
@@ -258,67 +258,67 @@ public class Address
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Street", getStreet());
-        values.put("City", getCity());
-        values.put("State", getState());
-        values.put("Country", getCountry());
-        values.put("PostalCode", getPostalCode());
-        values.put("Latitude", getLatitude());
-        values.put("Longitude", getLongitude());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Street", getStreet());
+        cloudSdkValues.put("City", getCity());
+        cloudSdkValues.put("State", getState());
+        cloudSdkValues.put("Country", getCountry());
+        cloudSdkValues.put("PostalCode", getPostalCode());
+        cloudSdkValues.put("Latitude", getLatitude());
+        cloudSdkValues.put("Longitude", getLongitude());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Street")) {
-                final Object value = values.remove("Street");
+            if (cloudSdkValues.containsKey("Street")) {
+                final Object value = cloudSdkValues.remove("Street");
                 if ((value == null)||(!value.equals(getStreet()))) {
                     setStreet(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("City")) {
-                final Object value = values.remove("City");
+            if (cloudSdkValues.containsKey("City")) {
+                final Object value = cloudSdkValues.remove("City");
                 if ((value == null)||(!value.equals(getCity()))) {
                     setCity(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("State")) {
-                final Object value = values.remove("State");
+            if (cloudSdkValues.containsKey("State")) {
+                final Object value = cloudSdkValues.remove("State");
                 if ((value == null)||(!value.equals(getState()))) {
                     setState(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Country")) {
-                final Object value = values.remove("Country");
+            if (cloudSdkValues.containsKey("Country")) {
+                final Object value = cloudSdkValues.remove("Country");
                 if ((value == null)||(!value.equals(getCountry()))) {
                     setCountry(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("PostalCode")) {
-                final Object value = values.remove("PostalCode");
+            if (cloudSdkValues.containsKey("PostalCode")) {
+                final Object value = cloudSdkValues.remove("PostalCode");
                 if ((value == null)||(!value.equals(getPostalCode()))) {
                     setPostalCode(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Latitude")) {
-                final Object value = values.remove("Latitude");
+            if (cloudSdkValues.containsKey("Latitude")) {
+                final Object value = cloudSdkValues.remove("Latitude");
                 if ((value == null)||(!value.equals(getLatitude()))) {
                     setLatitude(((Double) value));
                 }
             }
-            if (values.containsKey("Longitude")) {
-                final Object value = values.remove("Longitude");
+            if (cloudSdkValues.containsKey("Longitude")) {
+                final Object value = cloudSdkValues.remove("Longitude");
                 if ((value == null)||(!value.equals(getLongitude()))) {
                     setLongitude(((Double) value));
                 }
@@ -330,7 +330,7 @@ public class Address
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -185,39 +185,39 @@ public class Customer
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("Email", getEmail());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("Email", getEmail());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Email")) {
-                final Object value = values.remove("Email");
+            if (cloudSdkValues.containsKey("Email")) {
+                final Object value = cloudSdkValues.remove("Email");
                 if ((value == null)||(!value.equals(getEmail()))) {
                     setEmail(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("AddressId")) {
-                final Object value = values.remove("AddressId");
+            if (cloudSdkValues.containsKey("AddressId")) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if ((value == null)||(!value.equals(getAddressId()))) {
                     setAddressId(((Integer) value));
                 }
@@ -228,8 +228,8 @@ public class Customer
         }
         // navigation properties
         {
-            if ((values).containsKey("Address")) {
-                final Object value = (values).remove("Address");
+            if ((cloudSdkValues).containsKey("Address")) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if (value instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
@@ -240,7 +240,7 @@ public class Customer
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -251,11 +251,11 @@ public class Customer
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toAddress!= null) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/DateRange.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/DateRange.java
@@ -73,25 +73,25 @@ public class DateRange
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Start", getStart());
-        values.put("End", getEnd());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Start", getStart());
+        cloudSdkValues.put("End", getEnd());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Start")) {
-                final Object value = values.remove("Start");
+            if (cloudSdkValues.containsKey("Start")) {
+                final Object value = cloudSdkValues.remove("Start");
                 if ((value == null)||(!value.equals(getStart()))) {
                     setStart(((OffsetDateTime) value));
                 }
             }
-            if (values.containsKey("End")) {
-                final Object value = values.remove("End");
+            if (cloudSdkValues.containsKey("End")) {
+                final Object value = cloudSdkValues.remove("End");
                 if ((value == null)||(!value.equals(getEnd()))) {
                     setEnd(((OffsetDateTime) value));
                 }
@@ -103,7 +103,7 @@ public class DateRange
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
@@ -117,25 +117,25 @@ public class FloorPlan
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("ImageUri", getImageUri());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("ImageUri", getImageUri());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("ImageUri")) {
-                final Object value = values.remove("ImageUri");
+            if (cloudSdkValues.containsKey("ImageUri")) {
+                final Object value = cloudSdkValues.remove("ImageUri");
                 if ((value == null)||(!value.equals(getImageUri()))) {
                     setImageUri(((java.lang.String) value));
                 }
@@ -147,14 +147,14 @@ public class FloorPlan
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
@@ -169,39 +169,39 @@ public class OpeningHours
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("DayOfWeek", getDayOfWeek());
-        values.put("OpenTime", getOpenTime());
-        values.put("CloseTime", getCloseTime());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("DayOfWeek", getDayOfWeek());
+        cloudSdkValues.put("OpenTime", getOpenTime());
+        cloudSdkValues.put("CloseTime", getCloseTime());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("DayOfWeek")) {
-                final Object value = values.remove("DayOfWeek");
+            if (cloudSdkValues.containsKey("DayOfWeek")) {
+                final Object value = cloudSdkValues.remove("DayOfWeek");
                 if ((value == null)||(!value.equals(getDayOfWeek()))) {
                     setDayOfWeek(((Integer) value));
                 }
             }
-            if (values.containsKey("OpenTime")) {
-                final Object value = values.remove("OpenTime");
+            if (cloudSdkValues.containsKey("OpenTime")) {
+                final Object value = cloudSdkValues.remove("OpenTime");
                 if ((value == null)||(!value.equals(getOpenTime()))) {
                     setOpenTime(((LocalTime) value));
                 }
             }
-            if (values.containsKey("CloseTime")) {
-                final Object value = values.remove("CloseTime");
+            if (cloudSdkValues.containsKey("CloseTime")) {
+                final Object value = cloudSdkValues.remove("CloseTime");
                 if ((value == null)||(!value.equals(getCloseTime()))) {
                     setCloseTime(((LocalTime) value));
                 }
@@ -213,7 +213,7 @@ public class OpeningHours
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -247,53 +247,53 @@ public class Product
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("ShelfId", getShelfId());
-        values.put("VendorId", getVendorId());
-        values.put("Price", getPrice());
-        values.put("Categories", getCategories());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("ShelfId", getShelfId());
+        cloudSdkValues.put("VendorId", getVendorId());
+        cloudSdkValues.put("Price", getPrice());
+        cloudSdkValues.put("Categories", getCategories());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("ShelfId")) {
-                final Object value = values.remove("ShelfId");
+            if (cloudSdkValues.containsKey("ShelfId")) {
+                final Object value = cloudSdkValues.remove("ShelfId");
                 if ((value == null)||(!value.equals(getShelfId()))) {
                     setShelfId(((Integer) value));
                 }
             }
-            if (values.containsKey("VendorId")) {
-                final Object value = values.remove("VendorId");
+            if (cloudSdkValues.containsKey("VendorId")) {
+                final Object value = cloudSdkValues.remove("VendorId");
                 if ((value == null)||(!value.equals(getVendorId()))) {
                     setVendorId(((Integer) value));
                 }
             }
-            if (values.containsKey("Price")) {
-                final Object value = values.remove("Price");
+            if (cloudSdkValues.containsKey("Price")) {
+                final Object value = cloudSdkValues.remove("Price");
                 if ((value == null)||(!value.equals(getPrice()))) {
                     setPrice(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("Categories")) {
-                final Object value = values.remove("Categories");
+            if (cloudSdkValues.containsKey("Categories")) {
+                final Object value = cloudSdkValues.remove("Categories");
                 if ((value == null)&&(getCategories()!= null)) {
                     setCategories(null);
                 }
@@ -316,8 +316,8 @@ public class Product
         }
         // navigation properties
         {
-            if ((values).containsKey("Vendor")) {
-                final Object value = (values).remove("Vendor");
+            if ((cloudSdkValues).containsKey("Vendor")) {
+                final Object value = (cloudSdkValues).remove("Vendor");
                 if (value instanceof Map) {
                     if (toVendor == null) {
                         toVendor = new Vendor();
@@ -327,8 +327,8 @@ public class Product
                     toVendor.fromMap(inputMap);
                 }
             }
-            if ((values).containsKey("Shelf")) {
-                final Object value = (values).remove("Shelf");
+            if ((cloudSdkValues).containsKey("Shelf")) {
+                final Object value = (cloudSdkValues).remove("Shelf");
                 if (value instanceof Map) {
                     if (toShelf == null) {
                         toShelf = new Shelf();
@@ -339,7 +339,7 @@ public class Product
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -350,14 +350,14 @@ public class Product
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toVendor!= null) {
-            (values).put("Vendor", toVendor);
+            (cloudSdkValues).put("Vendor", toVendor);
         }
         if (toShelf!= null) {
-            (values).put("Shelf", toShelf);
+            (cloudSdkValues).put("Shelf", toShelf);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
@@ -72,25 +72,25 @@ public class ProductCount
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ProductId", getProductId());
-        values.put("Quantity", getQuantity());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ProductId", getProductId());
+        cloudSdkValues.put("Quantity", getQuantity());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("ProductId")) {
-                final Object value = values.remove("ProductId");
+            if (cloudSdkValues.containsKey("ProductId")) {
+                final Object value = cloudSdkValues.remove("ProductId");
                 if ((value == null)||(!value.equals(getProductId()))) {
                     setProductId(((Integer) value));
                 }
             }
-            if (values.containsKey("Quantity")) {
-                final Object value = values.remove("Quantity");
+            if (cloudSdkValues.containsKey("Quantity")) {
+                final Object value = cloudSdkValues.remove("Quantity");
                 if ((value == null)||(!value.equals(getQuantity()))) {
                     setQuantity(((Integer) value));
                 }
@@ -102,7 +102,7 @@ public class ProductCount
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
@@ -76,19 +76,19 @@ public class PurchaseHistoryItem
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ReceiptId", getReceiptId());
-        values.put("ProductCount", getProductCount());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ReceiptId", getReceiptId());
+        cloudSdkValues.put("ProductCount", getProductCount());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("ReceiptId")) {
-                final Object value = values.remove("ReceiptId");
+            if (cloudSdkValues.containsKey("ReceiptId")) {
+                final Object value = cloudSdkValues.remove("ReceiptId");
                 if ((value == null)||(!value.equals(getReceiptId()))) {
                     setReceiptId(((Integer) value));
                 }
@@ -96,8 +96,8 @@ public class PurchaseHistoryItem
         }
         // structured properties
         {
-            if (values.containsKey("ProductCount")) {
-                final Object value = values.remove("ProductCount");
+            if (cloudSdkValues.containsKey("ProductCount")) {
+                final Object value = cloudSdkValues.remove("ProductCount");
                 if (value instanceof Map) {
                     if (getProductCount() == null) {
                         setProductCount(new ProductCount());
@@ -114,7 +114,7 @@ public class PurchaseHistoryItem
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -189,33 +189,33 @@ public class Receipt
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("CustomerId", getCustomerId());
-        values.put("TotalAmount", getTotalAmount());
-        values.put("ProductCounts", getProductCounts());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("CustomerId", getCustomerId());
+        cloudSdkValues.put("TotalAmount", getTotalAmount());
+        cloudSdkValues.put("ProductCounts", getProductCounts());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("CustomerId")) {
-                final Object value = values.remove("CustomerId");
+            if (cloudSdkValues.containsKey("CustomerId")) {
+                final Object value = cloudSdkValues.remove("CustomerId");
                 if ((value == null)||(!value.equals(getCustomerId()))) {
                     setCustomerId(((Integer) value));
                 }
             }
-            if (values.containsKey("TotalAmount")) {
-                final Object value = values.remove("TotalAmount");
+            if (cloudSdkValues.containsKey("TotalAmount")) {
+                final Object value = cloudSdkValues.remove("TotalAmount");
                 if ((value == null)||(!value.equals(getTotalAmount()))) {
                     setTotalAmount(((BigDecimal) value));
                 }
@@ -223,8 +223,8 @@ public class Receipt
         }
         // structured properties
         {
-            if (values.containsKey("ProductCounts")) {
-                final Object value = values.remove("ProductCounts");
+            if (cloudSdkValues.containsKey("ProductCounts")) {
+                final Object value = cloudSdkValues.remove("ProductCounts");
                 if (value instanceof Iterable) {
                     final LinkedList<ProductCount> productCounts = new LinkedList<ProductCount>();
                     for (Object properties: ((Iterable<?> ) value)) {
@@ -245,8 +245,8 @@ public class Receipt
         }
         // navigation properties
         {
-            if ((values).containsKey("Customer")) {
-                final Object value = (values).remove("Customer");
+            if ((cloudSdkValues).containsKey("Customer")) {
+                final Object value = (cloudSdkValues).remove("Customer");
                 if (value instanceof Map) {
                     if (toCustomer == null) {
                         toCustomer = new Customer();
@@ -257,7 +257,7 @@ public class Receipt
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -268,11 +268,11 @@ public class Receipt
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toCustomer!= null) {
-            (values).put("Customer", toCustomer);
+            (cloudSdkValues).put("Customer", toCustomer);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -153,25 +153,25 @@ public class Shelf
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("FloorPlanId", getFloorPlanId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("FloorPlanId", getFloorPlanId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("FloorPlanId")) {
-                final Object value = values.remove("FloorPlanId");
+            if (cloudSdkValues.containsKey("FloorPlanId")) {
+                final Object value = cloudSdkValues.remove("FloorPlanId");
                 if ((value == null)||(!value.equals(getFloorPlanId()))) {
                     setFloorPlanId(((Integer) value));
                 }
@@ -182,8 +182,8 @@ public class Shelf
         }
         // navigation properties
         {
-            if ((values).containsKey("FloorPlan")) {
-                final Object value = (values).remove("FloorPlan");
+            if ((cloudSdkValues).containsKey("FloorPlan")) {
+                final Object value = (cloudSdkValues).remove("FloorPlan");
                 if (value instanceof Map) {
                     if (toFloorPlan == null) {
                         toFloorPlan = new FloorPlan();
@@ -193,8 +193,8 @@ public class Shelf
                     toFloorPlan.fromMap(inputMap);
                 }
             }
-            if ((values).containsKey("Products")) {
-                final Object value = (values).remove("Products");
+            if ((cloudSdkValues).containsKey("Products")) {
+                final Object value = (cloudSdkValues).remove("Products");
                 if (value instanceof Iterable) {
                     if (toProducts == null) {
                         toProducts = Lists.newArrayList();
@@ -221,7 +221,7 @@ public class Shelf
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -232,14 +232,14 @@ public class Shelf
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toFloorPlan!= null) {
-            (values).put("FloorPlan", toFloorPlan);
+            (cloudSdkValues).put("FloorPlan", toFloorPlan);
         }
         if (toProducts!= null) {
-            (values).put("Products", toProducts);
+            (cloudSdkValues).put("Products", toProducts);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -157,32 +157,32 @@ public class Vendor
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("AddressId")) {
-                final Object value = values.remove("AddressId");
+            if (cloudSdkValues.containsKey("AddressId")) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if ((value == null)||(!value.equals(getAddressId()))) {
                     setAddressId(((Integer) value));
                 }
@@ -193,8 +193,8 @@ public class Vendor
         }
         // navigation properties
         {
-            if ((values).containsKey("Address")) {
-                final Object value = (values).remove("Address");
+            if ((cloudSdkValues).containsKey("Address")) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if (value instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
@@ -205,17 +205,17 @@ public class Vendor
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toAddress!= null) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTest/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTest/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -194,46 +194,46 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        values.put("Amount", getAmount());
-        values.put("Cost", getCost());
-        values.put("SSomeday", getSSomeday());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        cloudSdkValues.put("Amount", getAmount());
+        cloudSdkValues.put("Cost", getCost());
+        cloudSdkValues.put("SSomeday", getSSomeday());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Amount")) {
-                final Object value = values.remove("Amount");
+            if (cloudSdkValues.containsKey("Amount")) {
+                final Object value = cloudSdkValues.remove("Amount");
                 if ((value == null)||(!value.equals(getAmount()))) {
                     setAmount(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("Cost")) {
-                final Object value = values.remove("Cost");
+            if (cloudSdkValues.containsKey("Cost")) {
+                final Object value = cloudSdkValues.remove("Cost");
                 if ((value == null)||(!value.equals(getCost()))) {
                     setCost(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SSomeday")) {
-                final Object value = values.remove("SSomeday");
+            if (cloudSdkValues.containsKey("SSomeday")) {
+                final Object value = cloudSdkValues.remove("SSomeday");
                 if ((value == null)||(!value.equals(getSSomeday()))) {
                     setSSomeday(((LocalTime) value));
                 }
@@ -245,7 +245,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
@@ -120,25 +120,25 @@ public class FooType
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Foo", getFoo());
-        values.put("Type", getType_2());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Foo", getFoo());
+        cloudSdkValues.put("Type", getType_2());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Foo")) {
-                final Object value = values.remove("Foo");
+            if (cloudSdkValues.containsKey("Foo")) {
+                final Object value = cloudSdkValues.remove("Foo");
                 if ((value == null)||(!value.equals(getFoo()))) {
                     setFoo(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("Type")) {
-                final Object value = values.remove("Type");
+            if (cloudSdkValues.containsKey("Type")) {
+                final Object value = cloudSdkValues.remove("Type");
                 if ((value == null)||(!value.equals(getType_2()))) {
                     setType_2(((java.lang.String) value));
                 }
@@ -150,7 +150,7 @@ public class FooType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
@@ -120,25 +120,25 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((java.lang.String) value));
                 }
@@ -150,7 +150,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/Friend.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/Friend.java
@@ -93,18 +93,18 @@ public class Friend
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Name", getName());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Name", getName());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((java.lang.String) value));
                 }
@@ -116,14 +116,14 @@ public class Friend
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -137,25 +137,25 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("ToFriend", getToFriend());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("ToFriend", getToFriend());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("ToFriend")) {
-                final Object value = values.remove("ToFriend");
+            if (cloudSdkValues.containsKey("ToFriend")) {
+                final Object value = cloudSdkValues.remove("ToFriend");
                 if ((value == null)||(!value.equals(getToFriend()))) {
                     setToFriend(((java.lang.String) value));
                 }
@@ -166,8 +166,8 @@ public class SimplePerson
         }
         // navigation properties
         {
-            if ((values).containsKey("Friend")) {
-                final Object value = (values).remove("Friend");
+            if ((cloudSdkValues).containsKey("Friend")) {
+                final Object value = (cloudSdkValues).remove("Friend");
                 if (value instanceof Map) {
                     if (toFriend_2 == null) {
                         toFriend_2 = new Friend();
@@ -178,7 +178,7 @@ public class SimplePerson
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -189,11 +189,11 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toFriend_2 != null) {
-            (values).put("Friend", toFriend_2);
+            (cloudSdkValues).put("Friend", toFriend_2);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -258,126 +258,126 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("BaseStringProperty", getBaseStringProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("EnumProperty", getEnumProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        values.put("CollectionStringProperty", getCollectionStringProperty());
-        values.put("CollectionComplexTypeProperty", getCollectionComplexTypeProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("BaseStringProperty", getBaseStringProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("EnumProperty", getEnumProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        cloudSdkValues.put("CollectionStringProperty", getCollectionStringProperty());
+        cloudSdkValues.put("CollectionComplexTypeProperty", getCollectionComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("BaseStringProperty")) {
-                final Object value = values.remove("BaseStringProperty");
+            if (cloudSdkValues.containsKey("BaseStringProperty")) {
+                final Object value = cloudSdkValues.remove("BaseStringProperty");
                 if ((value == null)||(!value.equals(getBaseStringProperty()))) {
                     setBaseStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((OffsetDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((OffsetDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("EnumProperty")) {
-                final Object value = values.remove("EnumProperty");
+            if (cloudSdkValues.containsKey("EnumProperty")) {
+                final Object value = cloudSdkValues.remove("EnumProperty");
                 if ((value instanceof java.lang.String)||(value == null)) {
                     final A_TestEnumType enumProperty = VdmEnum.getConstant(A_TestEnumType.class, ((java.lang.String) value));
                     if (!Objects.equals(enumProperty, getEnumProperty())) {
@@ -385,8 +385,8 @@ public class A_TestComplexType
                     }
                 }
             }
-            if (values.containsKey("CollectionStringProperty")) {
-                final Object value = values.remove("CollectionStringProperty");
+            if (cloudSdkValues.containsKey("CollectionStringProperty")) {
+                final Object value = cloudSdkValues.remove("CollectionStringProperty");
                 if (value instanceof Iterable) {
                     final LinkedList<java.lang.String> collectionStringProperty = new LinkedList<java.lang.String>();
                     for (Object item: ((Iterable<?> ) value)) {
@@ -398,8 +398,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -412,8 +412,8 @@ public class A_TestComplexType
                     setComplexTypeProperty(null);
                 }
             }
-            if (values.containsKey("CollectionComplexTypeProperty")) {
-                final Object value = values.remove("CollectionComplexTypeProperty");
+            if (cloudSdkValues.containsKey("CollectionComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("CollectionComplexTypeProperty");
                 if (value instanceof Iterable) {
                     final LinkedList<A_TestNestedComplexType> collectionComplexTypeProperty = new LinkedList<A_TestNestedComplexType>();
                     for (Object properties: ((Iterable<?> ) value)) {
@@ -435,7 +435,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -62,18 +62,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
@@ -85,7 +85,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,19 +76,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
@@ -96,8 +96,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -114,7 +114,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
@@ -114,18 +114,18 @@ public class TestEntityCircularLinkChild
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
@@ -136,8 +136,8 @@ public class TestEntityCircularLinkChild
         }
         // navigation properties
         {
-            if ((values).containsKey("to_Parent")) {
-                final Object value = (values).remove("to_Parent");
+            if ((cloudSdkValues).containsKey("to_Parent")) {
+                final Object value = (cloudSdkValues).remove("to_Parent");
                 if (value instanceof Map) {
                     if (toParent == null) {
                         toParent = new TestEntityCircularLinkParent();
@@ -148,7 +148,7 @@ public class TestEntityCircularLinkChild
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -159,11 +159,11 @@ public class TestEntityCircularLinkChild
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toParent!= null) {
-            (values).put("to_Parent", toParent);
+            (cloudSdkValues).put("to_Parent", toParent);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
@@ -114,18 +114,18 @@ public class TestEntityCircularLinkParent
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
@@ -136,8 +136,8 @@ public class TestEntityCircularLinkParent
         }
         // navigation properties
         {
-            if ((values).containsKey("to_Child")) {
-                final Object value = (values).remove("to_Child");
+            if ((cloudSdkValues).containsKey("to_Child")) {
+                final Object value = (cloudSdkValues).remove("to_Child");
                 if (value instanceof Map) {
                     if (toChild == null) {
                         toChild = new TestEntityCircularLinkChild();
@@ -148,7 +148,7 @@ public class TestEntityCircularLinkParent
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -159,11 +159,11 @@ public class TestEntityCircularLinkParent
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toChild!= null) {
-            (values).put("to_Child", toChild);
+            (cloudSdkValues).put("to_Child", toChild);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -190,46 +190,46 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -241,7 +241,7 @@ public class TestEntityLvl2MultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -190,46 +190,46 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -241,7 +241,7 @@ public class TestEntityLvl2SingleLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -222,46 +222,46 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -272,8 +272,8 @@ public class TestEntityMultiLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -299,8 +299,8 @@ public class TestEntityMultiLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -311,7 +311,7 @@ public class TestEntityMultiLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -322,14 +322,14 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -97,18 +97,18 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
@@ -120,7 +120,7 @@ public class TestEntityOtherMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -222,46 +222,46 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -272,8 +272,8 @@ public class TestEntitySingleLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -299,8 +299,8 @@ public class TestEntitySingleLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -311,7 +311,7 @@ public class TestEntitySingleLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -322,14 +322,14 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityStream.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityStream.java
@@ -93,18 +93,18 @@ public class TestEntityStream
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StreamProperty", getStreamProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StreamProperty", getStreamProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StreamProperty")) {
-                final Object value = values.remove("StreamProperty");
+            if (cloudSdkValues.containsKey("StreamProperty")) {
+                final Object value = cloudSdkValues.remove("StreamProperty");
                 if ((value == null)||(!value.equals(getStreamProperty()))) {
                     setStreamProperty(((URI) value));
                 }
@@ -116,14 +116,14 @@ public class TestEntityStream
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
@@ -682,148 +682,148 @@ public class TestEntityV4
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeOfDayProperty", getTimeOfDayProperty());
-        values.put("DateProperty", getDateProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("DurationProperty", getDurationProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("CollectionProperty", getCollectionProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        values.put("ComplexTypeCollectionProperty", getComplexTypeCollectionProperty());
-        values.put("EnumProperty", getEnumProperty());
-        values.put("EnumCollectionProperty", getEnumCollectionProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeOfDayProperty", getTimeOfDayProperty());
+        cloudSdkValues.put("DateProperty", getDateProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("DurationProperty", getDurationProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("CollectionProperty", getCollectionProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        cloudSdkValues.put("ComplexTypeCollectionProperty", getComplexTypeCollectionProperty());
+        cloudSdkValues.put("EnumProperty", getEnumProperty());
+        cloudSdkValues.put("EnumCollectionProperty", getEnumCollectionProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((java.lang.String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((java.lang.Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeOfDayProperty")) {
-                final Object value = values.remove("TimeOfDayProperty");
+            if (cloudSdkValues.containsKey("TimeOfDayProperty")) {
+                final Object value = cloudSdkValues.remove("TimeOfDayProperty");
                 if ((value == null)||(!value.equals(getTimeOfDayProperty()))) {
                     setTimeOfDayProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateProperty")) {
-                final Object value = values.remove("DateProperty");
+            if (cloudSdkValues.containsKey("DateProperty")) {
+                final Object value = cloudSdkValues.remove("DateProperty");
                 if ((value == null)||(!value.equals(getDateProperty()))) {
                     setDateProperty(((LocalDate) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((OffsetDateTime) value));
                 }
             }
-            if (values.containsKey("DurationProperty")) {
-                final Object value = values.remove("DurationProperty");
+            if (cloudSdkValues.containsKey("DurationProperty")) {
+                final Object value = cloudSdkValues.remove("DurationProperty");
                 if ((value == null)||(!value.equals(getDurationProperty()))) {
                     setDurationProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
             }
-            if (values.containsKey("CollectionProperty")) {
-                final Object value = values.remove("CollectionProperty");
+            if (cloudSdkValues.containsKey("CollectionProperty")) {
+                final Object value = cloudSdkValues.remove("CollectionProperty");
                 if (value instanceof Iterable) {
                     final LinkedList<java.lang.String> collectionProperty = new LinkedList<java.lang.String>();
                     for (Object item: ((Iterable<?> ) value)) {
@@ -832,8 +832,8 @@ public class TestEntityV4
                     setCollectionProperty(collectionProperty);
                 }
             }
-            if (values.containsKey("EnumProperty")) {
-                final Object value = values.remove("EnumProperty");
+            if (cloudSdkValues.containsKey("EnumProperty")) {
+                final Object value = cloudSdkValues.remove("EnumProperty");
                 if ((value instanceof java.lang.String)||(value == null)) {
                     final A_TestEnumType enumProperty = VdmEnum.getConstant(A_TestEnumType.class, ((java.lang.String) value));
                     if (!Objects.equals(enumProperty, getEnumProperty())) {
@@ -841,8 +841,8 @@ public class TestEntityV4
                     }
                 }
             }
-            if (values.containsKey("EnumCollectionProperty")) {
-                final Object value = values.remove("EnumCollectionProperty");
+            if (cloudSdkValues.containsKey("EnumCollectionProperty")) {
+                final Object value = cloudSdkValues.remove("EnumCollectionProperty");
                 if ((value == null)&&(getEnumCollectionProperty()!= null)) {
                     setEnumCollectionProperty(null);
                 }
@@ -862,8 +862,8 @@ public class TestEntityV4
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -876,8 +876,8 @@ public class TestEntityV4
                     setComplexTypeProperty(null);
                 }
             }
-            if (values.containsKey("ComplexTypeCollectionProperty")) {
-                final Object value = values.remove("ComplexTypeCollectionProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeCollectionProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeCollectionProperty");
                 if (value instanceof Iterable) {
                     final LinkedList<A_TestComplexType> complexTypeCollectionProperty = new LinkedList<A_TestComplexType>();
                     for (Object properties: ((Iterable<?> ) value)) {
@@ -898,8 +898,8 @@ public class TestEntityV4
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -925,8 +925,8 @@ public class TestEntityV4
                     }
                 }
             }
-            if ((values).containsKey("to_OtherMultiLink")) {
-                final Object value = (values).remove("to_OtherMultiLink");
+            if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
                 if (value instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
@@ -952,8 +952,8 @@ public class TestEntityV4
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
@@ -963,8 +963,8 @@ public class TestEntityV4
                     toSingleLink.fromMap(inputMap);
                 }
             }
-            if ((values).containsKey("to_StreamLink")) {
-                final Object value = (values).remove("to_StreamLink");
+            if ((cloudSdkValues).containsKey("to_StreamLink")) {
+                final Object value = (cloudSdkValues).remove("to_StreamLink");
                 if (value instanceof Map) {
                     if (toStreamLink == null) {
                         toStreamLink = new TestEntityStream();
@@ -975,7 +975,7 @@ public class TestEntityV4
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Override
@@ -986,20 +986,20 @@ public class TestEntityV4
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toOtherMultiLink!= null) {
-            (values).put("to_OtherMultiLink", toOtherMultiLink);
+            (cloudSdkValues).put("to_OtherMultiLink", toOtherMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
         if (toStreamLink!= null) {
-            (values).put("to_StreamLink", toStreamLink);
+            (cloudSdkValues).put("to_StreamLink", toStreamLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4_Only_Function.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4_Only_Function.java
@@ -94,18 +94,18 @@ public class TestEntityV4_Only_Function
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfFields() {
-        final Map<java.lang.String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> values = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((java.lang.String) value));
                 }
@@ -117,14 +117,14 @@ public class TestEntityV4_Only_Function
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull
     @Override
     protected Map<java.lang.String, Object> toMapOfNavigationProperties() {
-        final Map<java.lang.String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<java.lang.String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Address.java
@@ -341,68 +341,68 @@ public class Address extends VdmEntity<Address>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Street", getStreet());
-        values.put("City", getCity());
-        values.put("State", getState());
-        values.put("Country", getCountry());
-        values.put("PostalCode", getPostalCode());
-        values.put("Latitude", getLatitude());
-        values.put("Longitude", getLongitude());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Street", getStreet());
+        cloudSdkValues.put("City", getCity());
+        cloudSdkValues.put("State", getState());
+        cloudSdkValues.put("Country", getCountry());
+        cloudSdkValues.put("PostalCode", getPostalCode());
+        cloudSdkValues.put("Latitude", getLatitude());
+        cloudSdkValues.put("Longitude", getLongitude());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Street") ) {
-                final Object value = values.remove("Street");
+            if( cloudSdkValues.containsKey("Street") ) {
+                final Object value = cloudSdkValues.remove("Street");
                 if( (value == null) || (!value.equals(getStreet())) ) {
                     setStreet(((String) value));
                 }
             }
-            if( values.containsKey("City") ) {
-                final Object value = values.remove("City");
+            if( cloudSdkValues.containsKey("City") ) {
+                final Object value = cloudSdkValues.remove("City");
                 if( (value == null) || (!value.equals(getCity())) ) {
                     setCity(((String) value));
                 }
             }
-            if( values.containsKey("State") ) {
-                final Object value = values.remove("State");
+            if( cloudSdkValues.containsKey("State") ) {
+                final Object value = cloudSdkValues.remove("State");
                 if( (value == null) || (!value.equals(getState())) ) {
                     setState(((String) value));
                 }
             }
-            if( values.containsKey("Country") ) {
-                final Object value = values.remove("Country");
+            if( cloudSdkValues.containsKey("Country") ) {
+                final Object value = cloudSdkValues.remove("Country");
                 if( (value == null) || (!value.equals(getCountry())) ) {
                     setCountry(((String) value));
                 }
             }
-            if( values.containsKey("PostalCode") ) {
-                final Object value = values.remove("PostalCode");
+            if( cloudSdkValues.containsKey("PostalCode") ) {
+                final Object value = cloudSdkValues.remove("PostalCode");
                 if( (value == null) || (!value.equals(getPostalCode())) ) {
                     setPostalCode(((String) value));
                 }
             }
-            if( values.containsKey("Latitude") ) {
-                final Object value = values.remove("Latitude");
+            if( cloudSdkValues.containsKey("Latitude") ) {
+                final Object value = cloudSdkValues.remove("Latitude");
                 if( (value == null) || (!value.equals(getLatitude())) ) {
                     setLatitude(((Double) value));
                 }
             }
-            if( values.containsKey("Longitude") ) {
-                final Object value = values.remove("Longitude");
+            if( cloudSdkValues.containsKey("Longitude") ) {
+                final Object value = cloudSdkValues.remove("Longitude");
                 if( (value == null) || (!value.equals(getLongitude())) ) {
                     setLongitude(((Double) value));
                 }
@@ -414,7 +414,7 @@ public class Address extends VdmEntity<Address>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
@@ -258,40 +258,40 @@ public class Customer extends VdmEntity<Customer>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("Email", getEmail());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("Email", getEmail());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((String) value));
                 }
             }
-            if( values.containsKey("Email") ) {
-                final Object value = values.remove("Email");
+            if( cloudSdkValues.containsKey("Email") ) {
+                final Object value = cloudSdkValues.remove("Email");
                 if( (value == null) || (!value.equals(getEmail())) ) {
                     setEmail(((String) value));
                 }
             }
-            if( values.containsKey("AddressId") ) {
-                final Object value = values.remove("AddressId");
+            if( cloudSdkValues.containsKey("AddressId") ) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if( (value == null) || (!value.equals(getAddressId())) ) {
                     setAddressId(((Integer) value));
                 }
@@ -302,8 +302,8 @@ public class Customer extends VdmEntity<Customer>
         }
         // navigation properties
         {
-            if( (values).containsKey("Address") ) {
-                final Object value = (values).remove("Address");
+            if( (cloudSdkValues).containsKey("Address") ) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if( value instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
@@ -314,7 +314,7 @@ public class Customer extends VdmEntity<Customer>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -384,11 +384,11 @@ public class Customer extends VdmEntity<Customer>
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toAddress != null ) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlan.java
@@ -143,26 +143,26 @@ public class FloorPlan extends VdmEntity<FloorPlan>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("ImageUri", getImageUri());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("ImageUri", getImageUri());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("ImageUri") ) {
-                final Object value = values.remove("ImageUri");
+            if( cloudSdkValues.containsKey("ImageUri") ) {
+                final Object value = cloudSdkValues.remove("ImageUri");
                 if( (value == null) || (!value.equals(getImageUri())) ) {
                     setImageUri(((String) value));
                 }
@@ -174,7 +174,7 @@ public class FloorPlan extends VdmEntity<FloorPlan>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHours.java
@@ -222,40 +222,40 @@ public class OpeningHours extends VdmEntity<OpeningHours>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("DayOfWeek", getDayOfWeek());
-        values.put("OpenTime", getOpenTime());
-        values.put("CloseTime", getCloseTime());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("DayOfWeek", getDayOfWeek());
+        cloudSdkValues.put("OpenTime", getOpenTime());
+        cloudSdkValues.put("CloseTime", getCloseTime());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("DayOfWeek") ) {
-                final Object value = values.remove("DayOfWeek");
+            if( cloudSdkValues.containsKey("DayOfWeek") ) {
+                final Object value = cloudSdkValues.remove("DayOfWeek");
                 if( (value == null) || (!value.equals(getDayOfWeek())) ) {
                     setDayOfWeek(((Integer) value));
                 }
             }
-            if( values.containsKey("OpenTime") ) {
-                final Object value = values.remove("OpenTime");
+            if( cloudSdkValues.containsKey("OpenTime") ) {
+                final Object value = cloudSdkValues.remove("OpenTime");
                 if( (value == null) || (!value.equals(getOpenTime())) ) {
                     setOpenTime(((LocalTime) value));
                 }
             }
-            if( values.containsKey("CloseTime") ) {
-                final Object value = values.remove("CloseTime");
+            if( cloudSdkValues.containsKey("CloseTime") ) {
+                final Object value = cloudSdkValues.remove("CloseTime");
                 if( (value == null) || (!value.equals(getCloseTime())) ) {
                     setCloseTime(((LocalTime) value));
                 }
@@ -267,7 +267,7 @@ public class OpeningHours extends VdmEntity<OpeningHours>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
@@ -317,54 +317,54 @@ public class Product extends VdmMediaEntity<Product>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("ShelfId", getShelfId());
-        values.put("VendorId", getVendorId());
-        values.put("Price", getPrice());
-        values.put("Image", getImage());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("ShelfId", getShelfId());
+        cloudSdkValues.put("VendorId", getVendorId());
+        cloudSdkValues.put("Price", getPrice());
+        cloudSdkValues.put("Image", getImage());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((String) value));
                 }
             }
-            if( values.containsKey("ShelfId") ) {
-                final Object value = values.remove("ShelfId");
+            if( cloudSdkValues.containsKey("ShelfId") ) {
+                final Object value = cloudSdkValues.remove("ShelfId");
                 if( (value == null) || (!value.equals(getShelfId())) ) {
                     setShelfId(((Integer) value));
                 }
             }
-            if( values.containsKey("VendorId") ) {
-                final Object value = values.remove("VendorId");
+            if( cloudSdkValues.containsKey("VendorId") ) {
+                final Object value = cloudSdkValues.remove("VendorId");
                 if( (value == null) || (!value.equals(getVendorId())) ) {
                     setVendorId(((Integer) value));
                 }
             }
-            if( values.containsKey("Price") ) {
-                final Object value = values.remove("Price");
+            if( cloudSdkValues.containsKey("Price") ) {
+                final Object value = cloudSdkValues.remove("Price");
                 if( (value == null) || (!value.equals(getPrice())) ) {
                     setPrice(((BigDecimal) value));
                 }
             }
-            if( values.containsKey("Image") ) {
-                final Object value = values.remove("Image");
+            if( cloudSdkValues.containsKey("Image") ) {
+                final Object value = cloudSdkValues.remove("Image");
                 if( (value == null) || (!value.equals(getImage())) ) {
                     setImage(((byte[]) value));
                 }
@@ -375,8 +375,8 @@ public class Product extends VdmMediaEntity<Product>
         }
         // navigation properties
         {
-            if( (values).containsKey("Vendor") ) {
-                final Object value = (values).remove("Vendor");
+            if( (cloudSdkValues).containsKey("Vendor") ) {
+                final Object value = (cloudSdkValues).remove("Vendor");
                 if( value instanceof Map ) {
                     if( toVendor == null ) {
                         toVendor = new Vendor();
@@ -386,8 +386,8 @@ public class Product extends VdmMediaEntity<Product>
                     toVendor.fromMap(inputMap);
                 }
             }
-            if( (values).containsKey("Shelf") ) {
-                final Object value = (values).remove("Shelf");
+            if( (cloudSdkValues).containsKey("Shelf") ) {
+                final Object value = (cloudSdkValues).remove("Shelf");
                 if( value instanceof Iterable ) {
                     if( toShelf == null ) {
                         toShelf = Lists.newArrayList();
@@ -414,7 +414,7 @@ public class Product extends VdmMediaEntity<Product>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -484,14 +484,14 @@ public class Product extends VdmMediaEntity<Product>
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toVendor != null ) {
-            (values).put("Vendor", toVendor);
+            (cloudSdkValues).put("Vendor", toVendor);
         }
         if( toShelf != null ) {
-            (values).put("Shelf", toShelf);
+            (cloudSdkValues).put("Shelf", toShelf);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductCount.java
@@ -79,26 +79,26 @@ public class ProductCount extends VdmComplex<ProductCount>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ProductId", getProductId());
-        values.put("Quantity", getQuantity());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ProductId", getProductId());
+        cloudSdkValues.put("Quantity", getQuantity());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("ProductId") ) {
-                final Object value = values.remove("ProductId");
+            if( cloudSdkValues.containsKey("ProductId") ) {
+                final Object value = cloudSdkValues.remove("ProductId");
                 if( (value == null) || (!value.equals(getProductId())) ) {
                     setProductId(((Integer) value));
                 }
             }
-            if( values.containsKey("Quantity") ) {
-                final Object value = values.remove("Quantity");
+            if( cloudSdkValues.containsKey("Quantity") ) {
+                final Object value = cloudSdkValues.remove("Quantity");
                 if( (value == null) || (!value.equals(getQuantity())) ) {
                     setQuantity(((Integer) value));
                 }
@@ -110,7 +110,7 @@ public class ProductCount extends VdmComplex<ProductCount>
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -479,43 +479,43 @@ public class Receipt extends VdmEntity<Receipt>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("CustomerId", getCustomerId());
-        values.put("TotalAmount", getTotalAmount());
-        values.put("ProductCount1", getProductCount1());
-        values.put("ProductCount2", getProductCount2());
-        values.put("ProductCount3", getProductCount3());
-        values.put("ProductCount4", getProductCount4());
-        values.put("ProductCount5", getProductCount5());
-        values.put("ProductCount6", getProductCount6());
-        values.put("ProductCount7", getProductCount7());
-        values.put("ProductCount8", getProductCount8());
-        values.put("ProductCount9", getProductCount9());
-        values.put("ProductCount10", getProductCount10());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("CustomerId", getCustomerId());
+        cloudSdkValues.put("TotalAmount", getTotalAmount());
+        cloudSdkValues.put("ProductCount1", getProductCount1());
+        cloudSdkValues.put("ProductCount2", getProductCount2());
+        cloudSdkValues.put("ProductCount3", getProductCount3());
+        cloudSdkValues.put("ProductCount4", getProductCount4());
+        cloudSdkValues.put("ProductCount5", getProductCount5());
+        cloudSdkValues.put("ProductCount6", getProductCount6());
+        cloudSdkValues.put("ProductCount7", getProductCount7());
+        cloudSdkValues.put("ProductCount8", getProductCount8());
+        cloudSdkValues.put("ProductCount9", getProductCount9());
+        cloudSdkValues.put("ProductCount10", getProductCount10());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("CustomerId") ) {
-                final Object value = values.remove("CustomerId");
+            if( cloudSdkValues.containsKey("CustomerId") ) {
+                final Object value = cloudSdkValues.remove("CustomerId");
                 if( (value == null) || (!value.equals(getCustomerId())) ) {
                     setCustomerId(((Integer) value));
                 }
             }
-            if( values.containsKey("TotalAmount") ) {
-                final Object value = values.remove("TotalAmount");
+            if( cloudSdkValues.containsKey("TotalAmount") ) {
+                final Object value = cloudSdkValues.remove("TotalAmount");
                 if( (value == null) || (!value.equals(getTotalAmount())) ) {
                     setTotalAmount(((BigDecimal) value));
                 }
@@ -523,8 +523,8 @@ public class Receipt extends VdmEntity<Receipt>
         }
         // structured properties
         {
-            if( values.containsKey("ProductCount1") ) {
-                final Object value = values.remove("ProductCount1");
+            if( cloudSdkValues.containsKey("ProductCount1") ) {
+                final Object value = cloudSdkValues.remove("ProductCount1");
                 if( value instanceof Map ) {
                     if( getProductCount1() == null ) {
                         setProductCount1(new ProductCount());
@@ -537,8 +537,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount1(null);
                 }
             }
-            if( values.containsKey("ProductCount2") ) {
-                final Object value = values.remove("ProductCount2");
+            if( cloudSdkValues.containsKey("ProductCount2") ) {
+                final Object value = cloudSdkValues.remove("ProductCount2");
                 if( value instanceof Map ) {
                     if( getProductCount2() == null ) {
                         setProductCount2(new ProductCount());
@@ -551,8 +551,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount2(null);
                 }
             }
-            if( values.containsKey("ProductCount3") ) {
-                final Object value = values.remove("ProductCount3");
+            if( cloudSdkValues.containsKey("ProductCount3") ) {
+                final Object value = cloudSdkValues.remove("ProductCount3");
                 if( value instanceof Map ) {
                     if( getProductCount3() == null ) {
                         setProductCount3(new ProductCount());
@@ -565,8 +565,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount3(null);
                 }
             }
-            if( values.containsKey("ProductCount4") ) {
-                final Object value = values.remove("ProductCount4");
+            if( cloudSdkValues.containsKey("ProductCount4") ) {
+                final Object value = cloudSdkValues.remove("ProductCount4");
                 if( value instanceof Map ) {
                     if( getProductCount4() == null ) {
                         setProductCount4(new ProductCount());
@@ -579,8 +579,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount4(null);
                 }
             }
-            if( values.containsKey("ProductCount5") ) {
-                final Object value = values.remove("ProductCount5");
+            if( cloudSdkValues.containsKey("ProductCount5") ) {
+                final Object value = cloudSdkValues.remove("ProductCount5");
                 if( value instanceof Map ) {
                     if( getProductCount5() == null ) {
                         setProductCount5(new ProductCount());
@@ -593,8 +593,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount5(null);
                 }
             }
-            if( values.containsKey("ProductCount6") ) {
-                final Object value = values.remove("ProductCount6");
+            if( cloudSdkValues.containsKey("ProductCount6") ) {
+                final Object value = cloudSdkValues.remove("ProductCount6");
                 if( value instanceof Map ) {
                     if( getProductCount6() == null ) {
                         setProductCount6(new ProductCount());
@@ -607,8 +607,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount6(null);
                 }
             }
-            if( values.containsKey("ProductCount7") ) {
-                final Object value = values.remove("ProductCount7");
+            if( cloudSdkValues.containsKey("ProductCount7") ) {
+                final Object value = cloudSdkValues.remove("ProductCount7");
                 if( value instanceof Map ) {
                     if( getProductCount7() == null ) {
                         setProductCount7(new ProductCount());
@@ -621,8 +621,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount7(null);
                 }
             }
-            if( values.containsKey("ProductCount8") ) {
-                final Object value = values.remove("ProductCount8");
+            if( cloudSdkValues.containsKey("ProductCount8") ) {
+                final Object value = cloudSdkValues.remove("ProductCount8");
                 if( value instanceof Map ) {
                     if( getProductCount8() == null ) {
                         setProductCount8(new ProductCount());
@@ -635,8 +635,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount8(null);
                 }
             }
-            if( values.containsKey("ProductCount9") ) {
-                final Object value = values.remove("ProductCount9");
+            if( cloudSdkValues.containsKey("ProductCount9") ) {
+                final Object value = cloudSdkValues.remove("ProductCount9");
                 if( value instanceof Map ) {
                     if( getProductCount9() == null ) {
                         setProductCount9(new ProductCount());
@@ -649,8 +649,8 @@ public class Receipt extends VdmEntity<Receipt>
                     setProductCount9(null);
                 }
             }
-            if( values.containsKey("ProductCount10") ) {
-                final Object value = values.remove("ProductCount10");
+            if( cloudSdkValues.containsKey("ProductCount10") ) {
+                final Object value = cloudSdkValues.remove("ProductCount10");
                 if( value instanceof Map ) {
                     if( getProductCount10() == null ) {
                         setProductCount10(new ProductCount());
@@ -666,8 +666,8 @@ public class Receipt extends VdmEntity<Receipt>
         }
         // navigation properties
         {
-            if( (values).containsKey("Customer") ) {
-                final Object value = (values).remove("Customer");
+            if( (cloudSdkValues).containsKey("Customer") ) {
+                final Object value = (cloudSdkValues).remove("Customer");
                 if( value instanceof Map ) {
                     if( toCustomer == null ) {
                         toCustomer = new Customer();
@@ -678,7 +678,7 @@ public class Receipt extends VdmEntity<Receipt>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -748,11 +748,11 @@ public class Receipt extends VdmEntity<Receipt>
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toCustomer != null ) {
-            (values).put("Customer", toCustomer);
+            (cloudSdkValues).put("Customer", toCustomer);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -183,26 +183,26 @@ public class Shelf extends VdmEntity<Shelf>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("FloorPlanId", getFloorPlanId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("FloorPlanId", getFloorPlanId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("FloorPlanId") ) {
-                final Object value = values.remove("FloorPlanId");
+            if( cloudSdkValues.containsKey("FloorPlanId") ) {
+                final Object value = cloudSdkValues.remove("FloorPlanId");
                 if( (value == null) || (!value.equals(getFloorPlanId())) ) {
                     setFloorPlanId(((Integer) value));
                 }
@@ -213,8 +213,8 @@ public class Shelf extends VdmEntity<Shelf>
         }
         // navigation properties
         {
-            if( (values).containsKey("FloorPlan") ) {
-                final Object value = (values).remove("FloorPlan");
+            if( (cloudSdkValues).containsKey("FloorPlan") ) {
+                final Object value = (cloudSdkValues).remove("FloorPlan");
                 if( value instanceof Map ) {
                     if( toFloorPlan == null ) {
                         toFloorPlan = new FloorPlan();
@@ -224,8 +224,8 @@ public class Shelf extends VdmEntity<Shelf>
                     toFloorPlan.fromMap(inputMap);
                 }
             }
-            if( (values).containsKey("Products") ) {
-                final Object value = (values).remove("Products");
+            if( (cloudSdkValues).containsKey("Products") ) {
+                final Object value = (cloudSdkValues).remove("Products");
                 if( value instanceof Iterable ) {
                     if( toProducts == null ) {
                         toProducts = Lists.newArrayList();
@@ -252,7 +252,7 @@ public class Shelf extends VdmEntity<Shelf>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -322,14 +322,14 @@ public class Shelf extends VdmEntity<Shelf>
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toFloorPlan != null ) {
-            (values).put("FloorPlan", toFloorPlan);
+            (cloudSdkValues).put("FloorPlan", toFloorPlan);
         }
         if( toProducts != null ) {
-            (values).put("Products", toProducts);
+            (cloudSdkValues).put("Products", toProducts);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -198,33 +198,33 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected Map<String, Object> toMapOfFields()
     {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if( values.containsKey("Id") ) {
-                final Object value = values.remove("Id");
+            if( cloudSdkValues.containsKey("Id") ) {
+                final Object value = cloudSdkValues.remove("Id");
                 if( (value == null) || (!value.equals(getId())) ) {
                     setId(((Integer) value));
                 }
             }
-            if( values.containsKey("Name") ) {
-                final Object value = values.remove("Name");
+            if( cloudSdkValues.containsKey("Name") ) {
+                final Object value = cloudSdkValues.remove("Name");
                 if( (value == null) || (!value.equals(getName())) ) {
                     setName(((String) value));
                 }
             }
-            if( values.containsKey("AddressId") ) {
-                final Object value = values.remove("AddressId");
+            if( cloudSdkValues.containsKey("AddressId") ) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if( (value == null) || (!value.equals(getAddressId())) ) {
                     setAddressId(((Integer) value));
                 }
@@ -235,8 +235,8 @@ public class Vendor extends VdmEntity<Vendor>
         }
         // navigation properties
         {
-            if( (values).containsKey("Address") ) {
-                final Object value = (values).remove("Address");
+            if( (cloudSdkValues).containsKey("Address") ) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if( value instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
@@ -247,7 +247,7 @@ public class Vendor extends VdmEntity<Vendor>
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -317,11 +317,11 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected Map<String, Object> toMapOfNavigationProperties()
     {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if( toAddress != null ) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/CommonConstants.java
+++ b/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/CommonConstants.java
@@ -8,5 +8,5 @@ class CommonConstants
 {
     static final String CLASS_NAME_FIELD_SUFFIX = "Field";
     static final String CLASS_NAME_LINK_SUFFIX = "Link";
-    static final String INLINE_MAP_NAME = "values";
+    static final String INLINE_MAP_NAME = "cloudSdkValues";
 }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BP.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BP.java
@@ -99,18 +99,18 @@ public class BP
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Code", getCode());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Code", getCode());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Code")) {
-                final Object value = values.remove("Code");
+            if (cloudSdkValues.containsKey("Code")) {
+                final Object value = cloudSdkValues.remove("Code");
                 if ((value == null)||(!value.equals(getCode()))) {
                     setCode(((String) value));
                 }
@@ -122,7 +122,7 @@ public class BP
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
@@ -302,67 +302,67 @@ public class Address
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Street", getStreet());
-        values.put("City", getCity());
-        values.put("State", getState());
-        values.put("Country", getCountry());
-        values.put("PostalCode", getPostalCode());
-        values.put("Latitude", getLatitude());
-        values.put("Longitude", getLongitude());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Street", getStreet());
+        cloudSdkValues.put("City", getCity());
+        cloudSdkValues.put("State", getState());
+        cloudSdkValues.put("Country", getCountry());
+        cloudSdkValues.put("PostalCode", getPostalCode());
+        cloudSdkValues.put("Latitude", getLatitude());
+        cloudSdkValues.put("Longitude", getLongitude());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Street")) {
-                final Object value = values.remove("Street");
+            if (cloudSdkValues.containsKey("Street")) {
+                final Object value = cloudSdkValues.remove("Street");
                 if ((value == null)||(!value.equals(getStreet()))) {
                     setStreet(((String) value));
                 }
             }
-            if (values.containsKey("City")) {
-                final Object value = values.remove("City");
+            if (cloudSdkValues.containsKey("City")) {
+                final Object value = cloudSdkValues.remove("City");
                 if ((value == null)||(!value.equals(getCity()))) {
                     setCity(((String) value));
                 }
             }
-            if (values.containsKey("State")) {
-                final Object value = values.remove("State");
+            if (cloudSdkValues.containsKey("State")) {
+                final Object value = cloudSdkValues.remove("State");
                 if ((value == null)||(!value.equals(getState()))) {
                     setState(((String) value));
                 }
             }
-            if (values.containsKey("Country")) {
-                final Object value = values.remove("Country");
+            if (cloudSdkValues.containsKey("Country")) {
+                final Object value = cloudSdkValues.remove("Country");
                 if ((value == null)||(!value.equals(getCountry()))) {
                     setCountry(((String) value));
                 }
             }
-            if (values.containsKey("PostalCode")) {
-                final Object value = values.remove("PostalCode");
+            if (cloudSdkValues.containsKey("PostalCode")) {
+                final Object value = cloudSdkValues.remove("PostalCode");
                 if ((value == null)||(!value.equals(getPostalCode()))) {
                     setPostalCode(((String) value));
                 }
             }
-            if (values.containsKey("Latitude")) {
-                final Object value = values.remove("Latitude");
+            if (cloudSdkValues.containsKey("Latitude")) {
+                final Object value = cloudSdkValues.remove("Latitude");
                 if ((value == null)||(!value.equals(getLatitude()))) {
                     setLatitude(((Double) value));
                 }
             }
-            if (values.containsKey("Longitude")) {
-                final Object value = values.remove("Longitude");
+            if (cloudSdkValues.containsKey("Longitude")) {
+                final Object value = cloudSdkValues.remove("Longitude");
                 if ((value == null)||(!value.equals(getLongitude()))) {
                     setLongitude(((Double) value));
                 }
@@ -374,7 +374,7 @@ public class Address
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -208,39 +208,39 @@ public class Customer
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("Email", getEmail());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("Email", getEmail());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((String) value));
                 }
             }
-            if (values.containsKey("Email")) {
-                final Object value = values.remove("Email");
+            if (cloudSdkValues.containsKey("Email")) {
+                final Object value = cloudSdkValues.remove("Email");
                 if ((value == null)||(!value.equals(getEmail()))) {
                     setEmail(((String) value));
                 }
             }
-            if (values.containsKey("AddressId")) {
-                final Object value = values.remove("AddressId");
+            if (cloudSdkValues.containsKey("AddressId")) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if ((value == null)||(!value.equals(getAddressId()))) {
                     setAddressId(((Integer) value));
                 }
@@ -251,8 +251,8 @@ public class Customer
         }
         // navigation properties
         {
-            if ((values).containsKey("Address")) {
-                final Object value = (values).remove("Address");
+            if ((cloudSdkValues).containsKey("Address")) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if (value instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
@@ -263,7 +263,7 @@ public class Customer
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -340,11 +340,11 @@ public class Customer
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toAddress!= null) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
@@ -128,25 +128,25 @@ public class FloorPlan
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("ImageUri", getImageUri());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("ImageUri", getImageUri());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("ImageUri")) {
-                final Object value = values.remove("ImageUri");
+            if (cloudSdkValues.containsKey("ImageUri")) {
+                final Object value = cloudSdkValues.remove("ImageUri");
                 if ((value == null)||(!value.equals(getImageUri()))) {
                     setImageUri(((String) value));
                 }
@@ -158,7 +158,7 @@ public class FloorPlan
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
@@ -195,39 +195,39 @@ public class OpeningHours
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("DayOfWeek", getDayOfWeek());
-        values.put("OpenTime", getOpenTime());
-        values.put("CloseTime", getCloseTime());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("DayOfWeek", getDayOfWeek());
+        cloudSdkValues.put("OpenTime", getOpenTime());
+        cloudSdkValues.put("CloseTime", getCloseTime());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("DayOfWeek")) {
-                final Object value = values.remove("DayOfWeek");
+            if (cloudSdkValues.containsKey("DayOfWeek")) {
+                final Object value = cloudSdkValues.remove("DayOfWeek");
                 if ((value == null)||(!value.equals(getDayOfWeek()))) {
                     setDayOfWeek(((Integer) value));
                 }
             }
-            if (values.containsKey("OpenTime")) {
-                final Object value = values.remove("OpenTime");
+            if (cloudSdkValues.containsKey("OpenTime")) {
+                final Object value = cloudSdkValues.remove("OpenTime");
                 if ((value == null)||(!value.equals(getOpenTime()))) {
                     setOpenTime(((LocalTime) value));
                 }
             }
-            if (values.containsKey("CloseTime")) {
-                final Object value = values.remove("CloseTime");
+            if (cloudSdkValues.containsKey("CloseTime")) {
+                final Object value = cloudSdkValues.remove("CloseTime");
                 if ((value == null)||(!value.equals(getCloseTime()))) {
                     setCloseTime(((LocalTime) value));
                 }
@@ -239,7 +239,7 @@ public class OpeningHours
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -286,53 +286,53 @@ public class Product
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("ShelfId", getShelfId());
-        values.put("VendorId", getVendorId());
-        values.put("Price", getPrice());
-        values.put("Image", getImage());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("ShelfId", getShelfId());
+        cloudSdkValues.put("VendorId", getVendorId());
+        cloudSdkValues.put("Price", getPrice());
+        cloudSdkValues.put("Image", getImage());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((String) value));
                 }
             }
-            if (values.containsKey("ShelfId")) {
-                final Object value = values.remove("ShelfId");
+            if (cloudSdkValues.containsKey("ShelfId")) {
+                final Object value = cloudSdkValues.remove("ShelfId");
                 if ((value == null)||(!value.equals(getShelfId()))) {
                     setShelfId(((Integer) value));
                 }
             }
-            if (values.containsKey("VendorId")) {
-                final Object value = values.remove("VendorId");
+            if (cloudSdkValues.containsKey("VendorId")) {
+                final Object value = cloudSdkValues.remove("VendorId");
                 if ((value == null)||(!value.equals(getVendorId()))) {
                     setVendorId(((Integer) value));
                 }
             }
-            if (values.containsKey("Price")) {
-                final Object value = values.remove("Price");
+            if (cloudSdkValues.containsKey("Price")) {
+                final Object value = cloudSdkValues.remove("Price");
                 if ((value == null)||(!value.equals(getPrice()))) {
                     setPrice(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("Image")) {
-                final Object value = values.remove("Image");
+            if (cloudSdkValues.containsKey("Image")) {
+                final Object value = cloudSdkValues.remove("Image");
                 if ((value == null)||(!value.equals(getImage()))) {
                     setImage(((byte[]) value));
                 }
@@ -343,8 +343,8 @@ public class Product
         }
         // navigation properties
         {
-            if ((values).containsKey("Vendor")) {
-                final Object value = (values).remove("Vendor");
+            if ((cloudSdkValues).containsKey("Vendor")) {
+                final Object value = (cloudSdkValues).remove("Vendor");
                 if (value instanceof Map) {
                     if (toVendor == null) {
                         toVendor = new Vendor();
@@ -354,8 +354,8 @@ public class Product
                     toVendor.fromMap(inputMap);
                 }
             }
-            if ((values).containsKey("Shelf")) {
-                final Object value = (values).remove("Shelf");
+            if ((cloudSdkValues).containsKey("Shelf")) {
+                final Object value = (cloudSdkValues).remove("Shelf");
                 if (value instanceof Iterable) {
                     if (toShelf == null) {
                         toShelf = Lists.newArrayList();
@@ -382,7 +382,7 @@ public class Product
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -459,14 +459,14 @@ public class Product
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toVendor!= null) {
-            (values).put("Vendor", toVendor);
+            (cloudSdkValues).put("Vendor", toVendor);
         }
         if (toShelf!= null) {
-            (values).put("Shelf", toShelf);
+            (cloudSdkValues).put("Shelf", toShelf);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
@@ -70,25 +70,25 @@ public class ProductCount
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("ProductId", getProductId());
-        values.put("Quantity", getQuantity());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("ProductId", getProductId());
+        cloudSdkValues.put("Quantity", getQuantity());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("ProductId")) {
-                final Object value = values.remove("ProductId");
+            if (cloudSdkValues.containsKey("ProductId")) {
+                final Object value = cloudSdkValues.remove("ProductId");
                 if ((value == null)||(!value.equals(getProductId()))) {
                     setProductId(((Integer) value));
                 }
             }
-            if (values.containsKey("Quantity")) {
-                final Object value = values.remove("Quantity");
+            if (cloudSdkValues.containsKey("Quantity")) {
+                final Object value = cloudSdkValues.remove("Quantity");
                 if ((value == null)||(!value.equals(getQuantity()))) {
                     setQuantity(((Integer) value));
                 }
@@ -100,7 +100,7 @@ public class ProductCount
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -420,42 +420,42 @@ public class Receipt
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("CustomerId", getCustomerId());
-        values.put("TotalAmount", getTotalAmount());
-        values.put("ProductCount1", getProductCount1());
-        values.put("ProductCount2", getProductCount2());
-        values.put("ProductCount3", getProductCount3());
-        values.put("ProductCount4", getProductCount4());
-        values.put("ProductCount5", getProductCount5());
-        values.put("ProductCount6", getProductCount6());
-        values.put("ProductCount7", getProductCount7());
-        values.put("ProductCount8", getProductCount8());
-        values.put("ProductCount9", getProductCount9());
-        values.put("ProductCount10", getProductCount10());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("CustomerId", getCustomerId());
+        cloudSdkValues.put("TotalAmount", getTotalAmount());
+        cloudSdkValues.put("ProductCount1", getProductCount1());
+        cloudSdkValues.put("ProductCount2", getProductCount2());
+        cloudSdkValues.put("ProductCount3", getProductCount3());
+        cloudSdkValues.put("ProductCount4", getProductCount4());
+        cloudSdkValues.put("ProductCount5", getProductCount5());
+        cloudSdkValues.put("ProductCount6", getProductCount6());
+        cloudSdkValues.put("ProductCount7", getProductCount7());
+        cloudSdkValues.put("ProductCount8", getProductCount8());
+        cloudSdkValues.put("ProductCount9", getProductCount9());
+        cloudSdkValues.put("ProductCount10", getProductCount10());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("CustomerId")) {
-                final Object value = values.remove("CustomerId");
+            if (cloudSdkValues.containsKey("CustomerId")) {
+                final Object value = cloudSdkValues.remove("CustomerId");
                 if ((value == null)||(!value.equals(getCustomerId()))) {
                     setCustomerId(((Integer) value));
                 }
             }
-            if (values.containsKey("TotalAmount")) {
-                final Object value = values.remove("TotalAmount");
+            if (cloudSdkValues.containsKey("TotalAmount")) {
+                final Object value = cloudSdkValues.remove("TotalAmount");
                 if ((value == null)||(!value.equals(getTotalAmount()))) {
                     setTotalAmount(((BigDecimal) value));
                 }
@@ -463,8 +463,8 @@ public class Receipt
         }
         // structured properties
         {
-            if (values.containsKey("ProductCount1")) {
-                final Object value = values.remove("ProductCount1");
+            if (cloudSdkValues.containsKey("ProductCount1")) {
+                final Object value = cloudSdkValues.remove("ProductCount1");
                 if (value instanceof Map) {
                     if (getProductCount1() == null) {
                         setProductCount1(new ProductCount());
@@ -477,8 +477,8 @@ public class Receipt
                     setProductCount1(null);
                 }
             }
-            if (values.containsKey("ProductCount2")) {
-                final Object value = values.remove("ProductCount2");
+            if (cloudSdkValues.containsKey("ProductCount2")) {
+                final Object value = cloudSdkValues.remove("ProductCount2");
                 if (value instanceof Map) {
                     if (getProductCount2() == null) {
                         setProductCount2(new ProductCount());
@@ -491,8 +491,8 @@ public class Receipt
                     setProductCount2(null);
                 }
             }
-            if (values.containsKey("ProductCount3")) {
-                final Object value = values.remove("ProductCount3");
+            if (cloudSdkValues.containsKey("ProductCount3")) {
+                final Object value = cloudSdkValues.remove("ProductCount3");
                 if (value instanceof Map) {
                     if (getProductCount3() == null) {
                         setProductCount3(new ProductCount());
@@ -505,8 +505,8 @@ public class Receipt
                     setProductCount3(null);
                 }
             }
-            if (values.containsKey("ProductCount4")) {
-                final Object value = values.remove("ProductCount4");
+            if (cloudSdkValues.containsKey("ProductCount4")) {
+                final Object value = cloudSdkValues.remove("ProductCount4");
                 if (value instanceof Map) {
                     if (getProductCount4() == null) {
                         setProductCount4(new ProductCount());
@@ -519,8 +519,8 @@ public class Receipt
                     setProductCount4(null);
                 }
             }
-            if (values.containsKey("ProductCount5")) {
-                final Object value = values.remove("ProductCount5");
+            if (cloudSdkValues.containsKey("ProductCount5")) {
+                final Object value = cloudSdkValues.remove("ProductCount5");
                 if (value instanceof Map) {
                     if (getProductCount5() == null) {
                         setProductCount5(new ProductCount());
@@ -533,8 +533,8 @@ public class Receipt
                     setProductCount5(null);
                 }
             }
-            if (values.containsKey("ProductCount6")) {
-                final Object value = values.remove("ProductCount6");
+            if (cloudSdkValues.containsKey("ProductCount6")) {
+                final Object value = cloudSdkValues.remove("ProductCount6");
                 if (value instanceof Map) {
                     if (getProductCount6() == null) {
                         setProductCount6(new ProductCount());
@@ -547,8 +547,8 @@ public class Receipt
                     setProductCount6(null);
                 }
             }
-            if (values.containsKey("ProductCount7")) {
-                final Object value = values.remove("ProductCount7");
+            if (cloudSdkValues.containsKey("ProductCount7")) {
+                final Object value = cloudSdkValues.remove("ProductCount7");
                 if (value instanceof Map) {
                     if (getProductCount7() == null) {
                         setProductCount7(new ProductCount());
@@ -561,8 +561,8 @@ public class Receipt
                     setProductCount7(null);
                 }
             }
-            if (values.containsKey("ProductCount8")) {
-                final Object value = values.remove("ProductCount8");
+            if (cloudSdkValues.containsKey("ProductCount8")) {
+                final Object value = cloudSdkValues.remove("ProductCount8");
                 if (value instanceof Map) {
                     if (getProductCount8() == null) {
                         setProductCount8(new ProductCount());
@@ -575,8 +575,8 @@ public class Receipt
                     setProductCount8(null);
                 }
             }
-            if (values.containsKey("ProductCount9")) {
-                final Object value = values.remove("ProductCount9");
+            if (cloudSdkValues.containsKey("ProductCount9")) {
+                final Object value = cloudSdkValues.remove("ProductCount9");
                 if (value instanceof Map) {
                     if (getProductCount9() == null) {
                         setProductCount9(new ProductCount());
@@ -589,8 +589,8 @@ public class Receipt
                     setProductCount9(null);
                 }
             }
-            if (values.containsKey("ProductCount10")) {
-                final Object value = values.remove("ProductCount10");
+            if (cloudSdkValues.containsKey("ProductCount10")) {
+                final Object value = cloudSdkValues.remove("ProductCount10");
                 if (value instanceof Map) {
                     if (getProductCount10() == null) {
                         setProductCount10(new ProductCount());
@@ -606,8 +606,8 @@ public class Receipt
         }
         // navigation properties
         {
-            if ((values).containsKey("Customer")) {
-                final Object value = (values).remove("Customer");
+            if ((cloudSdkValues).containsKey("Customer")) {
+                final Object value = (cloudSdkValues).remove("Customer");
                 if (value instanceof Map) {
                     if (toCustomer == null) {
                         toCustomer = new Customer();
@@ -618,7 +618,7 @@ public class Receipt
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -695,11 +695,11 @@ public class Receipt
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toCustomer!= null) {
-            (values).put("Customer", toCustomer);
+            (cloudSdkValues).put("Customer", toCustomer);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -168,25 +168,25 @@ public class Shelf
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("FloorPlanId", getFloorPlanId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("FloorPlanId", getFloorPlanId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("FloorPlanId")) {
-                final Object value = values.remove("FloorPlanId");
+            if (cloudSdkValues.containsKey("FloorPlanId")) {
+                final Object value = cloudSdkValues.remove("FloorPlanId");
                 if ((value == null)||(!value.equals(getFloorPlanId()))) {
                     setFloorPlanId(((Integer) value));
                 }
@@ -197,8 +197,8 @@ public class Shelf
         }
         // navigation properties
         {
-            if ((values).containsKey("FloorPlan")) {
-                final Object value = (values).remove("FloorPlan");
+            if ((cloudSdkValues).containsKey("FloorPlan")) {
+                final Object value = (cloudSdkValues).remove("FloorPlan");
                 if (value instanceof Map) {
                     if (toFloorPlan == null) {
                         toFloorPlan = new FloorPlan();
@@ -208,8 +208,8 @@ public class Shelf
                     toFloorPlan.fromMap(inputMap);
                 }
             }
-            if ((values).containsKey("Products")) {
-                final Object value = (values).remove("Products");
+            if ((cloudSdkValues).containsKey("Products")) {
+                final Object value = (cloudSdkValues).remove("Products");
                 if (value instanceof Iterable) {
                     if (toProducts == null) {
                         toProducts = Lists.newArrayList();
@@ -236,7 +236,7 @@ public class Shelf
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -313,14 +313,14 @@ public class Shelf
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toFloorPlan!= null) {
-            (values).put("FloorPlan", toFloorPlan);
+            (cloudSdkValues).put("FloorPlan", toFloorPlan);
         }
         if (toProducts!= null) {
-            (values).put("Products", toProducts);
+            (cloudSdkValues).put("Products", toProducts);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -179,32 +179,32 @@ public class Vendor
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Id", getId());
-        values.put("Name", getName());
-        values.put("AddressId", getAddressId());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Id", getId());
+        cloudSdkValues.put("Name", getName());
+        cloudSdkValues.put("AddressId", getAddressId());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Id")) {
-                final Object value = values.remove("Id");
+            if (cloudSdkValues.containsKey("Id")) {
+                final Object value = cloudSdkValues.remove("Id");
                 if ((value == null)||(!value.equals(getId()))) {
                     setId(((Integer) value));
                 }
             }
-            if (values.containsKey("Name")) {
-                final Object value = values.remove("Name");
+            if (cloudSdkValues.containsKey("Name")) {
+                final Object value = cloudSdkValues.remove("Name");
                 if ((value == null)||(!value.equals(getName()))) {
                     setName(((String) value));
                 }
             }
-            if (values.containsKey("AddressId")) {
-                final Object value = values.remove("AddressId");
+            if (cloudSdkValues.containsKey("AddressId")) {
+                final Object value = cloudSdkValues.remove("AddressId");
                 if ((value == null)||(!value.equals(getAddressId()))) {
                     setAddressId(((Integer) value));
                 }
@@ -215,8 +215,8 @@ public class Vendor
         }
         // navigation properties
         {
-            if ((values).containsKey("Address")) {
-                final Object value = (values).remove("Address");
+            if ((cloudSdkValues).containsKey("Address")) {
+                final Object value = (cloudSdkValues).remove("Address");
                 if (value instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
@@ -227,7 +227,7 @@ public class Vendor
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -304,11 +304,11 @@ public class Vendor
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toAddress!= null) {
-            (values).put("Address", toAddress);
+            (cloudSdkValues).put("Address", toAddress);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabel.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabel.java
@@ -96,18 +96,18 @@ public class EntityWithoutKeyLabel
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("SomeField", getSomeField());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("SomeField", getSomeField());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("SomeField")) {
-                final Object value = values.remove("SomeField");
+            if (cloudSdkValues.containsKey("SomeField")) {
+                final Object value = cloudSdkValues.remove("SomeField");
                 if ((value == null)||(!value.equals(getSomeField()))) {
                     setSomeField(((String) value));
                 }
@@ -119,7 +119,7 @@ public class EntityWithoutKeyLabel
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabel.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabel.java
@@ -100,18 +100,18 @@ public class SomeTypeLabel
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyFieldWithKeyLabel", getKey_2());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyFieldWithKeyLabel", getKey_2());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyFieldWithKeyLabel")) {
-                final Object value = values.remove("KeyFieldWithKeyLabel");
+            if (cloudSdkValues.containsKey("KeyFieldWithKeyLabel")) {
+                final Object value = cloudSdkValues.remove("KeyFieldWithKeyLabel");
                 if ((value == null)||(!value.equals(getKey_2()))) {
                     setKey_2(((UUID) value));
                 }
@@ -123,7 +123,7 @@ public class SomeTypeLabel
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -128,25 +128,25 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((String) value));
                 }
@@ -158,7 +158,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
@@ -128,25 +128,25 @@ public class FooType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Foo", getFoo());
-        values.put("Type", getType_2());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Foo", getFoo());
+        cloudSdkValues.put("Type", getType_2());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Foo")) {
-                final Object value = values.remove("Foo");
+            if (cloudSdkValues.containsKey("Foo")) {
+                final Object value = cloudSdkValues.remove("Foo");
                 if ((value == null)||(!value.equals(getFoo()))) {
                     setFoo(((String) value));
                 }
             }
-            if (values.containsKey("Type")) {
-                final Object value = values.remove("Type");
+            if (cloudSdkValues.containsKey("Type")) {
+                final Object value = cloudSdkValues.remove("Type");
                 if ((value == null)||(!value.equals(getType_2()))) {
                     setType_2(((String) value));
                 }
@@ -158,7 +158,7 @@ public class FooType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
@@ -128,25 +128,25 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("Person", getPerson());
-        values.put("EmailAddress", getEmailAddress());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("Person", getPerson());
+        cloudSdkValues.put("EmailAddress", getEmailAddress());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("Person")) {
-                final Object value = values.remove("Person");
+            if (cloudSdkValues.containsKey("Person")) {
+                final Object value = cloudSdkValues.remove("Person");
                 if ((value == null)||(!value.equals(getPerson()))) {
                     setPerson(((String) value));
                 }
             }
-            if (values.containsKey("EmailAddress")) {
-                final Object value = values.remove("EmailAddress");
+            if (cloudSdkValues.containsKey("EmailAddress")) {
+                final Object value = cloudSdkValues.remove("EmailAddress");
                 if ((value == null)||(!value.equals(getEmailAddress()))) {
                     setEmailAddress(((String) value));
                 }
@@ -158,7 +158,7 @@ public class SimplePerson
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLink.java
@@ -99,18 +99,18 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class TestEntityMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
@@ -181,32 +181,32 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("MultiLink", getMultiLink());
-        values.put("toMultiLink", getToMultiLink());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("MultiLink", getMultiLink());
+        cloudSdkValues.put("toMultiLink", getToMultiLink());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("MultiLink")) {
-                final Object value = values.remove("MultiLink");
+            if (cloudSdkValues.containsKey("MultiLink")) {
+                final Object value = cloudSdkValues.remove("MultiLink");
                 if ((value == null)||(!value.equals(getMultiLink()))) {
                     setMultiLink(((String) value));
                 }
             }
-            if (values.containsKey("toMultiLink")) {
-                final Object value = values.remove("toMultiLink");
+            if (cloudSdkValues.containsKey("toMultiLink")) {
+                final Object value = cloudSdkValues.remove("toMultiLink");
                 if ((value == null)||(!value.equals(getToMultiLink()))) {
                     setToMultiLink(((String) value));
                 }
@@ -217,8 +217,8 @@ public class TestEntityV2
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink_2 == null) {
                         toMultiLink_2 = Lists.newArrayList();
@@ -245,7 +245,7 @@ public class TestEntityV2
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -322,11 +322,11 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink_2 != null) {
-            (values).put("to_MultiLink", toMultiLink_2);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink_2);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_OtherTestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_OtherTestComplexType.java
@@ -57,18 +57,18 @@ public class A_OtherTestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_OtherTestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntity.java
@@ -99,18 +99,18 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class MediaEntity
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2MultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2SingleLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -257,46 +257,46 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntityMultiLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntityMultiLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntityMultiLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -99,18 +99,18 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class TestEntityOtherMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -257,46 +257,46 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntitySingleLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntitySingleLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntitySingleLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -662,131 +662,131 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
@@ -794,8 +794,8 @@ public class TestEntityV2
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -811,8 +811,8 @@ public class TestEntityV2
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -838,8 +838,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_OtherMultiLink")) {
-                final Object value = (values).remove("to_OtherMultiLink");
+            if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
                 if (value instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
@@ -865,8 +865,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
@@ -877,7 +877,7 @@ public class TestEntityV2
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -954,17 +954,17 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toOtherMultiLink!= null) {
-            (values).put("to_OtherMultiLink", toOtherMultiLink);
+            (cloudSdkValues).put("to_OtherMultiLink", toOtherMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/Unrelated.java
@@ -99,18 +99,18 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class Unrelated
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/MediaEntity.java
@@ -99,18 +99,18 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class MediaEntity
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2MultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2SingleLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -257,46 +257,46 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntityMultiLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntityMultiLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntityMultiLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -424,14 +424,14 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -99,18 +99,18 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class TestEntityOtherMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -257,46 +257,46 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntitySingleLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntitySingleLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntitySingleLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -424,14 +424,14 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -662,131 +662,131 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
@@ -794,8 +794,8 @@ public class TestEntityV2
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -811,8 +811,8 @@ public class TestEntityV2
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -838,8 +838,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_OtherMultiLink")) {
-                final Object value = (values).remove("to_OtherMultiLink");
+            if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
                 if (value instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
@@ -865,8 +865,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
@@ -877,7 +877,7 @@ public class TestEntityV2
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -955,17 +955,17 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toOtherMultiLink!= null) {
-            (values).put("to_OtherMultiLink", toOtherMultiLink);
+            (cloudSdkValues).put("to_OtherMultiLink", toOtherMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/Unrelated.java
@@ -99,18 +99,18 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class Unrelated
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -607,131 +607,131 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
@@ -739,8 +739,8 @@ public class TestEntityV2
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -757,7 +757,7 @@ public class TestEntityV2
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -834,8 +834,8 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
+        return cloudSdkValues;
     }
 
 }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntity.java
@@ -99,18 +99,18 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class MediaEntity
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2MultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2SingleLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -257,46 +257,46 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntityMultiLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntityMultiLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntityMultiLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -99,18 +99,18 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class TestEntityOtherMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -257,46 +257,46 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntitySingleLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntitySingleLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntitySingleLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -662,131 +662,131 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
@@ -794,8 +794,8 @@ public class TestEntityV2
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -811,8 +811,8 @@ public class TestEntityV2
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -838,8 +838,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_OtherMultiLink")) {
-                final Object value = (values).remove("to_OtherMultiLink");
+            if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
                 if (value instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
@@ -865,8 +865,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
@@ -877,7 +877,7 @@ public class TestEntityV2
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -954,17 +954,17 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toOtherMultiLink!= null) {
-            (values).put("to_OtherMultiLink", toOtherMultiLink);
+            (cloudSdkValues).put("to_OtherMultiLink", toOtherMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/Unrelated.java
@@ -99,18 +99,18 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class Unrelated
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntity.java
@@ -99,18 +99,18 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class MediaEntity
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2MultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -217,46 +217,46 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -268,7 +268,7 @@ public class TestEntityLvl2SingleLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -257,46 +257,46 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntityMultiLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntityMultiLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntityMultiLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -99,18 +99,18 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class TestEntityOtherMultiLink
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -257,46 +257,46 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
@@ -307,8 +307,8 @@ public class TestEntitySingleLink
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -334,8 +334,8 @@ public class TestEntitySingleLink
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
@@ -346,7 +346,7 @@ public class TestEntitySingleLink
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -423,14 +423,14 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -662,131 +662,131 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyPropertyGuid", getKeyPropertyGuid());
-        values.put("KeyPropertyString", getKeyPropertyString());
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("BinaryProperty", getBinaryProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyPropertyGuid", getKeyPropertyGuid());
+        cloudSdkValues.put("KeyPropertyString", getKeyPropertyString());
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("BinaryProperty", getBinaryProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyPropertyGuid")) {
-                final Object value = values.remove("KeyPropertyGuid");
+            if (cloudSdkValues.containsKey("KeyPropertyGuid")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyGuid");
                 if ((value == null)||(!value.equals(getKeyPropertyGuid()))) {
                     setKeyPropertyGuid(((UUID) value));
                 }
             }
-            if (values.containsKey("KeyPropertyString")) {
-                final Object value = values.remove("KeyPropertyString");
+            if (cloudSdkValues.containsKey("KeyPropertyString")) {
+                final Object value = cloudSdkValues.remove("KeyPropertyString");
                 if ((value == null)||(!value.equals(getKeyPropertyString()))) {
                     setKeyPropertyString(((String) value));
                 }
             }
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
             }
-            if (values.containsKey("BinaryProperty")) {
-                final Object value = values.remove("BinaryProperty");
+            if (cloudSdkValues.containsKey("BinaryProperty")) {
+                final Object value = cloudSdkValues.remove("BinaryProperty");
                 if ((value == null)||(!value.equals(getBinaryProperty()))) {
                     setBinaryProperty(((byte[]) value));
                 }
@@ -794,8 +794,8 @@ public class TestEntityV2
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestComplexType());
@@ -811,8 +811,8 @@ public class TestEntityV2
         }
         // navigation properties
         {
-            if ((values).containsKey("to_MultiLink")) {
-                final Object value = (values).remove("to_MultiLink");
+            if ((cloudSdkValues).containsKey("to_MultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_MultiLink");
                 if (value instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
@@ -838,8 +838,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_OtherMultiLink")) {
-                final Object value = (values).remove("to_OtherMultiLink");
+            if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
+                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
                 if (value instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
@@ -865,8 +865,8 @@ public class TestEntityV2
                     }
                 }
             }
-            if ((values).containsKey("to_SingleLink")) {
-                final Object value = (values).remove("to_SingleLink");
+            if ((cloudSdkValues).containsKey("to_SingleLink")) {
+                final Object value = (cloudSdkValues).remove("to_SingleLink");
                 if (value instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
@@ -877,7 +877,7 @@ public class TestEntityV2
                 }
             }
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**
@@ -954,17 +954,17 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfNavigationProperties() {
-        final Map<String, Object> values = super.toMapOfNavigationProperties();
+        final Map<String, Object> cloudSdkValues = super.toMapOfNavigationProperties();
         if (toMultiLink!= null) {
-            (values).put("to_MultiLink", toMultiLink);
+            (cloudSdkValues).put("to_MultiLink", toMultiLink);
         }
         if (toOtherMultiLink!= null) {
-            (values).put("to_OtherMultiLink", toOtherMultiLink);
+            (cloudSdkValues).put("to_OtherMultiLink", toOtherMultiLink);
         }
         if (toSingleLink!= null) {
-            (values).put("to_SingleLink", toSingleLink);
+            (cloudSdkValues).put("to_SingleLink", toSingleLink);
         }
-        return values;
+        return cloudSdkValues;
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/Unrelated.java
@@ -99,18 +99,18 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("KeyProperty", getKeyProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("KeyProperty", getKeyProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("KeyProperty")) {
-                final Object value = values.remove("KeyProperty");
+            if (cloudSdkValues.containsKey("KeyProperty")) {
+                final Object value = cloudSdkValues.remove("KeyProperty");
                 if ((value == null)||(!value.equals(getKeyProperty()))) {
                     setKeyProperty(((String) value));
                 }
@@ -122,7 +122,7 @@ public class Unrelated
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     /**

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -228,110 +228,110 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("BooleanProperty", getBooleanProperty());
-        values.put("GuidProperty", getGuidProperty());
-        values.put("Int16Property", getInt16Property());
-        values.put("Int32Property", getInt32Property());
-        values.put("Int64Property", getInt64Property());
-        values.put("DecimalProperty", getDecimalProperty());
-        values.put("SingleProperty", getSingleProperty());
-        values.put("DoubleProperty", getDoubleProperty());
-        values.put("TimeProperty", getTimeProperty());
-        values.put("DateTimeProperty", getDateTimeProperty());
-        values.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
-        values.put("ByteProperty", getByteProperty());
-        values.put("SByteProperty", getSByteProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("BooleanProperty", getBooleanProperty());
+        cloudSdkValues.put("GuidProperty", getGuidProperty());
+        cloudSdkValues.put("Int16Property", getInt16Property());
+        cloudSdkValues.put("Int32Property", getInt32Property());
+        cloudSdkValues.put("Int64Property", getInt64Property());
+        cloudSdkValues.put("DecimalProperty", getDecimalProperty());
+        cloudSdkValues.put("SingleProperty", getSingleProperty());
+        cloudSdkValues.put("DoubleProperty", getDoubleProperty());
+        cloudSdkValues.put("TimeProperty", getTimeProperty());
+        cloudSdkValues.put("DateTimeProperty", getDateTimeProperty());
+        cloudSdkValues.put("DateTimeOffSetProperty", getDateTimeOffSetProperty());
+        cloudSdkValues.put("ByteProperty", getByteProperty());
+        cloudSdkValues.put("SByteProperty", getSByteProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
             }
-            if (values.containsKey("BooleanProperty")) {
-                final Object value = values.remove("BooleanProperty");
+            if (cloudSdkValues.containsKey("BooleanProperty")) {
+                final Object value = cloudSdkValues.remove("BooleanProperty");
                 if ((value == null)||(!value.equals(getBooleanProperty()))) {
                     setBooleanProperty(((Boolean) value));
                 }
             }
-            if (values.containsKey("GuidProperty")) {
-                final Object value = values.remove("GuidProperty");
+            if (cloudSdkValues.containsKey("GuidProperty")) {
+                final Object value = cloudSdkValues.remove("GuidProperty");
                 if ((value == null)||(!value.equals(getGuidProperty()))) {
                     setGuidProperty(((UUID) value));
                 }
             }
-            if (values.containsKey("Int16Property")) {
-                final Object value = values.remove("Int16Property");
+            if (cloudSdkValues.containsKey("Int16Property")) {
+                final Object value = cloudSdkValues.remove("Int16Property");
                 if ((value == null)||(!value.equals(getInt16Property()))) {
                     setInt16Property(((Short) value));
                 }
             }
-            if (values.containsKey("Int32Property")) {
-                final Object value = values.remove("Int32Property");
+            if (cloudSdkValues.containsKey("Int32Property")) {
+                final Object value = cloudSdkValues.remove("Int32Property");
                 if ((value == null)||(!value.equals(getInt32Property()))) {
                     setInt32Property(((Integer) value));
                 }
             }
-            if (values.containsKey("Int64Property")) {
-                final Object value = values.remove("Int64Property");
+            if (cloudSdkValues.containsKey("Int64Property")) {
+                final Object value = cloudSdkValues.remove("Int64Property");
                 if ((value == null)||(!value.equals(getInt64Property()))) {
                     setInt64Property(((Long) value));
                 }
             }
-            if (values.containsKey("DecimalProperty")) {
-                final Object value = values.remove("DecimalProperty");
+            if (cloudSdkValues.containsKey("DecimalProperty")) {
+                final Object value = cloudSdkValues.remove("DecimalProperty");
                 if ((value == null)||(!value.equals(getDecimalProperty()))) {
                     setDecimalProperty(((BigDecimal) value));
                 }
             }
-            if (values.containsKey("SingleProperty")) {
-                final Object value = values.remove("SingleProperty");
+            if (cloudSdkValues.containsKey("SingleProperty")) {
+                final Object value = cloudSdkValues.remove("SingleProperty");
                 if ((value == null)||(!value.equals(getSingleProperty()))) {
                     setSingleProperty(((Float) value));
                 }
             }
-            if (values.containsKey("DoubleProperty")) {
-                final Object value = values.remove("DoubleProperty");
+            if (cloudSdkValues.containsKey("DoubleProperty")) {
+                final Object value = cloudSdkValues.remove("DoubleProperty");
                 if ((value == null)||(!value.equals(getDoubleProperty()))) {
                     setDoubleProperty(((Double) value));
                 }
             }
-            if (values.containsKey("TimeProperty")) {
-                final Object value = values.remove("TimeProperty");
+            if (cloudSdkValues.containsKey("TimeProperty")) {
+                final Object value = cloudSdkValues.remove("TimeProperty");
                 if ((value == null)||(!value.equals(getTimeProperty()))) {
                     setTimeProperty(((LocalTime) value));
                 }
             }
-            if (values.containsKey("DateTimeProperty")) {
-                final Object value = values.remove("DateTimeProperty");
+            if (cloudSdkValues.containsKey("DateTimeProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeProperty");
                 if ((value == null)||(!value.equals(getDateTimeProperty()))) {
                     setDateTimeProperty(((LocalDateTime) value));
                 }
             }
-            if (values.containsKey("DateTimeOffSetProperty")) {
-                final Object value = values.remove("DateTimeOffSetProperty");
+            if (cloudSdkValues.containsKey("DateTimeOffSetProperty")) {
+                final Object value = cloudSdkValues.remove("DateTimeOffSetProperty");
                 if ((value == null)||(!value.equals(getDateTimeOffSetProperty()))) {
                     setDateTimeOffSetProperty(((ZonedDateTime) value));
                 }
             }
-            if (values.containsKey("ByteProperty")) {
-                final Object value = values.remove("ByteProperty");
+            if (cloudSdkValues.containsKey("ByteProperty")) {
+                final Object value = cloudSdkValues.remove("ByteProperty");
                 if ((value == null)||(!value.equals(getByteProperty()))) {
                     setByteProperty(((Short) value));
                 }
             }
-            if (values.containsKey("SByteProperty")) {
-                final Object value = values.remove("SByteProperty");
+            if (cloudSdkValues.containsKey("SByteProperty")) {
+                final Object value = cloudSdkValues.remove("SByteProperty");
                 if ((value == null)||(!value.equals(getSByteProperty()))) {
                     setSByteProperty(((Byte) value));
                 }
@@ -339,8 +339,8 @@ public class A_TestComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestNestedComplexType());
@@ -357,7 +357,7 @@ public class A_TestComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -57,18 +57,18 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -80,7 +80,7 @@ public class A_TestLvl2NestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -68,19 +68,19 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> toMapOfFields() {
-        final Map<String, Object> values = super.toMapOfFields();
-        values.put("StringProperty", getStringProperty());
-        values.put("ComplexTypeProperty", getComplexTypeProperty());
-        return values;
+        final Map<String, Object> cloudSdkValues = super.toMapOfFields();
+        cloudSdkValues.put("StringProperty", getStringProperty());
+        cloudSdkValues.put("ComplexTypeProperty", getComplexTypeProperty());
+        return cloudSdkValues;
     }
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> values = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
         // simple properties
         {
-            if (values.containsKey("StringProperty")) {
-                final Object value = values.remove("StringProperty");
+            if (cloudSdkValues.containsKey("StringProperty")) {
+                final Object value = cloudSdkValues.remove("StringProperty");
                 if ((value == null)||(!value.equals(getStringProperty()))) {
                     setStringProperty(((String) value));
                 }
@@ -88,8 +88,8 @@ public class A_TestNestedComplexType
         }
         // structured properties
         {
-            if (values.containsKey("ComplexTypeProperty")) {
-                final Object value = values.remove("ComplexTypeProperty");
+            if (cloudSdkValues.containsKey("ComplexTypeProperty")) {
+                final Object value = cloudSdkValues.remove("ComplexTypeProperty");
                 if (value instanceof Map) {
                     if (getComplexTypeProperty() == null) {
                         setComplexTypeProperty(new A_TestLvl2NestedComplexType());
@@ -106,7 +106,7 @@ public class A_TestNestedComplexType
         // navigation properties
         {
         }
-        super.fromMap(values);
+        super.fromMap(cloudSdkValues);
     }
 
     @Nonnull

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,5 +25,5 @@
 ### 🐛 Fixed Issues
 
 - Fix ApacheHttpClient5Wrapper to propagate the configuration to Spring RestTemplate.
-- Fix OData v4 generator to work when property name is `values` and is of collection type.
+- Fix OData v2 and v4 generators to work when property name is `values` and is of collection type.
   - The internal variable is now `cloudSdkValues` to avoid conflicts with the `values` property.

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,3 +25,5 @@
 ### 🐛 Fixed Issues
 
 - Fix ApacheHttpClient5Wrapper to propagate the configuration to Spring RestTemplate.
+- Fix OData v4 generator to work when property name is `values` and is of collection type.
+  - The internal variable is now `cloudSdkValues` to avoid conflicts with the `values` property.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://sap.stackenterprise.co/questions/65172


Users can't create an object with a field named `values` and make a List or Map of this object.
Solution: rename our internal variable from `values` to `cloudSdkValues` to make sure it doesn't collide.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Documentation updated~
- [x] Release notes updated
