### PR TITLE
Exchange HashMap with LinkedHashMap (odata v2)

### DIFF
--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Address.java
@@ -332,7 +332,7 @@ public class Address extends VdmEntity<Address>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -356,7 +356,7 @@ public class Address extends VdmEntity<Address>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/AddressByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/AddressByKeyFluentHelper.java
@@ -21,7 +21,7 @@ import com.sap.cloud.sdk.datamodel.odata.sample.namespaces.sdkgrocerystore.selec
 public class AddressByKeyFluentHelper extends FluentHelperByKey<AddressByKeyFluentHelper, Address, AddressSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Customer.java
@@ -249,7 +249,7 @@ public class Customer extends VdmEntity<Customer>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -269,7 +269,7 @@ public class Customer extends VdmEntity<Customer>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/CustomerByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/CustomerByKeyFluentHelper.java
@@ -23,7 +23,7 @@ public class CustomerByKeyFluentHelper
     FluentHelperByKey<CustomerByKeyFluentHelper, Customer, CustomerSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlan.java
@@ -134,7 +134,7 @@ public class FloorPlan extends VdmEntity<FloorPlan>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -152,7 +152,7 @@ public class FloorPlan extends VdmEntity<FloorPlan>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlanByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/FloorPlanByKeyFluentHelper.java
@@ -23,7 +23,7 @@ public class FloorPlanByKeyFluentHelper
     FluentHelperByKey<FloorPlanByKeyFluentHelper, FloorPlan, FloorPlanSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/GetProductQuantitiesFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/GetProductQuantitiesFluentHelper.java
@@ -29,7 +29,7 @@ public class GetProductQuantitiesFluentHelper
     CollectionValuedFluentHelperFunction<GetProductQuantitiesFluentHelper, ProductCount, List<ProductCount>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>GetProductQuantities</b> OData function import with the

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/IsStoreOpenFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/IsStoreOpenFluentHelper.java
@@ -27,7 +27,7 @@ import com.sap.cloud.sdk.datamodel.odata.helper.SingleValuedFluentHelperFunction
 public class IsStoreOpenFluentHelper extends SingleValuedFluentHelperFunction<IsStoreOpenFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>IsStoreOpen</b> OData function import with the provided

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHours.java
@@ -213,7 +213,7 @@ public class OpeningHours extends VdmEntity<OpeningHours>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -233,7 +233,7 @@ public class OpeningHours extends VdmEntity<OpeningHours>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHoursByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OpeningHoursByKeyFluentHelper.java
@@ -24,7 +24,7 @@ public class OpeningHoursByKeyFluentHelper
     FluentHelperByKey<OpeningHoursByKeyFluentHelper, OpeningHours, OpeningHoursSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OrderProductFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/OrderProductFluentHelper.java
@@ -28,7 +28,7 @@ public class OrderProductFluentHelper
     SingleValuedFluentHelperFunction<OrderProductFluentHelper, Receipt, Receipt>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>OrderProduct</b> OData function import with the provided

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/PrintReceiptFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/PrintReceiptFluentHelper.java
@@ -26,7 +26,7 @@ import com.sap.cloud.sdk.datamodel.odata.helper.SingleValuedFluentHelperFunction
 public class PrintReceiptFluentHelper extends SingleValuedFluentHelperFunction<PrintReceiptFluentHelper, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>PrintReceipt</b> OData function import with the provided

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Product.java
@@ -308,7 +308,7 @@ public class Product extends VdmMediaEntity<Product>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -330,7 +330,7 @@ public class Product extends VdmMediaEntity<Product>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductByKeyFluentHelper.java
@@ -21,7 +21,7 @@ import com.sap.cloud.sdk.datamodel.odata.sample.namespaces.sdkgrocerystore.selec
 public class ProductByKeyFluentHelper extends FluentHelperByKey<ProductByKeyFluentHelper, Product, ProductSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ProductCount.java
