### PR TITLE
feat: OpenAPI Generator to drop the redundant `isIsBoolean()` method prefix

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GeneratorCustomProperties.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GeneratorCustomProperties.java
@@ -15,7 +15,12 @@ enum GeneratorCustomProperties
     /**
      * Use JsonCreator instead of sub-type deduction for oneOf and anyOf schemas.
      */
-    USE_ONE_OF_CREATORS("useOneOfCreators", "false");
+    USE_ONE_OF_CREATORS("useOneOfCreators", "false"),
+
+    /**
+     * Fix isIsBoolean() to isBoolean() for fields specified as `"isBoolean":{"type":"boolean"}`.
+     */
+    FIX_REDUNDANT_IS_BOOLEAN_PREFIX("fixRedundantIsBooleanPrefix", "false");
 
     private final String key;
     private final String defaultValue;

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -34,7 +34,7 @@ class DataModelGeneratorIntegrationTest
             true,
             true,
             6,
-            Map.of("aiSdkConstructor", "true")),
+            Map.of("aiSdkConstructor", "true", "fixRedundantIsBooleanPrefix", "true")),
         API_CLASS_VENDOR_EXTENSION_YAML(
             "api-class-vendor-extension-yaml",
             "sodastore.yaml",

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/input/sodastore.json
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/input/sodastore.json
@@ -169,6 +169,9 @@
           "brand": {
             "type": "string"
           },
+          "isAvailable": {
+            "type": "boolean"
+          },
           "flavor": {
             "type": "string"
           },

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -166,7 +166,7 @@ public class Soda
    * @return isAvailable  The isAvailable of this {@link Soda} instance.
    */
   @Nonnull
-  public Boolean isIsAvailable() {
+  public Boolean isAvailable() {
     return isAvailable;
   }
 

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -50,6 +50,9 @@ public class Soda
   @JsonProperty("brand")
   private String brand;
 
+  @JsonProperty("isAvailable")
+  private Boolean isAvailable;
+
   @JsonProperty("flavor")
   private String flavor;
 
@@ -145,6 +148,35 @@ public class Soda
    */
   public void setBrand( @Nonnull final String brand) {
     this.brand = brand;
+  }
+
+  /**
+   * Set the isAvailable of this {@link Soda} instance and return the same instance.
+   *
+   * @param isAvailable  The isAvailable of this {@link Soda}
+   * @return The same instance of this {@link Soda} class
+   */
+  @Nonnull public Soda isAvailable( @Nullable final Boolean isAvailable) {
+    this.isAvailable = isAvailable;
+    return this;
+  }
+
+  /**
+   * Get isAvailable
+   * @return isAvailable  The isAvailable of this {@link Soda} instance.
+   */
+  @Nonnull
+  public Boolean isIsAvailable() {
+    return isAvailable;
+  }
+
+  /**
+   * Set the isAvailable of this {@link Soda} instance.
+   *
+   * @param isAvailable  The isAvailable of this {@link Soda}
+   */
+  public void setIsAvailable( @Nullable final Boolean isAvailable) {
+    this.isAvailable = isAvailable;
   }
 
   /**
@@ -244,6 +276,7 @@ public class Soda
     if( id != null ) declaredFields.put("id", id);
     if( name != null ) declaredFields.put("name", name);
     if( brand != null ) declaredFields.put("brand", brand);
+    if( isAvailable != null ) declaredFields.put("isAvailable", isAvailable);
     if( flavor != null ) declaredFields.put("flavor", flavor);
     if( price != null ) declaredFields.put("price", price);
     return declaredFields;
@@ -275,13 +308,14 @@ public class Soda
         Objects.equals(this.id, soda.id) &&
         Objects.equals(this.name, soda.name) &&
         Objects.equals(this.brand, soda.brand) &&
+        Objects.equals(this.isAvailable, soda.isAvailable) &&
         Objects.equals(this.flavor, soda.flavor) &&
         Objects.equals(this.price, soda.price);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, brand, flavor, price, cloudSdkCustomFields);
+    return Objects.hash(id, name, brand, isAvailable, flavor, price, cloudSdkCustomFields);
   }
 
   @Override
@@ -291,6 +325,7 @@ public class Soda
     sb.append("    id: ").append(toIndentedString(id)).append("\n");
     sb.append("    name: ").append(toIndentedString(name)).append("\n");
     sb.append("    brand: ").append(toIndentedString(brand)).append("\n");
+    sb.append("    isAvailable: ").append(toIndentedString(isAvailable)).append("\n");
     sb.append("    flavor: ").append(toIndentedString(flavor)).append("\n");
     sb.append("    price: ").append(toIndentedString(price)).append("\n");
     cloudSdkCustomFields.forEach((k,v) -> sb.append("    ").append(k).append(": ").append(toIndentedString(v)).append("\n"));


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

We encountered this in AI SDK, it would be nice to fix. The generated method name is a little embarrassing.

![image](https://github.com/user-attachments/assets/2add27d6-2fc0-489c-8405-a2a5986ec632)


### Feature scope:

* Feature toggle (default: disabled)
* Drop the double "is"-prefix.
  * There may be side effects though.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
