### PR TITLE
Dependabot PRs open earlier

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -5,8 +5,8 @@ updates:
     target-branch: main
     directory: '/'
     schedule:
-      interval: weekly
-      time: '08:00'
+      day: tuseday
+      time: '00:00'
       timezone: 'Europe/Berlin'
     open-pull-requests-limit: 5
     commit-message:


### PR DESCRIPTION
## Context

- Dependabot PRs are not being merged after their creation, they need to be created earlier [in the night like in the AI SDK](https://github.com/SAP/ai-sdk-java/blob/main/.github/dependabot.yaml#L9) to be merged on the same day.
- If PRs fail to merge, they will automatically close and re-open. They now do so on Tuesdays after the support handover.
