### PR TITLE
[OData] Renamed internal variable `value` to `cloudSdkValue`

### DIFF
--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
@@ -260,13 +260,13 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Address") ) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if( cloudSdkValue instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -310,12 +310,12 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Address</b> entity.
      */
-    public void setAddress( final Address value )
+    public void setAddress( final Address cloudSdkValue )
     {
-        toAddress = value;
+        toAddress = cloudSdkValue;
     }
 
     /**
@@ -409,23 +409,23 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
 
         private Address toAddress;
 
-        private Customer.CustomerBuilder toAddress( final Address value )
+        private Customer.CustomerBuilder toAddress( final Address cloudSdkValue )
         {
-            toAddress = value;
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Customer</b> to single <b>Address</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Address to build this Customer with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Customer.CustomerBuilder address( final Address value )
+        public Customer.CustomerBuilder address( final Address cloudSdkValue )
         {
-            return toAddress(value);
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
@@ -362,24 +362,24 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Vendor") ) {
-                final Object value = (cloudSdkValues).remove("Vendor");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Vendor");
+                if( cloudSdkValue instanceof Map ) {
                     if( toVendor == null ) {
                         toVendor = new Vendor();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) cloudSdkValue);
                     toVendor.fromMap(inputMap);
                 }
             }
             if( (cloudSdkValues).containsKey("Shelf") ) {
-                final Object value = (cloudSdkValues).remove("Shelf");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Shelf");
+                if( cloudSdkValue instanceof Map ) {
                     if( toShelf == null ) {
                         toShelf = new Shelf();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) cloudSdkValue);
                     toShelf.fromMap(inputMap);
                 }
             }
@@ -426,12 +426,12 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
     /**
      * Overwrites the associated <b>Vendor</b> entity for the loaded navigation property <b>Vendor</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Vendor</b> entity.
      */
-    public void setVendor( final Vendor value )
+    public void setVendor( final Vendor cloudSdkValue )
     {
-        toVendor = value;
+        toVendor = cloudSdkValue;
     }
 
     /**
@@ -453,12 +453,12 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
     /**
      * Overwrites the associated <b>Shelf</b> entity for the loaded navigation property <b>Shelf</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Shelf</b> entity.
      */
-    public void setShelf( final Shelf value )
+    public void setShelf( final Shelf cloudSdkValue )
     {
-        toShelf = value;
+        toShelf = cloudSdkValue;
     }
 
     /**
@@ -471,42 +471,42 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
         private Vendor toVendor;
         private Shelf toShelf;
 
-        private Product.ProductBuilder toVendor( final Vendor value )
+        private Product.ProductBuilder toVendor( final Vendor cloudSdkValue )
         {
-            toVendor = value;
+            toVendor = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Vendor</b> for <b>Product</b> to single <b>Vendor</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Vendor to build this Product with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder vendor( final Vendor value )
+        public Product.ProductBuilder vendor( final Vendor cloudSdkValue )
         {
-            return toVendor(value);
+            return toVendor(cloudSdkValue);
         }
 
-        private Product.ProductBuilder toShelf( final Shelf value )
+        private Product.ProductBuilder toShelf( final Shelf cloudSdkValue )
         {
-            toShelf = value;
+            toShelf = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Shelf</b> for <b>Product</b> to single <b>Shelf</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Shelf to build this Product with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder shelf( final Shelf value )
+        public Product.ProductBuilder shelf( final Shelf cloudSdkValue )
         {
-            return toShelf(value);
+            return toShelf(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -280,13 +280,13 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Customer") ) {
-                final Object value = (cloudSdkValues).remove("Customer");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Customer");
+                if( cloudSdkValue instanceof Map ) {
                     if( toCustomer == null ) {
                         toCustomer = new Customer();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toCustomer.fromMap(inputMap);
                 }
             }
@@ -330,12 +330,12 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
     /**
      * Overwrites the associated <b>Customer</b> entity for the loaded navigation property <b>Customer</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Customer</b> entity.
      */
-    public void setCustomer( final Customer value )
+    public void setCustomer( final Customer cloudSdkValue )
     {
-        toCustomer = value;
+        toCustomer = cloudSdkValue;
     }
 
     /**
@@ -347,23 +347,23 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
 
         private Customer toCustomer;
 
-        private Receipt.ReceiptBuilder toCustomer( final Customer value )
+        private Receipt.ReceiptBuilder toCustomer( final Customer cloudSdkValue )
         {
-            toCustomer = value;
+            toCustomer = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Customer</b> for <b>Receipt</b> to single <b>Customer</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Customer to build this Receipt with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Receipt.ReceiptBuilder customer( final Customer value )
+        public Receipt.ReceiptBuilder customer( final Customer cloudSdkValue )
         {
-            return toCustomer(value);
+            return toCustomer(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -208,26 +208,26 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("FloorPlan") ) {
-                final Object value = (cloudSdkValues).remove("FloorPlan");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("FloorPlan");
+                if( cloudSdkValue instanceof Map ) {
                     if( toFloorPlan == null ) {
                         toFloorPlan = new FloorPlan();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toFloorPlan.fromMap(inputMap);
                 }
             }
             if( (cloudSdkValues).containsKey("Products") ) {
-                final Object value = (cloudSdkValues).remove("Products");
-                if( value instanceof Iterable ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Products");
+                if( cloudSdkValue instanceof Iterable ) {
                     if( toProducts == null ) {
                         toProducts = Lists.newArrayList();
                     } else {
                         toProducts = Lists.newArrayList(toProducts);
                     }
                     int i = 0;
-                    for( Object item : ((Iterable<?>) value) ) {
+                    for( Object item : ((Iterable<?>) cloudSdkValue) ) {
                         if( !(item instanceof Map) ) {
                             continue;
                         }
@@ -289,12 +289,12 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
     /**
      * Overwrites the associated <b>FloorPlan</b> entity for the loaded navigation property <b>FloorPlan</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>FloorPlan</b> entity.
      */
-    public void setFloorPlan( final FloorPlan value )
+    public void setFloorPlan( final FloorPlan cloudSdkValue )
     {
-        toFloorPlan = value;
+        toFloorPlan = cloudSdkValue;
     }
 
     /**
@@ -324,16 +324,16 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
      * first time and it has not yet been loaded, an OData query will be run in order to load the missing information
      * and its result will get cached for future invocations.
      *
-     * @param value
+     * @param cloudSdkValue
      *            List of <b>Product</b> entities.
      */
-    public void setProducts( @Nonnull final List<Product> value )
+    public void setProducts( @Nonnull final List<Product> cloudSdkValue )
     {
         if( toProducts == null ) {
             toProducts = Lists.newArrayList();
         }
         toProducts.clear();
-        toProducts.addAll(value);
+        toProducts.addAll(cloudSdkValue);
     }
 
     /**
@@ -390,42 +390,42 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
         private FloorPlan toFloorPlan;
         private List<Product> toProducts = Lists.newArrayList();
 
-        private Shelf.ShelfBuilder toFloorPlan( final FloorPlan value )
+        private Shelf.ShelfBuilder toFloorPlan( final FloorPlan cloudSdkValue )
         {
-            toFloorPlan = value;
+            toFloorPlan = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>FloorPlan</b> for <b>Shelf</b> to single <b>FloorPlan</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The FloorPlan to build this Shelf with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder floorPlan( final FloorPlan value )
+        public Shelf.ShelfBuilder floorPlan( final FloorPlan cloudSdkValue )
         {
-            return toFloorPlan(value);
+            return toFloorPlan(cloudSdkValue);
         }
 
-        private Shelf.ShelfBuilder toProducts( final List<Product> value )
+        private Shelf.ShelfBuilder toProducts( final List<Product> cloudSdkValue )
         {
-            toProducts.addAll(value);
+            toProducts.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Products</b> for <b>Shelf</b> to multiple <b>Product</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Products to build this Shelf with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder products( Product... value )
+        public Shelf.ShelfBuilder products( Product... cloudSdkValue )
         {
-            return toProducts(Lists.newArrayList(value));
+            return toProducts(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -220,13 +220,13 @@ public class Vendor extends VdmEntity<Vendor>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Address") ) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if( cloudSdkValue instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object>) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -264,12 +264,12 @@ public class Vendor extends VdmEntity<Vendor>
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Address</b> entity.
      */