@@ -88,7 +88,7 @@ public class ProductCount extends VdmComplex<ProductCount>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("ProductId") ) {
@@ -117,7 +117,7 @@ public class ProductCount extends VdmComplex<ProductCount>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -470,7 +470,7 @@ public class Receipt extends VdmEntity<Receipt>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -499,7 +499,7 @@ public class Receipt extends VdmEntity<Receipt>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ReceiptByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ReceiptByKeyFluentHelper.java
@@ -21,7 +21,7 @@ import com.sap.cloud.sdk.datamodel.odata.sample.namespaces.sdkgrocerystore.selec
 public class ReceiptByKeyFluentHelper extends FluentHelperByKey<ReceiptByKeyFluentHelper, Receipt, ReceiptSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/RevokeReceiptFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/RevokeReceiptFluentHelper.java
@@ -28,7 +28,7 @@ public class RevokeReceiptFluentHelper
     SingleValuedFluentHelperFunction<RevokeReceiptFluentHelper, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>RevokeReceipt</b> OData function import with the provided

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -174,7 +174,7 @@ public class Shelf extends VdmEntity<Shelf>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -192,7 +192,7 @@ public class Shelf extends VdmEntity<Shelf>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ShelfByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/ShelfByKeyFluentHelper.java
@@ -21,7 +21,7 @@ import com.sap.cloud.sdk.datamodel.odata.sample.namespaces.sdkgrocerystore.selec
 public class ShelfByKeyFluentHelper extends FluentHelperByKey<ShelfByKeyFluentHelper, Shelf, ShelfSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -189,7 +189,7 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected Map<String, Object> getKey()
     {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -208,7 +208,7 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/VendorByKeyFluentHelper.java
+++ b/datamodel/odata/odata-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odata/sample/namespaces/sdkgrocerystore/VendorByKeyFluentHelper.java
@@ -21,7 +21,7 @@ import com.sap.cloud.sdk.datamodel.odata.sample.namespaces.sdkgrocerystore.selec
 public class VendorByKeyFluentHelper extends FluentHelperByKey<VendorByKeyFluentHelper, Vendor, VendorSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single

--- a/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/FluentHelperClassGenerator.java
+++ b/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/FluentHelperClassGenerator.java
@@ -187,7 +187,7 @@ class FluentHelperClassGenerator
                     JMod.PRIVATE | JMod.FINAL,
                     keyClass,
                     "key",
-                    codeModel.ref(Maps.class).staticInvoke("newHashMap"));
+                    codeModel.ref(Maps.class).staticInvoke("newLinkedHashMap"));
 
         // constructor with service path and entity collection parameter
         final JMethod constructor =
@@ -298,7 +298,7 @@ class FluentHelperClassGenerator
                     JMod.PRIVATE | JMod.FINAL,
                     codeModel.ref(Map.class).narrow(String.class, Object.class),
                     "values",
-                    codeModel.ref(Maps.class).staticInvoke("newHashMap"));
+                    codeModel.ref(Maps.class).staticInvoke("newLinkedHashMap"));
 
         createGetEntityClass(functionImportFluentHelperClass, returnTypeClass);
 

--- a/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/NamespaceClassGenerator.java
+++ b/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/NamespaceClassGenerator.java
@@ -512,7 +512,7 @@ class NamespaceClassGenerator
                     JMod.FINAL,
                     fieldMapClass,
                     CommonConstants.INLINE_MAP_NAME,
-                    codeModel.ref(Maps.class).staticInvoke("newHashMap").arg(inputValues));
+                    codeModel.ref(Maps.class).staticInvoke("newLinkedHashMap").arg(inputValues));
 
         body.block().directStatement("// simple properties");
         final JBlock simplePropertiesBlock = new JBlock(true, true);
@@ -600,7 +600,7 @@ class NamespaceClassGenerator
         getKeyMethod.annotate(Override.class);
         final JBlock body = getKeyMethod.body();
         final JVar v =
