### PR TITLE
Fix OData `VDMObject.getChangedFields()` for `BigDecimal`

### DIFF
--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/VdmObject.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/VdmObject.java
@@ -1,5 +1,6 @@
 package com.sap.cloud.sdk.datamodel.odatav4.core;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -356,8 +357,14 @@ public abstract class VdmObject<ObjectT>
             return false;
         }
 
-        if( changedOriginalFields.containsKey(fieldName) && !Objects.equals(currentValue, overriddenValue) ) {
-            return true;
+        if( changedOriginalFields.containsKey(fieldName) ) {
+            if( currentValue instanceof BigDecimal currentDecimal
+                && overriddenValue instanceof BigDecimal overridenDecimal ) {
+                return currentDecimal.compareTo(overridenDecimal) != 0;
+            }
+            if( !Objects.equals(currentValue, overriddenValue) ) {
+                return true;
+            }
         }
 
         // property was either not updated directly, or the values are still "equal" (according to Objects.equals)

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/adapter/BigDecimalSerialisationTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/adapter/BigDecimalSerialisationTest.java
@@ -3,6 +3,9 @@ package com.sap.cloud.sdk.datamodel.odatav4.adapter;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.math.BigDecimal;
+import java.util.Map;
+
+import javax.annotation.Nonnull;
 
 import org.junit.jupiter.api.Test;
 
@@ -10,11 +13,14 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.google.common.collect.ImmutableMap;
 import com.google.gson.Gson;
 import com.google.gson.annotations.JsonAdapter;
 import com.sap.cloud.sdk.datamodel.odatav4.core.VdmEntity;
 import com.sap.cloud.sdk.result.ElementName;
 
+import lombok.AllArgsConstructor;
+import lombok.Builder;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -24,13 +30,15 @@ class BigDecimalSerialisationTest
 {
     private static final String TEST_DEFAULT_SERVICE_PATH = "/odata/default";
 
+    @Builder
     @NoArgsConstructor
+    @AllArgsConstructor
     @JsonAdapter( GsonVdmAdapterFactory.class )
     @JsonSerialize( using = JacksonVdmObjectSerializer.class )
     @JsonDeserialize( using = JacksonVdmObjectDeserializer.class )
     @EqualsAndHashCode( doNotUseGetters = true, callSuper = true )
     @Data
-    private class TestEntity extends VdmEntity<TestEntity>
+    private static class TestEntity extends VdmEntity<TestEntity>
     {
         @Getter
         private final String odataType = "TestEntity";
@@ -47,6 +55,22 @@ class BigDecimalSerialisationTest
         @ElementName( "BigDecimalField" )
         BigDecimal bigDecimalField;
 
+        public void setBigDecimalField( BigDecimal bigDecimalField )
+        {
+            rememberChangedField("BigDecimalField", this.bigDecimalField);
+            this.bigDecimalField = bigDecimalField;
+        }
+
+        @Nonnull
+        @Override
+        protected Map<String, Object> toMapOfFields()
+        {
+            return ImmutableMap
+                .<String, Object> builder()
+                .putAll(super.toMapOfFields())
+                .put("BigDecimalField", getBigDecimalField())
+                .build();
+        }
     }
 
     @Test
@@ -61,5 +85,13 @@ class BigDecimalSerialisationTest
         // Jackson
         final String jsonJackson = new ObjectMapper().writeValueAsString(testEntity);
         assertThat(jsonJackson).doesNotContain("3E-9").contains("0.000000003");
+    }
+
+    @Test
+    void testBigDecimalEquals()
+    {
+        final TestEntity testEntity = TestEntity.builder().bigDecimalField(new BigDecimal("1.0")).build();
+        testEntity.setBigDecimalField(new BigDecimal("1"));
+        assertThat(testEntity.getChangedFields()).isEmpty();
     }
 }

--- a/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/PreparedEntityBluePrint.java
+++ b/datamodel/odata-v4/odata-v4-generator/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/generator/PreparedEntityBluePrint.java
@@ -24,27 +24,6 @@ final class PreparedEntityBluePrint
     private final JDefinedClass entityClass;
 
     /**
-     * The more concrete sub-interface of the {@link com.sap.cloud.sdk.datamodel.odata.helper.EntitySelectable
-     * EntitySelectable} interface for this entity.
-     */
-    /*@Nullable // in case of "POJO only"
-    private final JDefinedClass selectableInterface;*/
-
-    /**
-     * The concrete sub-class of the {@link com.sap.cloud.sdk.datamodel.odata.helper.EntityLink EntityLink} class for
-     * this entity used for one-to-many links.
-     */
-    /*@Nullable // in case of "POJO only"
-    private final JDefinedClass entityOneToManyLinkClass;
-    */
-    /**
-     * The concrete sub-class of the {@link com.sap.cloud.sdk.datamodel.odata.helper.EntityLink EntityLink} class for
-     * this entity used for one-to–one links.
-     */
-    /*@Nullable // in case of "POJO only"
-    private final JDefinedClass entityOneToOneLinkClass;*/
-
-    /**
      * A list containing all navigation properties that should be added to the entity.
      */
     @Nonnull