-    public void setAddress( final Address value )
+    public void setAddress( final Address cloudSdkValue )
     {
-        toAddress = value;
+        toAddress = cloudSdkValue;
     }
 
     /**
@@ -281,23 +281,23 @@ public class Vendor extends VdmEntity<Vendor>
 
         private Address toAddress;
 
-        private Vendor.VendorBuilder toAddress( final Address value )
+        private Vendor.VendorBuilder toAddress( final Address cloudSdkValue )
         {
-            toAddress = value;
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Vendor</b> to single <b>Address</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Address to build this Vendor with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Vendor.VendorBuilder address( final Address value )
+        public Vendor.VendorBuilder address( final Address cloudSdkValue )
         {
-            return toAddress(value);
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/NavigationPropertyMethodsGenerator.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/NavigationPropertyMethodsGenerator.java
@@ -285,7 +285,7 @@ class NavigationPropertyMethodsGenerator
                             associatedEntity.name(),
                             navigationProperty.getEdmName()));
             setterMethod.javadoc().add(JavadocUtils.getLazyWarningMessage(navigationProperty, entityClass));
-            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "value");
+            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
             setterMethod
                 .javadoc()
                 .addParam(setterParam)
@@ -310,7 +310,7 @@ class NavigationPropertyMethodsGenerator
                             "Overwrites the associated <b>%s</b> entity for the loaded navigation property <b>%s</b>.",
                             associatedEntity.name(),
                             navigationProperty.getEdmName()));
-            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "value");
+            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
             setterMethod
                 .javadoc()
                 .addParam(setterParam)
@@ -447,7 +447,7 @@ class NavigationPropertyMethodsGenerator
                 .decl(
                     JMod.FINAL,
                     codeModel.ref(Object.class),
-                    "value",
+                    "cloudSdkValue",
                     JExpr
                         .direct(CommonConstants.INLINE_MAP_NAME)
                         .invoke("remove")
@@ -510,7 +510,7 @@ class NavigationPropertyMethodsGenerator
         final JType returnType = classMemberField.type();
         final JFieldVar buildField = builderClass.field(JMod.PRIVATE, returnType, classMemberName, init);
         final JMethod origMethod = builderClass.method(JMod.PRIVATE, builderClass, classMemberName);
-        final JVar origMethodVal = origMethod.param(JMod.FINAL, returnType, "value");
+        final JVar origMethodVal = origMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
         if( isOneToMany ) {
             origMethod.body().invoke(buildField, "addAll").arg(origMethodVal);
         } else {
@@ -524,7 +524,7 @@ class NavigationPropertyMethodsGenerator
 
         final JInvocation invocation;
         if( isOneToMany ) {
-            final JVar fixedMethodParam = fixedMethod.varParam(associatedEntity, "value");
+            final JVar fixedMethodParam = fixedMethod.varParam(associatedEntity, "cloudSdkValue");
             invocation =
                 JExpr
                     .invoke(origMethod)
@@ -535,7 +535,7 @@ class NavigationPropertyMethodsGenerator
                 .addParam(fixedMethodParam)
                 .add(String.format("The %ss to build this %s with.", associatedEntity.name(), entityClass.name()));
         } else {
-            final JVar fixedMethodParam = fixedMethod.param(JMod.FINAL, associatedEntity, "value");
+            final JVar fixedMethodParam = fixedMethod.param(JMod.FINAL, associatedEntity, "cloudSdkValue");
             invocation = JExpr.invoke(origMethod).arg(fixedMethodParam);
 
             fixedMethod
@@ -592,7 +592,7 @@ class NavigationPropertyMethodsGenerator
         final String origName = originalField.name();
         final JMethod originalMethod = builderClass.method(JMod.PUBLIC, builderClass, origName);
         final JFieldVar origBuildField = builderClass.field(JMod.PRIVATE, origType, origName, JExpr._null());
-        final JVar originalMethodParameter = originalMethod.param(JMod.FINAL, origType, "value");
+        final JVar originalMethodParameter = originalMethod.param(JMod.FINAL, origType, "cloudSdkValue");
 
         originalMethod.javadoc().add(originalField.javadoc());
 

--- a/datamodel/odata-v4/odata-v4-generator/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/generator/ODataGeneratorIntegrationTest.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/generator/ODataGeneratorIntegrationTest.java
@@ -144,7 +144,6 @@ class ODataGeneratorIntegrationTest
 
     @Test
     void testDeprecationNoticeAddition( @TempDir final Path path )
-        throws IOException
     {
         final Path inputDirectory =
             Paths.get("src/test/resources/oDataGeneratorIntegrationTest/explicitDeprecation/input");

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -229,13 +229,13 @@ public class Customer
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Address")) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if (cloudSdkValue instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -274,11 +274,11 @@ public class Customer
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Address</b> entity.
      */