-            body.decl(JMod.FINAL, fieldMapClass, "result", codeModel.ref(Maps.class).staticInvoke("newHashMap"));
+            body.decl(JMod.FINAL, fieldMapClass, "result", codeModel.ref(Maps.class).staticInvoke("newLinkedHashMap"));
         for( final Map.Entry<String, EntityPropertyModel> entry : entityClassFields.entrySet() ) {
             if( entry.getValue().isKeyField() ) {
                 final String javaFieldName = entry.getValue().getJavaFieldName();

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BP.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BP.java
@@ -91,7 +91,7 @@ public class BP
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Code", getCode());
         return result;
     }
@@ -106,7 +106,7 @@ public class BP
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Code")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class BPByKeyFluentHelper
     extends FluentHelperByKey<BPByKeyFluentHelper, BP, BPSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.functionimportnameclash.BP BP} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPByKeyFluentHelper_2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPByKeyFluentHelper_2.java
@@ -25,7 +25,7 @@ public class BPByKeyFluentHelper_2
     extends SingleValuedFluentHelperFunction<BPByKeyFluentHelper_2, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>BPByKey</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPCreateFluentHelper_2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPCreateFluentHelper_2.java
@@ -25,7 +25,7 @@ public class BPCreateFluentHelper_2
     extends SingleValuedFluentHelperFunction<BPCreateFluentHelper_2, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>BPCreate</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPDeleteFluentHelper_2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPDeleteFluentHelper_2.java
@@ -25,7 +25,7 @@ public class BPDeleteFluentHelper_2
     extends SingleValuedFluentHelperFunction<BPDeleteFluentHelper_2, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>BPDelete</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPUpdateFluentHelper_2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/functionImportClash/output/testcomparison/namespaces/functionimportnameclash/BPUpdateFluentHelper_2.java
@@ -25,7 +25,7 @@ public class BPUpdateFluentHelper_2
     extends SingleValuedFluentHelperFunction<BPUpdateFluentHelper_2, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>BPUpdate</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
@@ -294,7 +294,7 @@ public class Address
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -316,7 +316,7 @@ public class Address
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/AddressByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/AddressByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class AddressByKeyFluentHelper
     extends FluentHelperByKey<AddressByKeyFluentHelper, Address, AddressSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Address Address} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -200,7 +200,7 @@ public class Customer
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -218,7 +218,7 @@ public class Customer
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/CustomerByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/CustomerByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class CustomerByKeyFluentHelper
     extends FluentHelperByKey<CustomerByKeyFluentHelper, Customer, CustomerSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Customer Customer} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
@@ -120,7 +120,7 @@ public class FloorPlan
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -136,7 +136,7 @@ public class FloorPlan
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlanByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlanByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class FloorPlanByKeyFluentHelper
     extends FluentHelperByKey<FloorPlanByKeyFluentHelper, FloorPlan, FloorPlanSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.FloorPlan FloorPlan} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/GetProductQuantitiesFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/GetProductQuantitiesFluentHelper.java
@@ -26,7 +26,7 @@ public class GetProductQuantitiesFluentHelper
     extends CollectionValuedFluentHelperFunction<GetProductQuantitiesFluentHelper, ProductCount, List<ProductCount>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>GetProductQuantities</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/IsStoreOpenFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/IsStoreOpenFluentHelper.java
@@ -26,7 +26,7 @@ public class IsStoreOpenFluentHelper
     extends SingleValuedFluentHelperFunction<IsStoreOpenFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>IsStoreOpen</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
@@ -187,7 +187,7 @@ public class OpeningHours
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -205,7 +205,7 @@ public class OpeningHours
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHoursByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHoursByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class OpeningHoursByKeyFluentHelper
     extends FluentHelperByKey<OpeningHoursByKeyFluentHelper, OpeningHours, OpeningHoursSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.OpeningHours OpeningHours} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OrderProductFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OrderProductFluentHelper.java
@@ -25,7 +25,7 @@ public class OrderProductFluentHelper
     extends SingleValuedFluentHelperFunction<OrderProductFluentHelper, Receipt, Receipt>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>OrderProduct</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PrintReceiptFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PrintReceiptFluentHelper.java
