### PR TITLE
Fix perform release

### DIFF
--- a/.github/workflows/perform-release.yml
+++ b/.github/workflows/perform-release.yml
@@ -21,11 +21,10 @@ jobs:
   prerequisites:
     name: "Prerequisites"
     outputs:
-      release-version: ${{ steps.determine-branch-names.outputs.RELEASE_VERSION }}
-      release-tag: ${{ steps.determine-branch-names.outputs.RELEASE_TAG }}
       code-branch: ${{ steps.determine-branch-names.outputs.CODE_BRANCH_NAME }}
       docs-branch: ${{ steps.determine-branch-names.outputs.DOCS_BRANCH_NAME }}
       release-notes-branch: ${{ steps.determine-branch-names.outputs.RELEASE_NOTES_BRANCH_NAME }}
+      release-tag: ${{ steps.determine-branch-names.outputs.RELEASE_TAG }}
       release-commit: ${{ steps.determine-branch-names.outputs.RELEASE_COMMIT }}
     permissions:
       pull-requests: read
@@ -35,29 +34,17 @@ jobs:
       - name: "Determine Branch Names"
         id: determine-branch-names
         run: |
-          if [[ "${{ github.event_name }}" == "pull_request_review" ]]; then
-            echo "[DEBUG] Taking branch name from pull request event"
-            BRANCH_NAME=${{ github.event.pull_request.head.ref }}
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            echo "[DEBUG] Taking branch name from workflow dispatch event"
-            BRANCH_NAME=$(gh pr view ${{ github.event.inputs.release_pr_number }} --repo "${{ github.repository }}" --json headRefName | jq -r '.headRefName')
-          else
-            echo "Cannot determine branch name from event '${{ github.event_name }}'"
-            exit 1
-          fi
+          CODE_BRANCH_NAME=$(gh pr view ${{github.event.inputs.release_pr_number}} --repo ${{github.repository}} --json headRefName --jq '.headRefName')
+          RELEASE_VERSION=$(echo $CODE_BRANCH_NAME | cut -d '-' -f2)
+          RELEASE_TAG=rel/$RELEASE_VERSION
+          RELEASE_COMMIT=$(gh release view $RELEASE_TAG --repo ${{github.repository}} --json targetCommitish --jq '.targetCommitish')
           
-          RELEASE_VERSION=$(echo "$BRANCH_NAME" | cut -d '-' -f2) 
-          DOCS_BRANCH=java/release-docs-$RELEASE_VERSION
-          RELEASE_NOTES_BRANCH=java/release-notes-$RELEASE_VERSION
-          
+          echo "CODE_BRANCH_NAME=$CODE_BRANCH_NAME" >> $GITHUB_OUTPUT
           echo "RELEASE_VERSION=$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          echo "RELEASE_TAG=rel/$RELEASE_VERSION" >> $GITHUB_OUTPUT
-          echo "CODE_BRANCH_NAME=$BRANCH_NAME" >> $GITHUB_OUTPUT
-          echo "DOCS_BRANCH_NAME=$DOCS_BRANCH" >> $GITHUB_OUTPUT
-          echo "RELEASE_NOTES_BRANCH_NAME=$RELEASE_NOTES_BRANCH" >> $GITHUB_OUTPUT
-          echo "RELEASE_COMMIT=$(gh release view "$RELEASE_TAG" --repo "${{ github.repository }}" --json targetCommitish | jq -r '.targetCommitish')" >> $GITHUB_OUTPUT
+          echo "RELEASE_TAG=$RELEASE_TAG" >> $GITHUB_OUTPUT
+          echo "RELEASE_COMMIT=$RELEASE_COMMIT" >> $GITHUB_OUTPUT
           
-          echo "[DEBUG] Current GITHUB_OUTPUT: '$(cat $GITHUB_OUTPUT)'"
+          echo -e "[DEBUG] Current GITHUB_OUTPUT:\n$(cat $GITHUB_OUTPUT)"
         env:
           GH_TOKEN: ${{ github.token }}
 


### PR DESCRIPTION
## Context

The release script was pointing to the last release when making checks in the perform release. If it did not exist, it still succeeded.

### Feature scope:
 
- [x] [The Perform Release](https://github.com/CharlesDuboisSAP/ai-sdk-java/actions/runs/12648585044) now assigns the commit to a variable correctly

## Definition of Done

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Aligned changes with the JavaScript SDK~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~