-    public void setAddress(final Address value) {
-        toAddress = value;
+    public void setAddress(final Address cloudSdkValue) {
+        toAddress = cloudSdkValue;
     }
 
     /**
@@ -344,22 +344,22 @@ public class Customer
 
         private Address toAddress;
 
-        private Customer.CustomerBuilder toAddress(final Address value) {
-            toAddress = value;
+        private Customer.CustomerBuilder toAddress(final Address cloudSdkValue) {
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Customer</b> to single <b>Address</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Address to build this Customer with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Customer.CustomerBuilder address(final Address value) {
-            return toAddress(value);
+        public Customer.CustomerBuilder address(final Address cloudSdkValue) {
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -317,24 +317,24 @@ public class Product
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Vendor")) {
-                final Object value = (cloudSdkValues).remove("Vendor");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Vendor");
+                if (cloudSdkValue instanceof Map) {
                     if (toVendor == null) {
                         toVendor = new Vendor();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toVendor.fromMap(inputMap);
                 }
             }
             if ((cloudSdkValues).containsKey("Shelf")) {
-                final Object value = (cloudSdkValues).remove("Shelf");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Shelf");
+                if (cloudSdkValue instanceof Map) {
                     if (toShelf == null) {
                         toShelf = new Shelf();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toShelf.fromMap(inputMap);
                 }
             }
@@ -376,11 +376,11 @@ public class Product
     /**
      * Overwrites the associated <b>Vendor</b> entity for the loaded navigation property <b>Vendor</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Vendor</b> entity.
      */
-    public void setVendor(final Vendor value) {
-        toVendor = value;
+    public void setVendor(final Vendor cloudSdkValue) {
+        toVendor = cloudSdkValue;
     }
 
     /**
@@ -399,11 +399,11 @@ public class Product
     /**
      * Overwrites the associated <b>Shelf</b> entity for the loaded navigation property <b>Shelf</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Shelf</b> entity.
      */
-    public void setShelf(final Shelf value) {
-        toShelf = value;
+    public void setShelf(final Shelf cloudSdkValue) {
+        toShelf = cloudSdkValue;
     }
 
 
@@ -416,40 +416,40 @@ public class Product
         private Vendor toVendor;
         private Shelf toShelf;
 
-        private Product.ProductBuilder toVendor(final Vendor value) {
-            toVendor = value;
+        private Product.ProductBuilder toVendor(final Vendor cloudSdkValue) {
+            toVendor = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Vendor</b> for <b>Product</b> to single <b>Vendor</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Vendor to build this Product with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder vendor(final Vendor value) {
-            return toVendor(value);
+        public Product.ProductBuilder vendor(final Vendor cloudSdkValue) {
+            return toVendor(cloudSdkValue);
         }
 
-        private Product.ProductBuilder toShelf(final Shelf value) {
-            toShelf = value;
+        private Product.ProductBuilder toShelf(final Shelf cloudSdkValue) {
+            toShelf = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Shelf</b> for <b>Product</b> to single <b>Shelf</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Shelf to build this Product with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder shelf(final Shelf value) {
-            return toShelf(value);
+        public Product.ProductBuilder shelf(final Shelf cloudSdkValue) {
+            return toShelf(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -246,13 +246,13 @@ public class Receipt
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Customer")) {
-                final Object value = (cloudSdkValues).remove("Customer");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Customer");
+                if (cloudSdkValue instanceof Map) {
                     if (toCustomer == null) {
                         toCustomer = new Customer();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toCustomer.fromMap(inputMap);
                 }
             }
@@ -291,11 +291,11 @@ public class Receipt
     /**
      * Overwrites the associated <b>Customer</b> entity for the loaded navigation property <b>Customer</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Customer</b> entity.
      */
-    public void setCustomer(final Customer value) {
-        toCustomer = value;
+    public void setCustomer(final Customer cloudSdkValue) {
+        toCustomer = cloudSdkValue;
     }
 
 
@@ -307,22 +307,22 @@ public class Receipt
 
         private Customer toCustomer;
 
-        private Receipt.ReceiptBuilder toCustomer(final Customer value) {
-            toCustomer = value;
+        private Receipt.ReceiptBuilder toCustomer(final Customer cloudSdkValue) {
+            toCustomer = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Customer</b> for <b>Receipt</b> to single <b>Customer</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Customer to build this Receipt with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Receipt.ReceiptBuilder customer(final Customer value) {
-            return toCustomer(value);
+        public Receipt.ReceiptBuilder customer(final Customer cloudSdkValue) {
+            return toCustomer(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -183,26 +183,26 @@ public class Shelf
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("FloorPlan")) {
-                final Object value = (cloudSdkValues).remove("FloorPlan");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("FloorPlan");
+                if (cloudSdkValue instanceof Map) {
                     if (toFloorPlan == null) {
                         toFloorPlan = new FloorPlan();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toFloorPlan.fromMap(inputMap);
                 }
             }
             if ((cloudSdkValues).containsKey("Products")) {
-                final Object value = (cloudSdkValues).remove("Products");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Products");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toProducts == null) {
                         toProducts = Lists.newArrayList();
                     } else {
                         toProducts = Lists.newArrayList(toProducts);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -258,11 +258,11 @@ public class Shelf
     /**
      * Overwrites the associated <b>FloorPlan</b> entity for the loaded navigation property <b>FloorPlan</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>FloorPlan</b> entity.
      */
-    public void setFloorPlan(final FloorPlan value) {
-        toFloorPlan = value;
+    public void setFloorPlan(final FloorPlan cloudSdkValue) {
+        toFloorPlan = cloudSdkValue;
     }
 
     /**
@@ -285,17 +285,17 @@ public class Shelf
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>Product</b> entities.
      */
     public void setProducts(
         @Nonnull
-        final List<Product> value) {
+        final List<Product> cloudSdkValue) {
         if (toProducts == null) {
             toProducts = Lists.newArrayList();
         }
         toProducts.clear();
-        toProducts.addAll(value);
+        toProducts.addAll(cloudSdkValue);
     }
 
     /**
@@ -337,40 +337,40 @@ public class Shelf
         private FloorPlan toFloorPlan;
         private List<Product> toProducts = Lists.newArrayList();
 
-        private Shelf.ShelfBuilder toFloorPlan(final FloorPlan value) {
-            toFloorPlan = value;
+        private Shelf.ShelfBuilder toFloorPlan(final FloorPlan cloudSdkValue) {
+            toFloorPlan = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>FloorPlan</b> for <b>Shelf</b> to single <b>FloorPlan</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The FloorPlan to build this Shelf with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder floorPlan(final FloorPlan value) {
-            return toFloorPlan(value);
+        public Shelf.ShelfBuilder floorPlan(final FloorPlan cloudSdkValue) {
+            return toFloorPlan(cloudSdkValue);
         }
 
-        private Shelf.ShelfBuilder toProducts(final List<Product> value) {
-            toProducts.addAll(value);
+        private Shelf.ShelfBuilder toProducts(final List<Product> cloudSdkValue) {
+            toProducts.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Products</b> for <b>Shelf</b> to multiple <b>Product</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Products to build this Shelf with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder products(Product... value) {
-            return toProducts(Lists.newArrayList(value));
+        public Shelf.ShelfBuilder products(Product... cloudSdkValue) {
+            return toProducts(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -194,13 +194,13 @@ public class Vendor
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Address")) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if (cloudSdkValue instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -234,11 +234,11 @@ public class Vendor
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Address</b> entity.
      */
-    public void setAddress(final Address value) {
-        toAddress = value;
+    public void setAddress(final Address cloudSdkValue) {
+        toAddress = cloudSdkValue;
     }
 
 
@@ -250,22 +250,22 @@ public class Vendor
 
         private Address toAddress;
 
-        private Vendor.VendorBuilder toAddress(final Address value) {
-            toAddress = value;
+        private Vendor.VendorBuilder toAddress(final Address cloudSdkValue) {
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Vendor</b> to single <b>Address</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Address to build this Vendor with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Vendor.VendorBuilder address(final Address value) {
-            return toAddress(value);
+        public Vendor.VendorBuilder address(final Address cloudSdkValue) {
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -167,13 +167,13 @@ public class SimplePerson
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Friend")) {
-                final Object value = (cloudSdkValues).remove("Friend");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Friend");
+                if (cloudSdkValue instanceof Map) {
                     if (toFriend_2 == null) {
                         toFriend_2 = new Friend();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toFriend_2 .fromMap(inputMap);
                 }
             }
@@ -212,11 +212,11 @@ public class SimplePerson
     /**
      * Overwrites the associated <b>Friend</b> entity for the loaded navigation property <b>Friend</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Friend</b> entity.
      */
-    public void setFriend(final Friend value) {
-        toFriend_2 = value;
+    public void setFriend(final Friend cloudSdkValue) {
+        toFriend_2 = cloudSdkValue;
     }
 
 
@@ -228,22 +228,22 @@ public class SimplePerson
 
         private Friend toFriend_2;
 
-        private SimplePerson.SimplePersonBuilder toFriend_2(final Friend value) {
-            toFriend_2 = value;
+        private SimplePerson.SimplePersonBuilder toFriend_2(final Friend cloudSdkValue) {
+            toFriend_2 = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Friend</b> for <b>SimplePerson</b> to single <b>Friend</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Friend to build this SimplePerson with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public SimplePerson.SimplePersonBuilder friend(final Friend value) {
-            return toFriend_2(value);
+        public SimplePerson.SimplePersonBuilder friend(final Friend cloudSdkValue) {
+            return toFriend_2(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
@@ -137,13 +137,13 @@ public class TestEntityCircularLinkChild
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_Parent")) {
-                final Object value = (cloudSdkValues).remove("to_Parent");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_Parent");
+                if (cloudSdkValue instanceof Map) {
                     if (toParent == null) {
                         toParent = new TestEntityCircularLinkParent();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toParent.fromMap(inputMap);
                 }
             }
@@ -182,11 +182,11 @@ public class TestEntityCircularLinkChild
     /**
      * Overwrites the associated <b>TestEntityCircularLinkParent</b> entity for the loaded navigation property <b>to_Parent</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityCircularLinkParent</b> entity.
      */
-    public void setParent(final TestEntityCircularLinkParent value) {
-        toParent = value;
+    public void setParent(final TestEntityCircularLinkParent cloudSdkValue) {
+        toParent = cloudSdkValue;
     }
 
 
@@ -198,22 +198,22 @@ public class TestEntityCircularLinkChild
 
         private TestEntityCircularLinkParent toParent;
 
-        private TestEntityCircularLinkChild.TestEntityCircularLinkChildBuilder toParent(final TestEntityCircularLinkParent value) {
-            toParent = value;
+        private TestEntityCircularLinkChild.TestEntityCircularLinkChildBuilder toParent(final TestEntityCircularLinkParent cloudSdkValue) {
+            toParent = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_Parent</b> for <b>TestEntityCircularLinkChild</b> to single <b>TestEntityCircularLinkParent</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityCircularLinkParent to build this TestEntityCircularLinkChild with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityCircularLinkChild.TestEntityCircularLinkChildBuilder parent(final TestEntityCircularLinkParent value) {
-            return toParent(value);
+        public TestEntityCircularLinkChild.TestEntityCircularLinkChildBuilder parent(final TestEntityCircularLinkParent cloudSdkValue) {
+            return toParent(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
@@ -137,13 +137,13 @@ public class TestEntityCircularLinkParent
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_Child")) {
-                final Object value = (cloudSdkValues).remove("to_Child");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_Child");
+                if (cloudSdkValue instanceof Map) {
                     if (toChild == null) {
                         toChild = new TestEntityCircularLinkChild();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toChild.fromMap(inputMap);
                 }
             }
@@ -182,11 +182,11 @@ public class TestEntityCircularLinkParent
     /**
      * Overwrites the associated <b>TestEntityCircularLinkChild</b> entity for the loaded navigation property <b>to_Child</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityCircularLinkChild</b> entity.
      */
-    public void setChild(final TestEntityCircularLinkChild value) {
-        toChild = value;
+    public void setChild(final TestEntityCircularLinkChild cloudSdkValue) {
+        toChild = cloudSdkValue;
     }
 
 
@@ -198,22 +198,22 @@ public class TestEntityCircularLinkParent
 
         private TestEntityCircularLinkChild toChild;
 
-        private TestEntityCircularLinkParent.TestEntityCircularLinkParentBuilder toChild(final TestEntityCircularLinkChild value) {
-            toChild = value;
+        private TestEntityCircularLinkParent.TestEntityCircularLinkParentBuilder toChild(final TestEntityCircularLinkChild cloudSdkValue) {
+            toChild = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_Child</b> for <b>TestEntityCircularLinkParent</b> to single <b>TestEntityCircularLinkChild</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityCircularLinkChild to build this TestEntityCircularLinkParent with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityCircularLinkParent.TestEntityCircularLinkParentBuilder child(final TestEntityCircularLinkChild value) {
-            return toChild(value);
+        public TestEntityCircularLinkParent.TestEntityCircularLinkParentBuilder child(final TestEntityCircularLinkChild cloudSdkValue) {
+            return toChild(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -273,15 +273,15 @@ public class TestEntityMultiLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -300,13 +300,13 @@ public class TestEntityMultiLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -352,17 +352,17 @@ public class TestEntityMultiLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -398,11 +398,11 @@ public class TestEntityMultiLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -415,40 +415,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -273,15 +273,15 @@ public class TestEntitySingleLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -300,13 +300,13 @@ public class TestEntitySingleLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -352,17 +352,17 @@ public class TestEntitySingleLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -398,11 +398,11 @@ public class TestEntitySingleLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -415,40 +415,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
@@ -899,15 +899,15 @@ public class TestEntityV4
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -926,15 +926,15 @@ public class TestEntityV4
                 }
             }
             if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_OtherMultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
                     } else {
                         toOtherMultiLink = Lists.newArrayList(toOtherMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -953,24 +953,24 @@ public class TestEntityV4
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
             if ((cloudSdkValues).containsKey("to_StreamLink")) {
-                final Object value = (cloudSdkValues).remove("to_StreamLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_StreamLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toStreamLink == null) {
                         toStreamLink = new TestEntityStream();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) value);
+                    final Map<java.lang.String, Object> inputMap = ((Map<java.lang.String, Object> ) cloudSdkValue);
                     toStreamLink.fromMap(inputMap);
                 }
             }
@@ -1022,17 +1022,17 @@ public class TestEntityV4
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1072,17 +1072,17 @@ public class TestEntityV4
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setOtherMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toOtherMultiLink == null) {
             toOtherMultiLink = Lists.newArrayList();
         }
         toOtherMultiLink.clear();
-        toOtherMultiLink.addAll(value);
+        toOtherMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1118,11 +1118,11 @@ public class TestEntityV4
     /**
      * Overwrites the associated <b>TestEntitySingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntitySingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntitySingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntitySingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
     /**
@@ -1141,11 +1141,11 @@ public class TestEntityV4
     /**
      * Overwrites the associated <b>TestEntityStream</b> entity for the loaded navigation property <b>to_StreamLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityStream</b> entity.
      */
-    public void setStreamLink(final TestEntityStream value) {
-        toStreamLink = value;
+    public void setStreamLink(final TestEntityStream cloudSdkValue) {
+        toStreamLink = cloudSdkValue;
     }
 
     /**
@@ -1384,76 +1384,76 @@ public class TestEntityV4
         private TestEntitySingleLink toSingleLink;
         private TestEntityStream toStreamLink;
 
-        private TestEntityV4 .TestEntityV4Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV4 .TestEntityV4Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV4</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV4 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV4 .TestEntityV4Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV4 .TestEntityV4Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV4 .TestEntityV4Builder toOtherMultiLink(final List<TestEntityMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV4 .TestEntityV4Builder toOtherMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV4</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV4 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV4 .TestEntityV4Builder otherMultiLink(TestEntityMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV4 .TestEntityV4Builder otherMultiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV4 .TestEntityV4Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV4 .TestEntityV4Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV4</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV4 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV4 .TestEntityV4Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV4 .TestEntityV4Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
-        private TestEntityV4 .TestEntityV4Builder toStreamLink(final TestEntityStream value) {
-            toStreamLink = value;
+        private TestEntityV4 .TestEntityV4Builder toStreamLink(final TestEntityStream cloudSdkValue) {
+            toStreamLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_StreamLink</b> for <b>TestEntityV4</b> to single <b>TestEntityStream</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityStream to build this TestEntityV4 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV4 .TestEntityV4Builder streamLink(final TestEntityStream value) {
-            return toStreamLink(value);
+        public TestEntityV4 .TestEntityV4Builder streamLink(final TestEntityStream cloudSdkValue) {
+            return toStreamLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
@@ -303,13 +303,13 @@ public class Customer extends VdmEntity<Customer>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Address") ) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if( cloudSdkValue instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -457,12 +457,12 @@ public class Customer extends VdmEntity<Customer>
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Address</b> entity.
      */
-    public void setAddress( final Address value )
+    public void setAddress( final Address cloudSdkValue )
     {
-        toAddress = value;
+        toAddress = cloudSdkValue;
     }
 
     /**
@@ -474,23 +474,23 @@ public class Customer extends VdmEntity<Customer>
 
         private Address toAddress;
 
-        private Customer.CustomerBuilder toAddress( final Address value )
+        private Customer.CustomerBuilder toAddress( final Address cloudSdkValue )
         {
-            toAddress = value;
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Customer</b> to single <b>Address</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Address to build this Customer with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Customer.CustomerBuilder address( final Address value )
+        public Customer.CustomerBuilder address( final Address cloudSdkValue )
         {
-            return toAddress(value);
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
@@ -376,26 +376,26 @@ public class Product extends VdmMediaEntity<Product>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Vendor") ) {
-                final Object value = (cloudSdkValues).remove("Vendor");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Vendor");
+                if( cloudSdkValue instanceof Map ) {
                     if( toVendor == null ) {
                         toVendor = new Vendor();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toVendor.fromMap(inputMap);
                 }
             }
             if( (cloudSdkValues).containsKey("Shelf") ) {
-                final Object value = (cloudSdkValues).remove("Shelf");
-                if( value instanceof Iterable ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Shelf");
+                if( cloudSdkValue instanceof Iterable ) {
                     if( toShelf == null ) {
                         toShelf = Lists.newArrayList();
                     } else {
                         toShelf = Lists.newArrayList(toShelf);
                     }
                     int i = 0;
-                    for( Object item : ((Iterable<?>) value) ) {
+                    for( Object item : ((Iterable<?>) cloudSdkValue) ) {
                         if( !(item instanceof Map) ) {
                             continue;
                         }
@@ -560,12 +560,12 @@ public class Product extends VdmMediaEntity<Product>
     /**
      * Overwrites the associated <b>Vendor</b> entity for the loaded navigation property <b>Vendor</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Vendor</b> entity.
      */
-    public void setVendor( final Vendor value )
+    public void setVendor( final Vendor cloudSdkValue )
     {
-        toVendor = value;
+        toVendor = cloudSdkValue;
     }
 
     /**
@@ -643,16 +643,16 @@ public class Product extends VdmMediaEntity<Product>
      * first time and it has not yet been loaded, an OData query will be run in order to load the missing information
      * and its result will get cached for future invocations.
      *
-     * @param value
+     * @param cloudSdkValue
      *            List of <b>Shelf</b> entities.
      */
-    public void setShelf( @Nonnull final List<Shelf> value )
+    public void setShelf( @Nonnull final List<Shelf> cloudSdkValue )
     {
         if( toShelf == null ) {
             toShelf = Lists.newArrayList();
         }
         toShelf.clear();
-        toShelf.addAll(value);
+        toShelf.addAll(cloudSdkValue);
     }
 
     /**
@@ -688,42 +688,42 @@ public class Product extends VdmMediaEntity<Product>
         private Vendor toVendor;
         private List<Shelf> toShelf = Lists.newArrayList();
 
-        private Product.ProductBuilder toVendor( final Vendor value )
+        private Product.ProductBuilder toVendor( final Vendor cloudSdkValue )
         {
-            toVendor = value;
+            toVendor = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Vendor</b> for <b>Product</b> to single <b>Vendor</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Vendor to build this Product with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder vendor( final Vendor value )
+        public Product.ProductBuilder vendor( final Vendor cloudSdkValue )
         {
-            return toVendor(value);
+            return toVendor(cloudSdkValue);
         }
 
-        private Product.ProductBuilder toShelf( final List<Shelf> value )
+        private Product.ProductBuilder toShelf( final List<Shelf> cloudSdkValue )
         {
-            toShelf.addAll(value);
+            toShelf.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Shelf</b> for <b>Product</b> to multiple <b>Shelf</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Shelfs to build this Product with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder shelf( Shelf... value )
+        public Product.ProductBuilder shelf( Shelf... cloudSdkValue )
         {
-            return toShelf(Lists.newArrayList(value));
+            return toShelf(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -667,13 +667,13 @@ public class Receipt extends VdmEntity<Receipt>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Customer") ) {
-                final Object value = (cloudSdkValues).remove("Customer");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Customer");
+                if( cloudSdkValue instanceof Map ) {
                     if( toCustomer == null ) {
                         toCustomer = new Customer();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toCustomer.fromMap(inputMap);
                 }
             }
@@ -821,12 +821,12 @@ public class Receipt extends VdmEntity<Receipt>
     /**
      * Overwrites the associated <b>Customer</b> entity for the loaded navigation property <b>Customer</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Customer</b> entity.
      */
-    public void setCustomer( final Customer value )
+    public void setCustomer( final Customer cloudSdkValue )
     {
-        toCustomer = value;
+        toCustomer = cloudSdkValue;
     }
 
     /**
@@ -838,23 +838,23 @@ public class Receipt extends VdmEntity<Receipt>
 
         private Customer toCustomer;
 
-        private Receipt.ReceiptBuilder toCustomer( final Customer value )
+        private Receipt.ReceiptBuilder toCustomer( final Customer cloudSdkValue )
         {
-            toCustomer = value;
+            toCustomer = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Customer</b> for <b>Receipt</b> to single <b>Customer</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Customer to build this Receipt with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Receipt.ReceiptBuilder customer( final Customer value )
+        public Receipt.ReceiptBuilder customer( final Customer cloudSdkValue )
         {
-            return toCustomer(value);
+            return toCustomer(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -214,26 +214,26 @@ public class Shelf extends VdmEntity<Shelf>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("FloorPlan") ) {
-                final Object value = (cloudSdkValues).remove("FloorPlan");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("FloorPlan");
+                if( cloudSdkValue instanceof Map ) {
                     if( toFloorPlan == null ) {
                         toFloorPlan = new FloorPlan();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toFloorPlan.fromMap(inputMap);
                 }
             }
             if( (cloudSdkValues).containsKey("Products") ) {
-                final Object value = (cloudSdkValues).remove("Products");
-                if( value instanceof Iterable ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Products");
+                if( cloudSdkValue instanceof Iterable ) {
                     if( toProducts == null ) {
                         toProducts = Lists.newArrayList();
                     } else {
                         toProducts = Lists.newArrayList(toProducts);
                     }
                     int i = 0;
-                    for( Object item : ((Iterable<?>) value) ) {
+                    for( Object item : ((Iterable<?>) cloudSdkValue) ) {
                         if( !(item instanceof Map) ) {
                             continue;
                         }
@@ -399,12 +399,12 @@ public class Shelf extends VdmEntity<Shelf>
     /**
      * Overwrites the associated <b>FloorPlan</b> entity for the loaded navigation property <b>FloorPlan</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>FloorPlan</b> entity.
      */
-    public void setFloorPlan( final FloorPlan value )
+    public void setFloorPlan( final FloorPlan cloudSdkValue )
     {
-        toFloorPlan = value;
+        toFloorPlan = cloudSdkValue;
     }
 
     /**
@@ -482,16 +482,16 @@ public class Shelf extends VdmEntity<Shelf>
      * first time and it has not yet been loaded, an OData query will be run in order to load the missing information
      * and its result will get cached for future invocations.
      *
-     * @param value
+     * @param cloudSdkValue
      *            List of <b>Product</b> entities.
      */
-    public void setProducts( @Nonnull final List<Product> value )
+    public void setProducts( @Nonnull final List<Product> cloudSdkValue )
     {
         if( toProducts == null ) {
             toProducts = Lists.newArrayList();
         }
         toProducts.clear();
-        toProducts.addAll(value);
+        toProducts.addAll(cloudSdkValue);
     }
 
     /**
@@ -527,42 +527,42 @@ public class Shelf extends VdmEntity<Shelf>
         private FloorPlan toFloorPlan;
         private List<Product> toProducts = Lists.newArrayList();
 
-        private Shelf.ShelfBuilder toFloorPlan( final FloorPlan value )
+        private Shelf.ShelfBuilder toFloorPlan( final FloorPlan cloudSdkValue )
         {
-            toFloorPlan = value;
+            toFloorPlan = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>FloorPlan</b> for <b>Shelf</b> to single <b>FloorPlan</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The FloorPlan to build this Shelf with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder floorPlan( final FloorPlan value )
+        public Shelf.ShelfBuilder floorPlan( final FloorPlan cloudSdkValue )
         {
-            return toFloorPlan(value);
+            return toFloorPlan(cloudSdkValue);
         }
 
-        private Shelf.ShelfBuilder toProducts( final List<Product> value )
+        private Shelf.ShelfBuilder toProducts( final List<Product> cloudSdkValue )
         {
-            toProducts.addAll(value);
+            toProducts.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Products</b> for <b>Shelf</b> to multiple <b>Product</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Products to build this Shelf with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder products( Product... value )
+        public Shelf.ShelfBuilder products( Product... cloudSdkValue )
         {
-            return toProducts(Lists.newArrayList(value));
+            return toProducts(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -236,13 +236,13 @@ public class Vendor extends VdmEntity<Vendor>
         // navigation properties
         {
             if( (cloudSdkValues).containsKey("Address") ) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if( value instanceof Map ) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if( cloudSdkValue instanceof Map ) {
                     if( toAddress == null ) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings( "unchecked" )
-                    final Map<String, Object> inputMap = ((Map<String, Object>) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object>) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -390,12 +390,12 @@ public class Vendor extends VdmEntity<Vendor>
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      *
-     * @param value
+     * @param cloudSdkValue
      *            New <b>Address</b> entity.
      */
-    public void setAddress( final Address value )
+    public void setAddress( final Address cloudSdkValue )
     {
-        toAddress = value;
+        toAddress = cloudSdkValue;
     }
 
     /**
@@ -407,23 +407,23 @@ public class Vendor extends VdmEntity<Vendor>
 
         private Address toAddress;
 
-        private Vendor.VendorBuilder toAddress( final Address value )
+        private Vendor.VendorBuilder toAddress( final Address cloudSdkValue )
         {
-            toAddress = value;
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Vendor</b> to single <b>Address</b>.
          *
-         * @param value
+         * @param cloudSdkValue
          *            The Address to build this Vendor with.
          * @return This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Vendor.VendorBuilder address( final Address value )
+        public Vendor.VendorBuilder address( final Address cloudSdkValue )
         {
-            return toAddress(value);
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/NavigationPropertyMethodsGenerator.java
+++ b/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/NavigationPropertyMethodsGenerator.java
@@ -300,7 +300,7 @@ class NavigationPropertyMethodsGenerator
                             associatedEntity.name(),
                             navigationProperty.getEdmName()));
             setterMethod.javadoc().add(JavadocUtils.getLazyWarningMessage(navigationProperty, entityClass));
-            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "value");
+            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
             setterMethod
                 .javadoc()
                 .addParam(setterParam)
@@ -325,7 +325,7 @@ class NavigationPropertyMethodsGenerator
                             "Overwrites the associated <b>%s</b> entity for the loaded navigation property <b>%s</b>.",
                             associatedEntity.name(),
                             navigationProperty.getEdmName()));
-            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "value");
+            final JVar setterParam = setterMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
             setterMethod
                 .javadoc()
                 .addParam(setterParam)
@@ -559,7 +559,7 @@ class NavigationPropertyMethodsGenerator
                 .decl(
                     JMod.FINAL,
                     codeModel.ref(Object.class),
-                    "value",
+                    "cloudSdkValue",
                     JExpr
                         .direct(CommonConstants.INLINE_MAP_NAME)
                         .invoke("remove")
@@ -622,7 +622,7 @@ class NavigationPropertyMethodsGenerator
         final JType returnType = classMemberField.type();
         final JFieldVar buildField = builderClass.field(JMod.PRIVATE, returnType, classMemberName, init);
         final JMethod origMethod = builderClass.method(JMod.PRIVATE, builderClass, classMemberName);
-        final JVar origMethodVal = origMethod.param(JMod.FINAL, returnType, "value");
+        final JVar origMethodVal = origMethod.param(JMod.FINAL, returnType, "cloudSdkValue");
         if( isOneToMany ) {
             origMethod.body().invoke(buildField, "addAll").arg(origMethodVal);
         } else {
@@ -640,7 +640,7 @@ class NavigationPropertyMethodsGenerator
 
             final JInvocation invocation;
             if( isOneToMany ) {
-                final JVar fixedMethodParam = fixedMethod.varParam(associatedEntity, "value");
+                final JVar fixedMethodParam = fixedMethod.varParam(associatedEntity, "cloudSdkValue");
                 invocation =
                     JExpr
                         .invoke(origMethod)
@@ -651,7 +651,7 @@ class NavigationPropertyMethodsGenerator
                     .addParam(fixedMethodParam)
                     .add(String.format("The %ss to build this %s with.", associatedEntity.name(), entityClass.name()));
             } else {
-                final JVar fixedMethodParam = fixedMethod.param(JMod.FINAL, associatedEntity, "value");
+                final JVar fixedMethodParam = fixedMethod.param(JMod.FINAL, associatedEntity, "cloudSdkValue");
                 invocation = JExpr.invoke(origMethod).arg(fixedMethodParam);
 
                 fixedMethod
@@ -709,7 +709,7 @@ class NavigationPropertyMethodsGenerator
         final String origName = originalField.name();
         final JMethod originalMethod = builderClass.method(JMod.PUBLIC, builderClass, origName);
         final JFieldVar origBuildField = builderClass.field(JMod.PRIVATE, origType, origName, JExpr._null());
-        final JVar originalMethodParameter = originalMethod.param(JMod.FINAL, origType, "value");
+        final JVar originalMethodParameter = originalMethod.param(JMod.FINAL, origType, "cloudSdkValue");
 
         originalMethod.javadoc().add(originalField.javadoc());
 

--- a/datamodel/odata/odata-generator/src/test/java/com/sap/cloud/sdk/datamodel/odata/generator/ODataGeneratorIntegrationTest.java
+++ b/datamodel/odata/odata-generator/src/test/java/com/sap/cloud/sdk/datamodel/odata/generator/ODataGeneratorIntegrationTest.java
@@ -159,7 +159,6 @@ class ODataGeneratorIntegrationTest
 
     @Test
     void testDeprecationNoticeAddition( @TempDir final Path path )
-        throws IOException
     {
         final Path inputDirectory =
             Paths.get("src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/input");

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -252,13 +252,13 @@ public class Customer
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Address")) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if (cloudSdkValue instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -398,11 +398,11 @@ public class Customer
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Address</b> entity.
      */
-    public void setAddress(final Address value) {
-        toAddress = value;
+    public void setAddress(final Address cloudSdkValue) {
+        toAddress = cloudSdkValue;
     }
 
 
@@ -414,22 +414,22 @@ public class Customer
 
         private Address toAddress;
 
-        private Customer.CustomerBuilder toAddress(final Address value) {
-            toAddress = value;
+        private Customer.CustomerBuilder toAddress(final Address cloudSdkValue) {
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Customer</b> to single <b>Address</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Address to build this Customer with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Customer.CustomerBuilder address(final Address value) {
-            return toAddress(value);
+        public Customer.CustomerBuilder address(final Address cloudSdkValue) {
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -344,26 +344,26 @@ public class Product
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Vendor")) {
-                final Object value = (cloudSdkValues).remove("Vendor");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Vendor");
+                if (cloudSdkValue instanceof Map) {
                     if (toVendor == null) {
                         toVendor = new Vendor();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toVendor.fromMap(inputMap);
                 }
             }
             if ((cloudSdkValues).containsKey("Shelf")) {
-                final Object value = (cloudSdkValues).remove("Shelf");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Shelf");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toShelf == null) {
                         toShelf = Lists.newArrayList();
                     } else {
                         toShelf = Lists.newArrayList(toShelf);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -520,11 +520,11 @@ public class Product
     /**
      * Overwrites the associated <b>Vendor</b> entity for the loaded navigation property <b>Vendor</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Vendor</b> entity.
      */
-    public void setVendor(final Vendor value) {
-        toVendor = value;
+    public void setVendor(final Vendor cloudSdkValue) {
+        toVendor = cloudSdkValue;
     }
 
     /**
@@ -582,17 +582,17 @@ public class Product
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>Shelf</b> entities.
      */
     public void setShelf(
         @Nonnull
-        final List<Shelf> value) {
+        final List<Shelf> cloudSdkValue) {
         if (toShelf == null) {
             toShelf = Lists.newArrayList();
         }
         toShelf.clear();
-        toShelf.addAll(value);
+        toShelf.addAll(cloudSdkValue);
     }
 
     /**
@@ -622,40 +622,40 @@ public class Product
         private Vendor toVendor;
         private List<Shelf> toShelf = Lists.newArrayList();
 
-        private Product.ProductBuilder toVendor(final Vendor value) {
-            toVendor = value;
+        private Product.ProductBuilder toVendor(final Vendor cloudSdkValue) {
+            toVendor = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Vendor</b> for <b>Product</b> to single <b>Vendor</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Vendor to build this Product with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder vendor(final Vendor value) {
-            return toVendor(value);
+        public Product.ProductBuilder vendor(final Vendor cloudSdkValue) {
+            return toVendor(cloudSdkValue);
         }
 
-        private Product.ProductBuilder toShelf(final List<Shelf> value) {
-            toShelf.addAll(value);
+        private Product.ProductBuilder toShelf(final List<Shelf> cloudSdkValue) {
+            toShelf.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Shelf</b> for <b>Product</b> to multiple <b>Shelf</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Shelfs to build this Product with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Product.ProductBuilder shelf(Shelf... value) {
-            return toShelf(Lists.newArrayList(value));
+        public Product.ProductBuilder shelf(Shelf... cloudSdkValue) {
+            return toShelf(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -607,13 +607,13 @@ public class Receipt
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Customer")) {
-                final Object value = (cloudSdkValues).remove("Customer");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Customer");
+                if (cloudSdkValue instanceof Map) {
                     if (toCustomer == null) {
                         toCustomer = new Customer();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toCustomer.fromMap(inputMap);
                 }
             }
@@ -753,11 +753,11 @@ public class Receipt
     /**
      * Overwrites the associated <b>Customer</b> entity for the loaded navigation property <b>Customer</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Customer</b> entity.
      */
-    public void setCustomer(final Customer value) {
-        toCustomer = value;
+    public void setCustomer(final Customer cloudSdkValue) {
+        toCustomer = cloudSdkValue;
     }
 
 
@@ -769,22 +769,22 @@ public class Receipt
 
         private Customer toCustomer;
 
-        private Receipt.ReceiptBuilder toCustomer(final Customer value) {
-            toCustomer = value;
+        private Receipt.ReceiptBuilder toCustomer(final Customer cloudSdkValue) {
+            toCustomer = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Customer</b> for <b>Receipt</b> to single <b>Customer</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Customer to build this Receipt with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Receipt.ReceiptBuilder customer(final Customer value) {
-            return toCustomer(value);
+        public Receipt.ReceiptBuilder customer(final Customer cloudSdkValue) {
+            return toCustomer(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -198,26 +198,26 @@ public class Shelf
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("FloorPlan")) {
-                final Object value = (cloudSdkValues).remove("FloorPlan");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("FloorPlan");
+                if (cloudSdkValue instanceof Map) {
                     if (toFloorPlan == null) {
                         toFloorPlan = new FloorPlan();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toFloorPlan.fromMap(inputMap);
                 }
             }
             if ((cloudSdkValues).containsKey("Products")) {
-                final Object value = (cloudSdkValues).remove("Products");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Products");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toProducts == null) {
                         toProducts = Lists.newArrayList();
                     } else {
                         toProducts = Lists.newArrayList(toProducts);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -374,11 +374,11 @@ public class Shelf
     /**
      * Overwrites the associated <b>FloorPlan</b> entity for the loaded navigation property <b>FloorPlan</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>FloorPlan</b> entity.
      */
-    public void setFloorPlan(final FloorPlan value) {
-        toFloorPlan = value;
+    public void setFloorPlan(final FloorPlan cloudSdkValue) {
+        toFloorPlan = cloudSdkValue;
     }
 
     /**
@@ -436,17 +436,17 @@ public class Shelf
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>Product</b> entities.
      */
     public void setProducts(
         @Nonnull
-        final List<Product> value) {
+        final List<Product> cloudSdkValue) {
         if (toProducts == null) {
             toProducts = Lists.newArrayList();
         }
         toProducts.clear();
-        toProducts.addAll(value);
+        toProducts.addAll(cloudSdkValue);
     }
 
     /**
@@ -476,40 +476,40 @@ public class Shelf
         private FloorPlan toFloorPlan;
         private List<Product> toProducts = Lists.newArrayList();
 
-        private Shelf.ShelfBuilder toFloorPlan(final FloorPlan value) {
-            toFloorPlan = value;
+        private Shelf.ShelfBuilder toFloorPlan(final FloorPlan cloudSdkValue) {
+            toFloorPlan = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>FloorPlan</b> for <b>Shelf</b> to single <b>FloorPlan</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The FloorPlan to build this Shelf with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder floorPlan(final FloorPlan value) {
-            return toFloorPlan(value);
+        public Shelf.ShelfBuilder floorPlan(final FloorPlan cloudSdkValue) {
+            return toFloorPlan(cloudSdkValue);
         }
 
-        private Shelf.ShelfBuilder toProducts(final List<Product> value) {
-            toProducts.addAll(value);
+        private Shelf.ShelfBuilder toProducts(final List<Product> cloudSdkValue) {
+            toProducts.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>Products</b> for <b>Shelf</b> to multiple <b>Product</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Products to build this Shelf with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Shelf.ShelfBuilder products(Product... value) {
-            return toProducts(Lists.newArrayList(value));
+        public Shelf.ShelfBuilder products(Product... cloudSdkValue) {
+            return toProducts(Lists.newArrayList(cloudSdkValue));
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -216,13 +216,13 @@ public class Vendor
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("Address")) {
-                final Object value = (cloudSdkValues).remove("Address");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("Address");
+                if (cloudSdkValue instanceof Map) {
                     if (toAddress == null) {
                         toAddress = new Address();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toAddress.fromMap(inputMap);
                 }
             }
@@ -362,11 +362,11 @@ public class Vendor
     /**
      * Overwrites the associated <b>Address</b> entity for the loaded navigation property <b>Address</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>Address</b> entity.
      */
-    public void setAddress(final Address value) {
-        toAddress = value;
+    public void setAddress(final Address cloudSdkValue) {
+        toAddress = cloudSdkValue;
     }
 
 
@@ -378,22 +378,22 @@ public class Vendor
 
         private Address toAddress;
 
-        private Vendor.VendorBuilder toAddress(final Address value) {
-            toAddress = value;
+        private Vendor.VendorBuilder toAddress(final Address cloudSdkValue) {
+            toAddress = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>Address</b> for <b>Vendor</b> to single <b>Address</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The Address to build this Vendor with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public Vendor.VendorBuilder address(final Address value) {
-            return toAddress(value);
+        public Vendor.VendorBuilder address(final Address cloudSdkValue) {
+            return toAddress(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
@@ -218,15 +218,15 @@ public class TestEntityV2
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink_2 == null) {
                         toMultiLink_2 = Lists.newArrayList();
                     } else {
                         toMultiLink_2 = Lists.newArrayList(toMultiLink_2);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -384,17 +384,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink_2 == null) {
             toMultiLink_2 = Lists.newArrayList();
         }
         toMultiLink_2 .clear();
-        toMultiLink_2 .addAll(value);
+        toMultiLink_2 .addAll(cloudSdkValue);
     }
 
     /**
@@ -424,35 +424,35 @@ public class TestEntityV2
         private List<TestEntityMultiLink> toMultiLink_2 = Lists.newArrayList();
         private String multiLink = null;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink_2(final List<TestEntityMultiLink> value) {
-            toMultiLink_2 .addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink_2(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink_2 .addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink_2(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink_2(Lists.newArrayList(cloudSdkValue));
         }
 
         /**
          * Constraints: Not nullable, Maximum length: 80 <p>Original property name from the Odata EDM: <b>MultiLink</b></p>
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The multiLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(final String value) {
-            multiLink = value;
+        public TestEntityV2 .TestEntityV2Builder multiLink(final String cloudSdkValue) {
+            multiLink = cloudSdkValue;
             return this;
         }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -308,15 +308,15 @@ public class TestEntityMultiLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntityMultiLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntityMultiLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntityMultiLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -308,15 +308,15 @@ public class TestEntitySingleLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntitySingleLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntitySingleLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntitySingleLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -812,15 +812,15 @@ public class TestEntityV2
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -839,15 +839,15 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_OtherMultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
                     } else {
                         toOtherMultiLink = Lists.newArrayList(toOtherMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -866,13 +866,13 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -1022,17 +1022,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1107,17 +1107,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityOtherMultiLink</b> entities.
      */
     public void setOtherMultiLink(
         @Nonnull
-        final List<TestEntityOtherMultiLink> value) {
+        final List<TestEntityOtherMultiLink> cloudSdkValue) {
         if (toOtherMultiLink == null) {
             toOtherMultiLink = Lists.newArrayList();
         }
         toOtherMultiLink.clear();
-        toOtherMultiLink.addAll(value);
+        toOtherMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1188,11 +1188,11 @@ public class TestEntityV2
     /**
      * Overwrites the associated <b>TestEntitySingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntitySingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntitySingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntitySingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -1206,58 +1206,58 @@ public class TestEntityV2
         private List<TestEntityOtherMultiLink> toOtherMultiLink = Lists.newArrayList();
         private TestEntitySingleLink toSingleLink;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityOtherMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityOtherMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV2</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -308,15 +308,15 @@ public class TestEntityMultiLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntityMultiLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -489,17 +489,17 @@ public class TestEntityMultiLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -570,11 +570,11 @@ public class TestEntityMultiLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -587,40 +587,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -308,15 +308,15 @@ public class TestEntitySingleLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntitySingleLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -489,17 +489,17 @@ public class TestEntitySingleLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -570,11 +570,11 @@ public class TestEntitySingleLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -587,40 +587,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -812,15 +812,15 @@ public class TestEntityV2
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -839,15 +839,15 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_OtherMultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
                     } else {
                         toOtherMultiLink = Lists.newArrayList(toOtherMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -866,13 +866,13 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -1023,17 +1023,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1108,17 +1108,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityOtherMultiLink</b> entities.
      */
     public void setOtherMultiLink(
         @Nonnull
-        final List<TestEntityOtherMultiLink> value) {
+        final List<TestEntityOtherMultiLink> cloudSdkValue) {
         if (toOtherMultiLink == null) {
             toOtherMultiLink = Lists.newArrayList();
         }
         toOtherMultiLink.clear();
-        toOtherMultiLink.addAll(value);
+        toOtherMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1189,11 +1189,11 @@ public class TestEntityV2
     /**
      * Overwrites the associated <b>TestEntitySingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntitySingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntitySingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntitySingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -1207,58 +1207,58 @@ public class TestEntityV2
         private List<TestEntityOtherMultiLink> toOtherMultiLink = Lists.newArrayList();
         private TestEntitySingleLink toSingleLink;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityOtherMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityOtherMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV2</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -308,15 +308,15 @@ public class TestEntityMultiLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntityMultiLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntityMultiLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntityMultiLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -308,15 +308,15 @@ public class TestEntitySingleLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntitySingleLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntitySingleLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntitySingleLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -812,15 +812,15 @@ public class TestEntityV2
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -839,15 +839,15 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_OtherMultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
                     } else {
                         toOtherMultiLink = Lists.newArrayList(toOtherMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -866,13 +866,13 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -1022,17 +1022,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1107,17 +1107,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityOtherMultiLink</b> entities.
      */
     public void setOtherMultiLink(
         @Nonnull
-        final List<TestEntityOtherMultiLink> value) {
+        final List<TestEntityOtherMultiLink> cloudSdkValue) {
         if (toOtherMultiLink == null) {
             toOtherMultiLink = Lists.newArrayList();
         }
         toOtherMultiLink.clear();
-        toOtherMultiLink.addAll(value);
+        toOtherMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1188,11 +1188,11 @@ public class TestEntityV2
     /**
      * Overwrites the associated <b>TestEntitySingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntitySingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntitySingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntitySingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -1206,58 +1206,58 @@ public class TestEntityV2
         private List<TestEntityOtherMultiLink> toOtherMultiLink = Lists.newArrayList();
         private TestEntitySingleLink toSingleLink;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityOtherMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityOtherMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV2</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -308,15 +308,15 @@ public class TestEntityMultiLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntityMultiLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntityMultiLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntityMultiLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -308,15 +308,15 @@ public class TestEntitySingleLink
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -335,13 +335,13 @@ public class TestEntitySingleLink
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntityLvl2SingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -488,17 +488,17 @@ public class TestEntitySingleLink
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityLvl2MultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityLvl2MultiLink> value) {
+        final List<TestEntityLvl2MultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -569,11 +569,11 @@ public class TestEntitySingleLink
     /**
      * Overwrites the associated <b>TestEntityLvl2SingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntityLvl2SingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntityLvl2SingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -586,40 +586,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -812,15 +812,15 @@ public class TestEntityV2
         // navigation properties
         {
             if ((cloudSdkValues).containsKey("to_MultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_MultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_MultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toMultiLink == null) {
                         toMultiLink = Lists.newArrayList();
                     } else {
                         toMultiLink = Lists.newArrayList(toMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -839,15 +839,15 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_OtherMultiLink")) {
-                final Object value = (cloudSdkValues).remove("to_OtherMultiLink");
-                if (value instanceof Iterable) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_OtherMultiLink");
+                if (cloudSdkValue instanceof Iterable) {
                     if (toOtherMultiLink == null) {
                         toOtherMultiLink = Lists.newArrayList();
                     } else {
                         toOtherMultiLink = Lists.newArrayList(toOtherMultiLink);
                     }
                     int i = 0;
-                    for (Object item: ((Iterable<?> ) value)) {
+                    for (Object item: ((Iterable<?> ) cloudSdkValue)) {
                         if (!(item instanceof Map)) {
                             continue;
                         }
@@ -866,13 +866,13 @@ public class TestEntityV2
                 }
             }
             if ((cloudSdkValues).containsKey("to_SingleLink")) {
-                final Object value = (cloudSdkValues).remove("to_SingleLink");
-                if (value instanceof Map) {
+                final Object cloudSdkValue = (cloudSdkValues).remove("to_SingleLink");
+                if (cloudSdkValue instanceof Map) {
                     if (toSingleLink == null) {
                         toSingleLink = new TestEntitySingleLink();
                     }
                     @SuppressWarnings("unchecked")
-                    final Map<String, Object> inputMap = ((Map<String, Object> ) value);
+                    final Map<String, Object> inputMap = ((Map<String, Object> ) cloudSdkValue);
                     toSingleLink.fromMap(inputMap);
                 }
             }
@@ -1022,17 +1022,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityMultiLink</b> entities.
      */
     public void setMultiLink(
         @Nonnull
-        final List<TestEntityMultiLink> value) {
+        final List<TestEntityMultiLink> cloudSdkValue) {
         if (toMultiLink == null) {
             toMultiLink = Lists.newArrayList();
         }
         toMultiLink.clear();
-        toMultiLink.addAll(value);
+        toMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1107,17 +1107,17 @@ public class TestEntityV2
      * <p>
      * Please note: <i>Lazy</i> loading of OData entity associations is the process of asynchronous retrieval and persisting of items from a navigation property. If a <i>lazy</i> property is requested by the application for the first time and it has not yet been loaded, an OData query will be run in order to load the missing information and its result will get cached for future invocations.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     List of <b>TestEntityOtherMultiLink</b> entities.
      */
     public void setOtherMultiLink(
         @Nonnull
-        final List<TestEntityOtherMultiLink> value) {
+        final List<TestEntityOtherMultiLink> cloudSdkValue) {
         if (toOtherMultiLink == null) {
             toOtherMultiLink = Lists.newArrayList();
         }
         toOtherMultiLink.clear();
-        toOtherMultiLink.addAll(value);
+        toOtherMultiLink.addAll(cloudSdkValue);
     }
 
     /**
@@ -1188,11 +1188,11 @@ public class TestEntityV2
     /**
      * Overwrites the associated <b>TestEntitySingleLink</b> entity for the loaded navigation property <b>to_SingleLink</b>.
      * 
-     * @param value
+     * @param cloudSdkValue
      *     New <b>TestEntitySingleLink</b> entity.
      */
-    public void setSingleLink(final TestEntitySingleLink value) {
-        toSingleLink = value;
+    public void setSingleLink(final TestEntitySingleLink cloudSdkValue) {
+        toSingleLink = cloudSdkValue;
     }
 
 
@@ -1206,58 +1206,58 @@ public class TestEntityV2
         private List<TestEntityOtherMultiLink> toOtherMultiLink = Lists.newArrayList();
         private TestEntitySingleLink toSingleLink;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityOtherMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityOtherMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV2</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -199,40 +199,40 @@ public class TestEntityMultiLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityMultiLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntityMultiLink.TestEntityMultiLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityMultiLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntityMultiLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntityMultiLink.TestEntityMultiLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -199,40 +199,40 @@ public class TestEntitySingleLink
         private List<TestEntityLvl2MultiLink> toMultiLink = Lists.newArrayList();
         private TestEntityLvl2SingleLink toSingleLink;
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toMultiLink(final List<TestEntityLvl2MultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntitySingleLink</b> to multiple <b>TestEntityLvl2MultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2MultiLinks to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder multiLink(TestEntityLvl2MultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink value) {
-            toSingleLink = value;
+        private TestEntitySingleLink.TestEntitySingleLinkBuilder toSingleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntitySingleLink</b> to single <b>TestEntityLvl2SingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityLvl2SingleLink to build this TestEntitySingleLink with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink value) {
-            return toSingleLink(value);
+        public TestEntitySingleLink.TestEntitySingleLinkBuilder singleLink(final TestEntityLvl2SingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -537,58 +537,58 @@ public class TestEntityV2
         private List<TestEntityOtherMultiLink> toOtherMultiLink = Lists.newArrayList();
         private TestEntitySingleLink toSingleLink;
 
-        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> value) {
-            toMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toMultiLink(final List<TestEntityMultiLink> cloudSdkValue) {
+            toMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_MultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... value) {
-            return toMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder multiLink(TestEntityMultiLink... cloudSdkValue) {
+            return toMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> value) {
-            toOtherMultiLink.addAll(value);
+        private TestEntityV2 .TestEntityV2Builder toOtherMultiLink(final List<TestEntityOtherMultiLink> cloudSdkValue) {
+            toOtherMultiLink.addAll(cloudSdkValue);
             return this;
         }
 
         /**
          * Navigation property <b>to_OtherMultiLink</b> for <b>TestEntityV2</b> to multiple <b>TestEntityOtherMultiLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntityOtherMultiLinks to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... value) {
-            return toOtherMultiLink(Lists.newArrayList(value));
+        public TestEntityV2 .TestEntityV2Builder otherMultiLink(TestEntityOtherMultiLink... cloudSdkValue) {
+            return toOtherMultiLink(Lists.newArrayList(cloudSdkValue));
         }
 
-        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink value) {
-            toSingleLink = value;
+        private TestEntityV2 .TestEntityV2Builder toSingleLink(final TestEntitySingleLink cloudSdkValue) {
+            toSingleLink = cloudSdkValue;
             return this;
         }
 
         /**
          * Navigation property <b>to_SingleLink</b> for <b>TestEntityV2</b> to single <b>TestEntitySingleLink</b>.
          * 
-         * @param value
+         * @param cloudSdkValue
          *     The TestEntitySingleLink to build this TestEntityV2 with.
          * @return
          *     This Builder to allow for a fluent interface.
          */
         @Nonnull
-        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink value) {
-            return toSingleLink(value);
+        public TestEntityV2 .TestEntityV2Builder singleLink(final TestEntitySingleLink cloudSdkValue) {
+            return toSingleLink(cloudSdkValue);
         }
 
     }

--- a/release_notes.md
+++ b/release_notes.md
@@ -25,5 +25,5 @@
 ### 🐛 Fixed Issues
 
 - Fix ApacheHttpClient5Wrapper to propagate the configuration to Spring RestTemplate.
-- Fix OData v2 and v4 generators to work when property name is `values` and is of collection type.
-  - The internal variable is now `cloudSdkValues` to avoid conflicts with the `values` property.
+- Fix OData v2 and v4 generators to work when property name is `value` or `values` and is of collection type.
+  - The internal variable is now respectively `cloudSdkValue` or `cloudSdkValues` to avoid conflicts with the `value` or `values` property.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://sap.stackenterprise.co/questions/65172

Follow up of #668 
Users can't create an object with a field named `values` and make a List or Map of this object.
Solution: rename our internal variable from `values` to `cloudSdkValues` to make sure it doesn't collide.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Documentation updated~
- [x] Release notes updated
