### PR TITLE
Exchange HashMap with LinkedHashMap (OData v4)

### DIFF
--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Address.java
@@ -318,7 +318,7 @@ public class Address extends VdmEntity<Address> implements VdmEntitySet
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Customer.java
@@ -226,7 +226,7 @@ public class Customer extends VdmEntity<Customer> implements VdmEntitySet
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/DateRange.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/DateRange.java
@@ -93,7 +93,7 @@ public class DateRange extends VdmComplex<DateRange>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Start") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/FloorPlan.java
@@ -143,7 +143,7 @@ public class FloorPlan extends VdmEntity<FloorPlan>
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/OpeningHours.java
@@ -206,7 +206,7 @@ public class OpeningHours extends VdmEntity<OpeningHours> implements VdmEntitySe
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Product.java
@@ -303,7 +303,7 @@ public class Product extends VdmEntity<Product> implements VdmEntitySet
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/ProductCount.java
@@ -96,7 +96,7 @@ public class ProductCount extends VdmComplex<ProductCount>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("ProductId") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
@@ -101,7 +101,7 @@ public class PurchaseHistoryItem extends VdmComplex<PurchaseHistoryItem>
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("ReceiptId") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Receipt.java
@@ -233,7 +233,7 @@ public class Receipt extends VdmEntity<Receipt> implements VdmEntitySet
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Shelf.java
@@ -186,7 +186,7 @@ public class Shelf extends VdmEntity<Shelf> implements VdmEntitySet
     @Override
     protected void fromMap( final Map<String, Object> inputValues )
     {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/sample/namespaces/sdkgrocerystore/Vendor.java
@@ -192,7 +192,7 @@ public class Vendor extends VdmEntity<Vendor>
     @Override
     protected void fromMap( final Map<java.lang.String, Object> inputValues )
     {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if( cloudSdkValues.containsKey("Id") ) {

--- a/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/NamespaceClassGenerator.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/NamespaceClassGenerator.java
@@ -625,7 +625,7 @@ class NamespaceClassGenerator
                     JMod.FINAL,
                     fieldMapClass,
                     CommonConstants.INLINE_MAP_NAME,
-                    codeModel.ref(Maps.class).staticInvoke("newHashMap").arg(inputValues));
+                    codeModel.ref(Maps.class).staticInvoke("newLinkedHashMap").arg(inputValues));
 
         body.block().directStatement("// simple properties");
         final JBlock simplePropertiesBlock = new JBlock(true, true);

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/Address.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/Address.java
@@ -80,7 +80,7 @@ public class Address
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Street")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/FunctionResult.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/FunctionResult.java
@@ -126,7 +126,7 @@ public class FunctionResult
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("RequestId")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/NewComplexResult.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/NewComplexResult.java
@@ -80,7 +80,7 @@ public class NewComplexResult
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Foo")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/actionsAndFunctionsTest/output/testcomparison/namespaces/actionsandfunctions/SimplePerson.java
@@ -130,7 +130,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/Relationship.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/Relationship.java
@@ -91,7 +91,7 @@ public class Relationship
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Description")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/complexProperties/output/testcomparison/namespaces/metadata/SimplePerson.java
@@ -186,7 +186,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("FirstName")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/explicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/explicitDeprecation/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -204,7 +204,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Address.java
@@ -272,7 +272,7 @@ public class Address
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Customer.java
@@ -195,7 +195,7 @@ public class Customer
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/DateRange.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/DateRange.java
@@ -81,7 +81,7 @@ public class DateRange
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Start")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/FloorPlan.java
@@ -125,7 +125,7 @@ public class FloorPlan
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/OpeningHours.java
@@ -179,7 +179,7 @@ public class OpeningHours
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Product.java
@@ -259,7 +259,7 @@ public class Product
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/ProductCount.java
@@ -80,7 +80,7 @@ public class ProductCount
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("ProductId")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/PurchaseHistoryItem.java
@@ -84,7 +84,7 @@ public class PurchaseHistoryItem
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("ReceiptId")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Receipt.java
@@ -199,7 +199,7 @@ public class Receipt
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Shelf.java
@@ -161,7 +161,7 @@ public class Shelf
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/groceryStore/output/testcomparison/namespaces/sdkgrocerystore/Vendor.java
@@ -166,7 +166,7 @@ public class Vendor
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Id")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTest/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/minimalTest/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -205,7 +205,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/FooType.java
@@ -128,7 +128,7 @@ public class FooType
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Foo")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/multipleEntitySets/output/testcomparison/namespaces/multipleentitysets/SimplePerson.java
@@ -128,7 +128,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/Friend.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/Friend.java
@@ -100,7 +100,7 @@ public class Friend
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Name")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/propertyNameClash/output/testcomparison/namespaces/minimalmetadata/SimplePerson.java
@@ -145,7 +145,7 @@ public class SimplePerson
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("Person")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestComplexType.java
@@ -283,7 +283,7 @@ public class A_TestComplexType
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("BaseStringProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestLvl2NestedComplexType.java
@@ -69,7 +69,7 @@ public class A_TestLvl2NestedComplexType
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/A_TestNestedComplexType.java
@@ -84,7 +84,7 @@ public class A_TestNestedComplexType
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StringProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkChild.java
@@ -121,7 +121,7 @@ public class TestEntityCircularLinkChild
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityCircularLinkParent.java
@@ -121,7 +121,7 @@ public class TestEntityCircularLinkParent
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2MultiLink.java
@@ -201,7 +201,7 @@ public class TestEntityLvl2MultiLink
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityLvl2SingleLink.java
@@ -201,7 +201,7 @@ public class TestEntityLvl2SingleLink
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityMultiLink.java
@@ -233,7 +233,7 @@ public class TestEntityMultiLink
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityOtherMultiLink.java
@@ -104,7 +104,7 @@ public class TestEntityOtherMultiLink
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntitySingleLink.java
@@ -233,7 +233,7 @@ public class TestEntitySingleLink
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityStream.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityStream.java
@@ -100,7 +100,7 @@ public class TestEntityStream
 
     @Override
     protected void fromMap(final Map<String, Object> inputValues) {
-        final Map<String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("StreamProperty")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4.java
@@ -711,7 +711,7 @@ public class TestEntityV4
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyPropertyGuid")) {

--- a/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4_Only_Function.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/test/resources/oDataGeneratorIntegrationTest/testService/output/testcomparison/namespaces/test/TestEntityV4_Only_Function.java
@@ -101,7 +101,7 @@ public class TestEntityV4_Only_Function
 
     @Override
     protected void fromMap(final Map<java.lang.String, Object> inputValues) {
-        final Map<java.lang.String, Object> cloudSdkValues = Maps.newHashMap(inputValues);
+        final Map<java.lang.String, Object> cloudSdkValues = Maps.newLinkedHashMap(inputValues);
         // simple properties
         {
             if (cloudSdkValues.containsKey("KeyProperty")) {

--- a/release_notes.md
+++ b/release_notes.md
@@ -21,6 +21,7 @@
 - Stabilize most of the remaining experimental APIs without changes, e.g.
   - RequestHeaderAccessor
   - ServiceBindingDestinationLoader
+- OData v2 and v4 generators now use `LinkedHashMap` for the properties of the generated classes to maintain the order of the properties.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
## Context

[SAP/cloud-sdk-java-backlog#DRAFT.](https://github.com/orgs/sap/projects/62/views/5?pane=issue&itemId=91185764)


A user reported that there can be instances where a change in the order of complex keys causes issues (see [GH issue](https://github.com/SAP/cloud-sdk-java/issues/669)). To circumvent that, this PR changes the use of `HashMap` into `LinkedHashMap` in the code generator for OData v4.

[This PR](https://github.com/SAP/cloud-sdk-java/pull/672) did the same for OData v2.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] generator for OData v4 uses `LinkedHashMap` instead of `HashMap`

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [x] Release notes updated