@@ -25,7 +25,7 @@ public class PrintReceiptFluentHelper
     extends SingleValuedFluentHelperFunction<PrintReceiptFluentHelper, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>PrintReceipt</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -278,7 +278,7 @@ public class Product
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -298,7 +298,7 @@ public class Product
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class ProductByKeyFluentHelper
     extends FluentHelperByKey<ProductByKeyFluentHelper, Product, ProductSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Product Product} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
@@ -78,7 +78,7 @@ public class ProductCount
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("ProductId")) {
@@ -106,7 +106,7 @@ public class ProductCount
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -412,7 +412,7 @@ public class Receipt
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -439,7 +439,7 @@ public class Receipt
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ReceiptByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ReceiptByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class ReceiptByKeyFluentHelper
     extends FluentHelperByKey<ReceiptByKeyFluentHelper, Receipt, ReceiptSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Receipt Receipt} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/RevokeReceiptFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/RevokeReceiptFluentHelper.java
@@ -25,7 +25,7 @@ public class RevokeReceiptFluentHelper
     extends SingleValuedFluentHelperFunction<RevokeReceiptFluentHelper, String, String>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>RevokeReceipt</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -160,7 +160,7 @@ public class Shelf
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -176,7 +176,7 @@ public class Shelf
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ShelfByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ShelfByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class ShelfByKeyFluentHelper
     extends FluentHelperByKey<ShelfByKeyFluentHelper, Shelf, ShelfSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Shelf Shelf} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -171,7 +171,7 @@ public class Vendor
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Id", getId());
         return result;
     }
@@ -188,7 +188,7 @@ public class Vendor
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/VendorByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/VendorByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class VendorByKeyFluentHelper
     extends FluentHelperByKey<VendorByKeyFluentHelper, Vendor, VendorSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.sdkgrocerystore.Vendor Vendor} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabel.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabel.java
@@ -89,7 +89,7 @@ public class EntityWithoutKeyLabel
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 
@@ -103,7 +103,7 @@ public class EntityWithoutKeyLabel
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("SomeField")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabelByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/EntityWithoutKeyLabelByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class EntityWithoutKeyLabelByKeyFluentHelper
     extends FluentHelperByKey<EntityWithoutKeyLabelByKeyFluentHelper, EntityWithoutKeyLabel, EntityWithoutKeyLabelSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.entitywithkeynamedfield.EntityWithoutKeyLabel EntityWithoutKeyLabel} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabel.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabel.java
@@ -92,7 +92,7 @@ public class SomeTypeLabel
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyFieldWithKeyLabel", getKey_2());
         return result;
     }
@@ -107,7 +107,7 @@ public class SomeTypeLabel
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyFieldWithKeyLabel")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabelByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/keyNamedField/output/testcomparison/namespaces/entitywithkeynamedfield/SomeTypeLabelByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class SomeTypeLabelByKeyFluentHelper
     extends FluentHelperByKey<SomeTypeLabelByKeyFluentHelper, SomeTypeLabel, SomeTypeLabelSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.entitywithkeynamedfield.SomeTypeLabel SomeTypeLabel} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -120,7 +120,7 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Person", getPerson());
         return result;
     }
@@ -136,7 +136,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePersonByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTestWithExplicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePersonByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class SimplePersonByKeyFluentHelper
     extends FluentHelperByKey<SimplePersonByKeyFluentHelper, SimplePerson, SimplePersonSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.minimalmetadata.SimplePerson SimplePerson} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
@@ -120,7 +120,7 @@ public class FooType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Foo", getFoo());
         return result;
     }
@@ -136,7 +136,7 @@ public class FooType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Foo")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooTypeByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooTypeByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class FooTypeByKeyFluentHelper
     extends FluentHelperByKey<FooTypeByKeyFluentHelper, FooType, FooTypeSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.multipleentitysets.FooType FooType} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