--- a/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/VdmObject.java
+++ b/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/VdmObject.java
@@ -1,8 +1,10 @@
 package com.sap.cloud.sdk.datamodel.odata.helper;
 
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 
 import javax.annotation.Nonnull;
@@ -335,9 +337,12 @@ public abstract class VdmObject<ObjectT>
             final Object originalValue = changedOriginalField.getValue();
             final Object currentValue = currentFields.get(changedOriginalField.getKey());
 
-            if( originalValue != null && !originalValue.equals(currentValue)
-                || originalValue == null && currentValue != null ) {
-
+            if( currentValue instanceof BigDecimal currentDecimal
+                && originalValue instanceof BigDecimal originalDecimal ) {
+                if( currentDecimal.compareTo(originalDecimal) != 0 ) {
+                    changedFields.put(changedOriginalField.getKey(), currentDecimal);
+                }
+            } else if( !Objects.equals(currentValue, originalValue) ) {
                 changedFields.put(changedOriginalField.getKey(), currentValue);
             }
         }

--- a/datamodel/odata/odata-core/src/test/java/com/sap/cloud/sdk/datamodel/odata/helper/ODataChangedFieldsTest.java
+++ b/datamodel/odata/odata-core/src/test/java/com/sap/cloud/sdk/datamodel/odata/helper/ODataChangedFieldsTest.java
@@ -3,6 +3,8 @@ package com.sap.cloud.sdk.datamodel.odata.helper;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.entry;
 
+import java.math.BigDecimal;
+
 import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
@@ -113,6 +115,14 @@ class ODataChangedFieldsTest
         final TestVdmEntity testEntity = new TestVdmEntity();
         final TestVdmEntity child1 = TestVdmEntity.builder().stringValue("Foo").build();
         testEntity.addToChildren(child1);
+        assertThat(testEntity.getChangedFields()).isEmpty();
+    }
+
+    @Test
+    void testBigDecimalEquals()
+    {
+        final TestVdmEntity testEntity = TestVdmEntity.builder().decimalValue(new BigDecimal("1.0")).build();
+        testEntity.setDecimalValue(new BigDecimal("1"));
         assertThat(testEntity.getChangedFields()).isEmpty();
     }
 }

--- a/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/DeprecationUtils.java
+++ b/datamodel/odata/odata-generator/src/main/java/com/sap/cloud/sdk/datamodel/odata/generator/DeprecationUtils.java
@@ -63,16 +63,6 @@ final class DeprecationUtils
      *            The class to add information to.
      * @param service
      *            The service to take the status information from.
-     *
-     */
-
-    /**
-     * Adds javadoc and annotations regarding states such as deprecation if necessary.
-     *
-     * @param affectedClass
-     *            The class to add information to.
-     * @param service
-     *            The service to take the status information from.
      * @param customDeprecationNotice
      *            The custom deprecation notice that is added as a comment
      */

--- a/pom.xml
+++ b/pom.xml
@@ -759,6 +759,12 @@
 							<arg>-Xlint:all</arg>
 							<arg>-Xlint:-processing</arg>
 						</compilerArgs>
+						<annotationProcessorPaths>
+							<annotationProcessorPath>
+								<groupId>org.projectlombok</groupId>
+								<artifactId>lombok</artifactId>
+							</annotationProcessorPath>
+						</annotationProcessorPaths>
 					</configuration>
 				</plugin>
 				<plugin>

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,5 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fix OData `VDMObject.getChangedFields()` to use `BigDecimal.compareTo()` instead of `BigDecimal.equals()`.
+  - Example: a `BigDecimal` field updated from `1` to `1.0` will not be considered as changed anymore.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

#704.


A `BigDecimal` field which is updated from `1` to `1.0` will not be considered as changed anymore.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] OData v2
- [x] OData v4
- [x] Drive-by Java 23 compilation fixes

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