@@ -120,7 +120,7 @@ public class SimplePerson
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("Person", getPerson());
         return result;
     }
@@ -136,7 +136,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePersonByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePersonByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class SimplePersonByKeyFluentHelper
     extends FluentHelperByKey<SimplePersonByKeyFluentHelper, SimplePerson, SimplePersonSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.multipleentitysets.SimplePerson SimplePerson} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLink.java
@@ -91,7 +91,7 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityMultiLinkByKeyFluentHelper, TestEntityMultiLink, TestEntityMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.nameclash.TestEntityMultiLink TestEntityMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2.java
@@ -173,7 +173,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         return result;
     }
@@ -190,7 +190,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2ByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/nameclash/TestEntityV2ByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class TestEntityV2ByKeyFluentHelper
     extends FluentHelperByKey<TestEntityV2ByKeyFluentHelper, TestEntityV2, TestEntityV2Selectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.nameclash.TestEntityV2 TestEntityV2} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_OtherTestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_OtherTestComplexType.java
@@ -64,7 +64,7 @@ public class A_OtherTestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_OtherTestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/ContinueFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/ContinueFluentHelper.java
@@ -25,7 +25,7 @@ public class ContinueFluentHelper
     extends SingleValuedFluentHelperFunction<ContinueFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>Continue</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
@@ -25,7 +25,7 @@ public class CreateTestComplexFluentHelper
     extends SingleValuedFluentHelperFunction<CreateTestComplexFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>CreateTestComplexType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntity.java
@@ -91,7 +91,7 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class MediaEntity
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class MediaEntityByKeyFluentHelper
     extends FluentHelperByKey<MediaEntityByKeyFluentHelper, MediaEntity, MediaEntitySelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.MediaEntity MediaEntity} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2MultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2MultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2MultiLinkByKeyFluentHelper, TestEntityLvl2MultiLink, TestEntityLvl2MultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2MultiLink TestEntityLvl2MultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2SingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2SingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2SingleLinkByKeyFluentHelper, TestEntityLvl2SingleLink, TestEntityLvl2SingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2SingleLink TestEntityLvl2SingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -249,7 +249,7 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityMultiLinkByKeyFluentHelper, TestEntityMultiLink, TestEntityMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityMultiLink TestEntityMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -91,7 +91,7 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class TestEntityOtherMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityOtherMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityOtherMultiLinkByKeyFluentHelper, TestEntityOtherMultiLink, TestEntityOtherMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityOtherMultiLink TestEntityOtherMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -249,7 +249,7 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntitySingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntitySingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntitySingleLinkByKeyFluentHelper, TestEntitySingleLink, TestEntitySingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntitySingleLink TestEntitySingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -653,7 +653,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         result.put("KeyPropertyString", getKeyPropertyString());
         return result;
@@ -686,7 +686,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class TestEntityV2ByKeyFluentHelper
     extends FluentHelperByKey<TestEntityV2ByKeyFluentHelper, TestEntityV2, TestEntityV2Selectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityV2 TestEntityV2} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportComplexReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportComplexReturnFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportComplexReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportComplexReturnTypeCollectionFluentHelper, A_TestComplexType, List<A_TestComplexType>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEdmReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEdmReturnFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEdmReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEdmReturnTypeCollectionFluentHelper, String, List<String>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEntityReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEntityReturnFluentHelper, TestEntityV2, TestEntityV2>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEntityReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEntityReturnTypeCollectionFluentHelper, TestEntityV2, List<TestEntityV2>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportGETFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportGETFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportGET</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportMultipleParamsFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportMultipleParamsFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportMultipleParams</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportNoReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportNoReturnFluentHelper, Void, Void>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportNoReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportPOSTFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportPOSTFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportPOST</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportUnprecedentedComplexReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestFunctionImportUnprecedentedComplexReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportUnprecedentedComplexReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportUnprecedentedComplexReturnFluentHelper, A_OtherTestComplexType, A_OtherTestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportUnprecedentedComplexReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/Unrelated.java
@@ -91,7 +91,7 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class Unrelated
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class UnrelatedByKeyFluentHelper
     extends FluentHelperByKey<UnrelatedByKeyFluentHelper, Unrelated, UnrelatedSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.Unrelated Unrelated} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/ContinueFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/ContinueFluentHelper.java
@@ -25,7 +25,7 @@ public class ContinueFluentHelper
     extends SingleValuedFluentHelperFunction<ContinueFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>Continue</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
@@ -25,7 +25,7 @@ public class CreateTestComplexFluentHelper
     extends SingleValuedFluentHelperFunction<CreateTestComplexFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>CreateTestComplexType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/MediaEntity.java
@@ -91,7 +91,7 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class MediaEntity
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2MultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2SingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -249,7 +249,7 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -91,7 +91,7 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class TestEntityOtherMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -249,7 +249,7 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntitySingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -653,7 +653,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         result.put("KeyPropertyString", getKeyPropertyString());
         return result;
@@ -686,7 +686,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportComplexReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportComplexReturnFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportComplexReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportComplexReturnTypeCollectionFluentHelper, A_TestComplexType, List<A_TestComplexType>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEdmReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEdmReturnFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEdmReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEdmReturnTypeCollectionFluentHelper, String, List<String>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEntityReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEntityReturnFluentHelper, TestEntityV2, TestEntityV2>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEntityReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEntityReturnTypeCollectionFluentHelper, TestEntityV2, List<TestEntityV2>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportGETFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportGETFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportGET</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportMultipleParamsFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportMultipleParamsFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportMultipleParams</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportNoReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportNoReturnFluentHelper, Void, Void>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportNoReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportPOSTFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportPOSTFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportPOST</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceDeprecation/output/testcomparison/namespaces/test/Unrelated.java
@@ -91,7 +91,7 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class Unrelated
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/ContinueFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/ContinueFluentHelper.java
@@ -25,7 +25,7 @@ public class ContinueFluentHelper
     extends SingleValuedFluentHelperFunction<ContinueFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>Continue</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
@@ -25,7 +25,7 @@ public class CreateTestComplexFluentHelper
     extends SingleValuedFluentHelperFunction<CreateTestComplexFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>CreateTestComplexType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -598,7 +598,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         result.put("KeyPropertyString", getKeyPropertyString());
         return result;
@@ -631,7 +631,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class TestEntityV2ByKeyFluentHelper
     extends FluentHelperByKey<TestEntityV2ByKeyFluentHelper, TestEntityV2, TestEntityV2Selectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityV2 TestEntityV2} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportComplexReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportComplexReturnFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportComplexReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportComplexReturnTypeCollectionFluentHelper, A_TestComplexType, List<A_TestComplexType>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEdmReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEdmReturnFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEdmReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEdmReturnTypeCollectionFluentHelper, String, List<String>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEntityReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEntityReturnFluentHelper, TestEntityV2, TestEntityV2>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEntityReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEntityReturnTypeCollectionFluentHelper, TestEntityV2, List<TestEntityV2>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportGETFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportGETFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportGET</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportMultipleParamsFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportMultipleParamsFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportMultipleParams</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportNoReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportNoReturnFluentHelper, Void, Void>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportNoReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceEntitySets/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportPOSTFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportPOSTFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportPOST</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntity.java
@@ -91,7 +91,7 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class MediaEntity
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class MediaEntityByKeyFluentHelper
     extends FluentHelperByKey<MediaEntityByKeyFluentHelper, MediaEntity, MediaEntitySelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.MediaEntity MediaEntity} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2MultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2MultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2MultiLinkByKeyFluentHelper, TestEntityLvl2MultiLink, TestEntityLvl2MultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2MultiLink TestEntityLvl2MultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2SingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2SingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2SingleLinkByKeyFluentHelper, TestEntityLvl2SingleLink, TestEntityLvl2SingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2SingleLink TestEntityLvl2SingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -249,7 +249,7 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityMultiLinkByKeyFluentHelper, TestEntityMultiLink, TestEntityMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityMultiLink TestEntityMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -91,7 +91,7 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class TestEntityOtherMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityOtherMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityOtherMultiLinkByKeyFluentHelper, TestEntityOtherMultiLink, TestEntityOtherMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityOtherMultiLink TestEntityOtherMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -249,7 +249,7 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntitySingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntitySingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntitySingleLinkByKeyFluentHelper, TestEntitySingleLink, TestEntitySingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntitySingleLink TestEntitySingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -653,7 +653,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         result.put("KeyPropertyString", getKeyPropertyString());
         return result;
@@ -686,7 +686,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class TestEntityV2ByKeyFluentHelper
     extends FluentHelperByKey<TestEntityV2ByKeyFluentHelper, TestEntityV2, TestEntityV2Selectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityV2 TestEntityV2} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportNoReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportNoReturnFluentHelper, Void, Void>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportNoReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/Unrelated.java
@@ -91,7 +91,7 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class Unrelated
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceFunctionImports/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class UnrelatedByKeyFluentHelper
     extends FluentHelperByKey<UnrelatedByKeyFluentHelper, Unrelated, UnrelatedSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.Unrelated Unrelated} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/ContinueFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/ContinueFluentHelper.java
@@ -25,7 +25,7 @@ public class ContinueFluentHelper
     extends SingleValuedFluentHelperFunction<ContinueFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>Continue</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/CreateTestComplexFluentHelper.java
@@ -25,7 +25,7 @@ public class CreateTestComplexFluentHelper
     extends SingleValuedFluentHelperFunction<CreateTestComplexFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>CreateTestComplexType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntity.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntity.java
@@ -91,7 +91,7 @@ public class MediaEntity
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class MediaEntity
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/MediaEntityByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class MediaEntityByKeyFluentHelper
     extends FluentHelperByKey<MediaEntityByKeyFluentHelper, MediaEntity, MediaEntitySelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.MediaEntity MediaEntity} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2MultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2MultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2MultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2MultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2MultiLinkByKeyFluentHelper, TestEntityLvl2MultiLink, TestEntityLvl2MultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2MultiLink TestEntityLvl2MultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -209,7 +209,7 @@ public class TestEntityLvl2SingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -228,7 +228,7 @@ public class TestEntityLvl2SingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityLvl2SingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityLvl2SingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityLvl2SingleLinkByKeyFluentHelper, TestEntityLvl2SingleLink, TestEntityLvl2SingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityLvl2SingleLink TestEntityLvl2SingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -249,7 +249,7 @@ public class TestEntityMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityMultiLinkByKeyFluentHelper, TestEntityMultiLink, TestEntityMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityMultiLink TestEntityMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -91,7 +91,7 @@ public class TestEntityOtherMultiLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class TestEntityOtherMultiLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityOtherMultiLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntityOtherMultiLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntityOtherMultiLinkByKeyFluentHelper, TestEntityOtherMultiLink, TestEntityOtherMultiLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityOtherMultiLink TestEntityOtherMultiLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -249,7 +249,7 @@ public class TestEntitySingleLink
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -268,7 +268,7 @@ public class TestEntitySingleLink
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntitySingleLinkByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class TestEntitySingleLinkByKeyFluentHelper
     extends FluentHelperByKey<TestEntitySingleLinkByKeyFluentHelper, TestEntitySingleLink, TestEntitySingleLinkSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntitySingleLink TestEntitySingleLink} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2.java
@@ -653,7 +653,7 @@ public class TestEntityV2
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyPropertyGuid", getKeyPropertyGuid());
         result.put("KeyPropertyString", getKeyPropertyString());
         return result;
@@ -686,7 +686,7 @@ public class TestEntityV2
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestEntityV2ByKeyFluentHelper.java
@@ -20,7 +20,7 @@ public class TestEntityV2ByKeyFluentHelper
     extends FluentHelperByKey<TestEntityV2ByKeyFluentHelper, TestEntityV2, TestEntityV2Selectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.TestEntityV2 TestEntityV2} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportComplexReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportComplexReturnFluentHelper, A_TestComplexType, A_TestComplexType>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportComplexReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportComplexReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportComplexReturnTypeCollectionFluentHelper, A_TestComplexType, List<A_TestComplexType>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportComplexReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEdmReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEdmReturnFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEdmReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEdmReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEdmReturnTypeCollectionFluentHelper, String, List<String>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEdmReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportEntityReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportEntityReturnFluentHelper, TestEntityV2, TestEntityV2>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportEntityReturnTypeCollectionFluentHelper.java
@@ -26,7 +26,7 @@ public class TestFunctionImportEntityReturnTypeCollectionFluentHelper
     extends CollectionValuedFluentHelperFunction<TestFunctionImportEntityReturnTypeCollectionFluentHelper, TestEntityV2, List<TestEntityV2>>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportEntityReturnTypeCollection</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportGETFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportGETFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportGETFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportGET</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportMultipleParamsFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportMultipleParamsFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportMultipleParamsFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportMultipleParams</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportNoReturnFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportNoReturnFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportNoReturnFluentHelper, Void, Void>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportNoReturnType</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/TestFunctionImportPOSTFluentHelper.java
@@ -25,7 +25,7 @@ public class TestFunctionImportPOSTFluentHelper
     extends SingleValuedFluentHelperFunction<TestFunctionImportPOSTFluentHelper, Boolean, Boolean>
 {
 
-    private final Map<String, Object> values = Maps.newHashMap();
+    private final Map<String, Object> values = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will execute the <b>TestFunctionImportPOST</b> OData function import with the provided parameters. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/Unrelated.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/Unrelated.java
@@ -91,7 +91,7 @@ public class Unrelated
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         result.put("KeyProperty", getKeyProperty());
         return result;
     }
@@ -106,7 +106,7 @@ public class Unrelated
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServiceNoApiLinks/output/testcomparison/namespaces/test/UnrelatedByKeyFluentHelper.java
@@ -19,7 +19,7 @@ public class UnrelatedByKeyFluentHelper
     extends FluentHelperByKey<UnrelatedByKeyFluentHelper, Unrelated, UnrelatedSelectable>
 {
 
-    private final Map<String, Object> key = Maps.newHashMap();
+    private final Map<String, Object> key = Maps.newLinkedHashMap();
 
     /**
      * Creates a fluent helper object that will fetch a single {@link testcomparison.namespaces.test.Unrelated Unrelated} entity with the provided key field values. To perform execution, call the {@link #executeRequest executeRequest} method on the fluent helper object.

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -249,7 +249,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -363,7 +363,7 @@ public class A_TestComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -64,7 +64,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -86,7 +86,7 @@ public class A_TestLvl2NestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 

--- a/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata/odata-generator/src/test/resources/oDataGeneratorIntegrationTest/testServicePojos/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -76,7 +76,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {
@@ -112,7 +112,7 @@ public class A_TestNestedComplexType
     @Nonnull
     @Override
     protected Map<String, Object> getKey() {
-        final Map<String, Object> result = Maps.newHashMap();
+        final Map<String, Object> result = Maps.newLinkedHashMap();
         return result;
     }
 


### PR DESCRIPTION
## Context

[SAP/cloud-sdk-java-backlog#DRAFT.](https://github.com/orgs/sap/projects/62/views/5?pane=issue&itemId=91185764)

A user reported that there can be instances where a change in the order of complex keys causes issues (see [GH issue](https://github.com/SAP/cloud-sdk-java/issues/669)). To circumvent that, this PR changes the use of `HashMap` into `LinkedHashMap` in the code generator for odata v2.

### Feature scope:
 
- [x] generator for odata v2 uses `LinkedHashMap` instead of `HashMap`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
