### PR TITLE
Adapting equals and  hashcode generation for float[]

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -40,7 +40,8 @@ import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomPrope
  * expects
  */
 @Slf4j
-class GenerationConfigurationConverter {
+class GenerationConfigurationConverter
+{
     private static final String IS_RELEASED_PROPERTY_KEY = "isReleased";
     private static final String JAVA_8_PROPERTY_KEY = "java8";
     private static final String DATE_LIBRARY_PROPERTY_KEY = "dateLibrary";
@@ -48,19 +49,20 @@ class GenerationConfigurationConverter {
     private static final String SOURCE_FOLDER_PROPERTY_KEY = "sourceFolder";
     private static final String OPEN_API_NULLABLE_PROPERTY_KEY = "openApiNullable";
     static final String COPYRIGHT_PROPERTY_KEY = "copyrightHeader";
-    
+
     static final String SAP_COPYRIGHT_HEADER =
         "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. All rights reserved.";
     static final String TEMPLATE_DIRECTORY = Paths.get("openapi-generator").resolve("mustache-templates").toString();
     static final String LIBRARY_NAME = JavaClientCodegen.RESTTEMPLATE;
-    
+
     @Nonnull
     static ClientOptInput convertGenerationConfiguration(
         @Nonnull final GenerationConfiguration generationConfiguration,
-        @Nonnull final Path inputSpec) {
+        @Nonnull final Path inputSpec )
+    {
         setGlobalSettings(generationConfiguration);
         final var inputSpecFile = inputSpec.toString();
-        
+
         final var config = createCodegenConfig(generationConfiguration);
         config.setOutputDir(generationConfiguration.getOutputDirectory());
         config.setLibrary(LIBRARY_NAME);
@@ -68,59 +70,65 @@ class GenerationConfigurationConverter {
         config.setModelPackage(generationConfiguration.getModelPackage());
         config.setTemplateDir(TEMPLATE_DIRECTORY);
         config.additionalProperties().putAll(getAdditionalProperties(generationConfiguration));
-        
+
         final var clientOptInput = new ClientOptInput();
         clientOptInput.config(config);
         clientOptInput.openAPI(parseOpenApiSpec(inputSpecFile));
         return clientOptInput;
     }
-    
-    private static JavaClientCodegen createCodegenConfig(@Nonnull final GenerationConfiguration config) {
+
+    private static JavaClientCodegen createCodegenConfig( @Nonnull final GenerationConfiguration config )
+    {
         final var primitives = Set.of("String", "Integer", "Long", "Double", "Float", "Byte");
         final var doubleIs = Pattern.compile("^isIs[A-Z]").asPredicate();
-        return new JavaClientCodegen() {
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+        return new JavaClientCodegen()
+        {
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             protected void updatePropertyForArray(
                 @Nonnull final CodegenProperty property,
-                @Nonnull final CodegenProperty innerProperty) {
+                @Nonnull final CodegenProperty innerProperty )
+            {
                 super.updatePropertyForArray(property, innerProperty);
-                
-                if (USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray) {
+
+                if( USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray ) {
                     property.dataType = "float[]";
                     property.datatypeWithEnum = "float[]";
                     property.isArray = false; // set false to omit `add{{nameInPascalCase}}Item(...)` convenience method
                     property.vendorExtensions.put("isPrimitiveArray", true);
                 }
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             @Nullable
-            public String toDefaultValue(@Nonnull final CodegenProperty cp, @Nonnull final Schema schema) {
-                if (USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType)) {
+            public String toDefaultValue( @Nonnull final CodegenProperty cp, @Nonnull final Schema schema )
+            {
+                if( USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType) ) {
                     return null;
                 }
                 return super.toDefaultValue(cp, schema);
             }
-            
+
             @Override
             @Nullable
-            public String toBooleanGetter(@Nullable final String name) {
+            public String toBooleanGetter( @Nullable final String name )
+            {
                 final String result = super.toBooleanGetter(name);
-                if (FIX_REDUNDANT_IS_BOOLEAN_PREFIX.isEnabled(config) && result != null && doubleIs.test(result)) {
+                if( FIX_REDUNDANT_IS_BOOLEAN_PREFIX.isEnabled(config) && result != null && doubleIs.test(result) ) {
                     return "is" + result.substring(4);
                 }
                 return result;
             }
-            
+
             // Custom processor to inject "x-return-nullable" extension
             @Override
             @Nonnull
             public OperationsMap postProcessOperationsWithModels(
                 @Nonnull final OperationsMap ops,
-                @Nonnull final List<ModelMap> allModels) {
-                for (final CodegenOperation op : ops.getOperations().getOperation()) {
+                @Nonnull final List<ModelMap> allModels )
+            {
+                for( final CodegenOperation op : ops.getOperations().getOperation() ) {
                     final var noContent =
                         op.isResponseOptional
                             || op.responses == null
@@ -129,51 +137,53 @@ class GenerationConfigurationConverter {
                 }
                 return super.postProcessOperationsWithModels(ops, allModels);
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             protected void updateModelForComposedSchema(
                 @Nonnull final CodegenModel m,
                 @Nonnull final Schema schema,
-                @Nonnull final Map<String, Schema> allDefinitions) {
+                @Nonnull final Map<String, Schema> allDefinitions )
+            {
                 super.updateModelForComposedSchema(m, schema, allDefinitions);
-                
-                if (USE_ONE_OF_CREATORS.isEnabled(config)) {
+
+                if( USE_ONE_OF_CREATORS.isEnabled(config) ) {
                     useCreatorsForInterfaceSubtypes(m);
                 }
             }
-            
+
             /**
              * Use JsonCreator for interface sub-types in case there are any primitives.
              *
              * @param m
              *            The model to update.
              */
-            private void useCreatorsForInterfaceSubtypes(@Nonnull final CodegenModel m) {
-                if (m.discriminator != null) {
+            private void useCreatorsForInterfaceSubtypes( @Nonnull final CodegenModel m )
+            {
+                if( m.discriminator != null ) {
                     return;
                 }
                 boolean useCreators = false;
-                for (final Set<String> candidates : List.of(m.anyOf, m.oneOf)) {
+                for( final Set<String> candidates : List.of(m.anyOf, m.oneOf) ) {
                     int nonPrimitives = 0;
                     final var candidatesSingle = new HashSet<String>();
                     final var candidatesMultiple = new HashSet<String>();
-                    
-                    for (final String candidate : candidates) {
-                        if (candidate.startsWith("List<")) {
+
+                    for( final String candidate : candidates ) {
+                        if( candidate.startsWith("List<") ) {
                             final var c1 = candidate.substring(5, candidate.length() - 1);
                             candidatesMultiple.add(c1);
                             useCreators = true;
                         } else {
                             candidatesSingle.add(candidate);
                             useCreators |= primitives.contains(candidate);
-                            if (!primitives.contains(candidate)) {
+                            if( !primitives.contains(candidate) ) {
                                 nonPrimitives++;
                             }
                         }
                     }
-                    if (useCreators) {
-                        if (nonPrimitives > 1) {
+                    if( useCreators ) {
+                        if( nonPrimitives > 1 ) {
                             final var msg =
                                 "Generating interface with mixed multiple non-primitive and primitive sub-types: {}. Deserialization may not work.";
                             log.warn(msg, m.name);
@@ -185,10 +195,11 @@ class GenerationConfigurationConverter {
                     }
                 }
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
-            protected void updateModelForObject(@Nonnull final CodegenModel m, @Nonnull final Schema schema) {
+            protected void updateModelForObject( @Nonnull final CodegenModel m, @Nonnull final Schema schema )
+            {
                 // Disable additional attributes to prevent model classes from extending "HashMap"
                 // SAP Cloud SDK offers custom field APIs to handle additional attributes already
                 schema.setAdditionalProperties(Boolean.FALSE);
@@ -196,15 +207,16 @@ class GenerationConfigurationConverter {
             }
         };
     }
-    
-    private static void setGlobalSettings(@Nonnull final GenerationConfiguration configuration) {
-        if (configuration.isGenerateApis()) {
+
+    private static void setGlobalSettings( @Nonnull final GenerationConfiguration configuration )
+    {
+        if( configuration.isGenerateApis() ) {
             GlobalSettings.setProperty(CodegenConstants.APIS, "");
         }
-        if (configuration.isGenerateModels()) {
+        if( configuration.isGenerateModels() ) {
             GlobalSettings.setProperty(CodegenConstants.MODELS, "");
         }
-        if (configuration.isDebugModels()) {
+        if( configuration.isDebugModels() ) {
             GlobalSettings.setProperty("debugModels", "true");
         }
         GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, Boolean.FALSE.toString());
@@ -214,31 +226,33 @@ class GenerationConfigurationConverter {
         GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES);
         GlobalSettings.setProperty(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
     }
-    
-    private static OpenAPI parseOpenApiSpec(@Nonnull final String inputSpecFile) {
+
+    private static OpenAPI parseOpenApiSpec( @Nonnull final String inputSpecFile )
+    {
         final List<AuthorizationValue> authorizationValues = List.of();
         final var options = new ParseOptions();
         options.setResolve(true);
         final var spec = new OpenAPIParser().readLocation(inputSpecFile, authorizationValues, options);
-        if (!spec.getMessages().isEmpty()) {
+        if( !spec.getMessages().isEmpty() ) {
             log.warn("Parsing the specification yielded the following messages: {}", spec.getMessages());
         }
         return spec.getOpenAPI();
     }
-    
-    private static Map<String, Object> getAdditionalProperties(@Nonnull final GenerationConfiguration config) {
+
+    private static Map<String, Object> getAdditionalProperties( @Nonnull final GenerationConfiguration config )
+    {
         log.info("Using {} as {}.", ApiMaturity.class.getSimpleName(), config.getApiMaturity());
-        
+
         final Map<String, Object> result = new HashMap<>();
         result.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
-        
-        switch (config.getApiMaturity()) {
+
+        switch( config.getApiMaturity() ) {
             case RELEASED -> result.put(IS_RELEASED_PROPERTY_KEY, true);
             case BETA -> result.remove(IS_RELEASED_PROPERTY_KEY);
         }
-        
+
         final var copyrightHeader = config.useSapCopyrightHeader() ? SAP_COPYRIGHT_HEADER : config.getCopyrightHeader();
-        if (!Strings.isNullOrEmpty(copyrightHeader)) {
+        if( !Strings.isNullOrEmpty(copyrightHeader) ) {
             result.put(COPYRIGHT_PROPERTY_KEY, copyrightHeader);
         }
         result.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
@@ -249,10 +263,10 @@ class GenerationConfigurationConverter {
         // this is set to false, to prevent issues with the JsonNullable annotation
         // long term fix part of BLI CLOUDECOSYSTEM-9843
         result.put(OPEN_API_NULLABLE_PROPERTY_KEY, "false");
-        
+
         // this allows the customer to override the default Cloud SDK settings above
-        config.getAdditionalProperties().forEach((k, v) -> {
-            if (result.containsKey(k)) {
+        config.getAdditionalProperties().forEach(( k, v ) -> {
+            if( result.containsKey(k) ) {
                 final var msg =
                     "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user provided configuration.";
                 log.info(msg, result.get(k), k, v);

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -1,20 +1,14 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Year;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import com.google.common.base.Strings;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import lombok.extern.slf4j.Slf4j;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
@@ -25,24 +19,26 @@ import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.OperationsMap;
 
-import com.google.common.base.Strings;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Year;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.core.models.AuthorizationValue;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import lombok.extern.slf4j.Slf4j;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
 
 /**
  * Converts a {@link GenerationConfiguration} instance to a {@link ClientOptInput} instance which the OpenAPI Generator
  * expects
  */
 @Slf4j
-class GenerationConfigurationConverter
-{
+class GenerationConfigurationConverter {
     private static final String IS_RELEASED_PROPERTY_KEY = "isReleased";
     private static final String JAVA_8_PROPERTY_KEY = "java8";
     private static final String DATE_LIBRARY_PROPERTY_KEY = "dateLibrary";
@@ -50,20 +46,19 @@ class GenerationConfigurationConverter
     private static final String SOURCE_FOLDER_PROPERTY_KEY = "sourceFolder";
     private static final String OPEN_API_NULLABLE_PROPERTY_KEY = "openApiNullable";
     static final String COPYRIGHT_PROPERTY_KEY = "copyrightHeader";
-
+    
     static final String SAP_COPYRIGHT_HEADER =
         "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. All rights reserved.";
     static final String TEMPLATE_DIRECTORY = Paths.get("openapi-generator").resolve("mustache-templates").toString();
     static final String LIBRARY_NAME = JavaClientCodegen.RESTTEMPLATE;
-
+    
     @Nonnull
     static ClientOptInput convertGenerationConfiguration(
         @Nonnull final GenerationConfiguration generationConfiguration,
-        @Nonnull final Path inputSpec )
-    {
+        @Nonnull final Path inputSpec) {
         setGlobalSettings(generationConfiguration);
         final var inputSpecFile = inputSpec.toString();
-
+        
         final var config = createCodegenConfig(generationConfiguration);
         config.setOutputDir(generationConfiguration.getOutputDirectory());
         config.setLibrary(LIBRARY_NAME);
@@ -71,52 +66,48 @@ class GenerationConfigurationConverter
         config.setModelPackage(generationConfiguration.getModelPackage());
         config.setTemplateDir(TEMPLATE_DIRECTORY);
         config.additionalProperties().putAll(getAdditionalProperties(generationConfiguration));
-
+        
         final var clientOptInput = new ClientOptInput();
         clientOptInput.config(config);
         clientOptInput.openAPI(parseOpenApiSpec(inputSpecFile));
         return clientOptInput;
     }
-
-    private static JavaClientCodegen createCodegenConfig( @Nonnull final GenerationConfiguration config )
-    {
+    
+    private static JavaClientCodegen createCodegenConfig(@Nonnull final GenerationConfiguration config) {
         final var primitives = Set.of("String", "Integer", "Long", "Double", "Float", "Byte");
-        return new JavaClientCodegen()
-        {
-            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
+        return new JavaClientCodegen() {
+            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
             @Override
             protected void updatePropertyForArray(
                 @Nonnull final CodegenProperty property,
-                @Nonnull final CodegenProperty innerProperty )
-            {
+                @Nonnull final CodegenProperty innerProperty) {
                 super.updatePropertyForArray(property, innerProperty);
-
-                if( USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray ) {
+                
+                if (USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray) {
                     property.dataType = "float[]";
                     property.datatypeWithEnum = "float[]";
                     property.isArray = false; // set false to omit `add{{nameInPascalCase}}Item(...)` convenience method
+                    property.isByteArray = true;
                 }
             }
-
-            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
+            
+            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
             @Override
             @Nullable
-            public String toDefaultValue( @Nonnull final CodegenProperty cp, @Nonnull final Schema schema )
-            {
-                if( USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType) ) {
+            public String toDefaultValue(@Nonnull final CodegenProperty cp, @Nonnull final Schema schema) {
+                if (USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType)) {
                     return null;
                 }
                 return super.toDefaultValue(cp, schema);
             }
-
+            
             // Custom processor to inject "x-return-nullable" extension
             @Override
             @Nonnull
             public OperationsMap postProcessOperationsWithModels(
                 @Nonnull final OperationsMap ops,
-                @Nonnull final List<ModelMap> allModels )
-            {
-                for( final CodegenOperation op : ops.getOperations().getOperation() ) {
+                @Nonnull final List<ModelMap> allModels) {
+                for (final CodegenOperation op : ops.getOperations().getOperation()) {
                     final var noContent =
                         op.isResponseOptional
                             || op.responses == null
@@ -125,53 +116,51 @@ class GenerationConfigurationConverter
                 }
                 return super.postProcessOperationsWithModels(ops, allModels);
             }
-
-            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
+            
+            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
             @Override
             protected void updateModelForComposedSchema(
                 @Nonnull final CodegenModel m,
                 @Nonnull final Schema schema,
-                @Nonnull final Map<String, Schema> allDefinitions )
-            {
+                @Nonnull final Map<String, Schema> allDefinitions) {
                 super.updateModelForComposedSchema(m, schema, allDefinitions);
-
-                if( USE_ONE_OF_CREATORS.isEnabled(config) ) {
+                
+                if (USE_ONE_OF_CREATORS.isEnabled(config)) {
                     useCreatorsForInterfaceSubtypes(m);
                 }
             }
-
+            
             /**
              * Use JsonCreator for interface sub-types in case there are any primitives.
              *
              * @param m
              *            The model to update.
              */
-            private void useCreatorsForInterfaceSubtypes( @Nonnull final CodegenModel m )
-            {
-                if( m.discriminator != null ) {
+            private void useCreatorsForInterfaceSubtypes(@Nonnull final CodegenModel m) {
+                if (m.discriminator != null) {
                     return;
                 }
                 boolean useCreators = false;
-                for( final Set<String> candidates : List.of(m.anyOf, m.oneOf) ) {
+                for (final Set<String> candidates : List.of(m.anyOf, m.oneOf)) {
                     int nonPrimitives = 0;
                     final var candidatesSingle = new HashSet<String>();
                     final var candidatesMultiple = new HashSet<String>();
-
-                    for( final String candidate : candidates ) {
-                        if( candidate.startsWith("List<") ) {
+                    
+                    for (final String candidate : candidates) {
+                        if (candidate.startsWith("List<")) {
                             final var c1 = candidate.substring(5, candidate.length() - 1);
                             candidatesMultiple.add(c1);
                             useCreators = true;
                         } else {
                             candidatesSingle.add(candidate);
                             useCreators |= primitives.contains(candidate);
-                            if( !primitives.contains(candidate) ) {
+                            if (!primitives.contains(candidate)) {
                                 nonPrimitives++;
                             }
                         }
                     }
-                    if( useCreators ) {
-                        if( nonPrimitives > 1 ) {
+                    if (useCreators) {
+                        if (nonPrimitives > 1) {
                             final var msg =
                                 "Generating interface with mixed multiple non-primitive and primitive sub-types: {}. Deserialization may not work.";
                             log.warn(msg, m.name);
@@ -183,11 +172,10 @@ class GenerationConfigurationConverter
                     }
                 }
             }
-
-            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
+            
+            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
             @Override
-            protected void updateModelForObject( @Nonnull final CodegenModel m, @Nonnull final Schema schema )
-            {
+            protected void updateModelForObject(@Nonnull final CodegenModel m, @Nonnull final Schema schema) {
                 // Disable additional attributes to prevent model classes from extending "HashMap"
                 // SAP Cloud SDK offers custom field APIs to handle additional attributes already
                 schema.setAdditionalProperties(Boolean.FALSE);
@@ -195,16 +183,15 @@ class GenerationConfigurationConverter
             }
         };
     }
-
-    private static void setGlobalSettings( @Nonnull final GenerationConfiguration configuration )
-    {
-        if( configuration.isGenerateApis() ) {
+    
+    private static void setGlobalSettings(@Nonnull final GenerationConfiguration configuration) {
+        if (configuration.isGenerateApis()) {
             GlobalSettings.setProperty(CodegenConstants.APIS, "");
         }
-        if( configuration.isGenerateModels() ) {
+        if (configuration.isGenerateModels()) {
             GlobalSettings.setProperty(CodegenConstants.MODELS, "");
         }
-        if( configuration.isDebugModels() ) {
+        if (configuration.isDebugModels()) {
             GlobalSettings.setProperty("debugModels", "true");
         }
         GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, Boolean.FALSE.toString());
@@ -214,33 +201,31 @@ class GenerationConfigurationConverter
         GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES);
         GlobalSettings.setProperty(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
     }
-
-    private static OpenAPI parseOpenApiSpec( @Nonnull final String inputSpecFile )
-    {
+    
+    private static OpenAPI parseOpenApiSpec(@Nonnull final String inputSpecFile) {
         final List<AuthorizationValue> authorizationValues = List.of();
         final var options = new ParseOptions();
         options.setResolve(true);
         final var spec = new OpenAPIParser().readLocation(inputSpecFile, authorizationValues, options);
-        if( !spec.getMessages().isEmpty() ) {
+        if (!spec.getMessages().isEmpty()) {
             log.warn("Parsing the specification yielded the following messages: {}", spec.getMessages());
         }
         return spec.getOpenAPI();
     }
-
-    private static Map<String, Object> getAdditionalProperties( @Nonnull final GenerationConfiguration config )
-    {
+    
+    private static Map<String, Object> getAdditionalProperties(@Nonnull final GenerationConfiguration config) {
         log.info("Using {} as {}.", ApiMaturity.class.getSimpleName(), config.getApiMaturity());
-
+        
         final Map<String, Object> result = new HashMap<>();
         result.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
-
-        switch( config.getApiMaturity() ) {
+        
+        switch (config.getApiMaturity()) {
             case RELEASED -> result.put(IS_RELEASED_PROPERTY_KEY, true);
             case BETA -> result.remove(IS_RELEASED_PROPERTY_KEY);
         }
-
+        
         final var copyrightHeader = config.useSapCopyrightHeader() ? SAP_COPYRIGHT_HEADER : config.getCopyrightHeader();
-        if( !Strings.isNullOrEmpty(copyrightHeader) ) {
+        if (!Strings.isNullOrEmpty(copyrightHeader)) {
             result.put(COPYRIGHT_PROPERTY_KEY, copyrightHeader);
         }
         result.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
@@ -251,10 +236,10 @@ class GenerationConfigurationConverter
         // this is set to false, to prevent issues with the JsonNullable annotation
         // long term fix part of BLI CLOUDECOSYSTEM-9843
         result.put(OPEN_API_NULLABLE_PROPERTY_KEY, "false");
-
+        
         // this allows the customer to override the default Cloud SDK settings above
-        config.getAdditionalProperties().forEach(( k, v ) -> {
-            if( result.containsKey(k) ) {
+        config.getAdditionalProperties().forEach((k, v) -> {
+            if (result.containsKey(k)) {
                 final var msg =
                     "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user provided configuration.";
                 log.info(msg, result.get(k), k, v);

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -1,20 +1,14 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
-
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Year;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
-
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-
+import com.google.common.base.Strings;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import lombok.extern.slf4j.Slf4j;
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
@@ -25,16 +19,19 @@ import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.OperationsMap;
 
-import com.google.common.base.Strings;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Year;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.core.models.AuthorizationValue;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import lombok.extern.slf4j.Slf4j;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
 
 /**
  * Converts a {@link GenerationConfiguration} instance to a {@link ClientOptInput} instance which the OpenAPI Generator

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -1,26 +1,9 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import com.google.common.base.Strings;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.core.models.AuthorizationValue;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import lombok.extern.slf4j.Slf4j;
-import org.openapitools.codegen.ClientOptInput;
-import org.openapitools.codegen.CodegenConstants;
-import org.openapitools.codegen.CodegenModel;
-import org.openapitools.codegen.CodegenOperation;
-import org.openapitools.codegen.CodegenProperty;
-import org.openapitools.codegen.config.GlobalSettings;
-import org.openapitools.codegen.languages.JavaClientCodegen;
-import org.openapitools.codegen.model.ModelMap;
-import org.openapitools.codegen.model.OperationsMap;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.FIX_REDUNDANT_IS_BOOLEAN_PREFIX;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Year;
@@ -31,9 +14,29 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Pattern;
 
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.FIX_REDUNDANT_IS_BOOLEAN_PREFIX;
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.openapitools.codegen.ClientOptInput;
+import org.openapitools.codegen.CodegenConstants;
+import org.openapitools.codegen.CodegenModel;
+import org.openapitools.codegen.CodegenOperation;
+import org.openapitools.codegen.CodegenProperty;
+import org.openapitools.codegen.config.GlobalSettings;
+import org.openapitools.codegen.languages.JavaClientCodegen;
+import org.openapitools.codegen.model.ModelMap;
+import org.openapitools.codegen.model.OperationsMap;
+
+import com.google.common.base.Strings;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Converts a {@link GenerationConfiguration} instance to a {@link ClientOptInput} instance which the OpenAPI Generator

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -1,14 +1,20 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import com.google.common.base.Strings;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
-import io.swagger.parser.OpenAPIParser;
-import io.swagger.v3.oas.models.OpenAPI;
-import io.swagger.v3.oas.models.media.Schema;
-import io.swagger.v3.parser.core.models.AuthorizationValue;
-import io.swagger.v3.parser.core.models.ParseOptions;
-import lombok.extern.slf4j.Slf4j;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
+import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.time.Year;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
 import org.openapitools.codegen.CodegenModel;
@@ -19,26 +25,24 @@ import org.openapitools.codegen.languages.JavaClientCodegen;
 import org.openapitools.codegen.model.ModelMap;
 import org.openapitools.codegen.model.OperationsMap;
 
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
-import java.nio.file.Path;
-import java.nio.file.Paths;
-import java.time.Year;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.base.Strings;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
 
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_FLOAT_ARRAYS;
-import static com.sap.cloud.sdk.datamodel.openapi.generator.GeneratorCustomProperties.USE_ONE_OF_CREATORS;
+import io.swagger.parser.OpenAPIParser;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+import io.swagger.v3.parser.core.models.AuthorizationValue;
+import io.swagger.v3.parser.core.models.ParseOptions;
+import lombok.extern.slf4j.Slf4j;
 
 /**
  * Converts a {@link GenerationConfiguration} instance to a {@link ClientOptInput} instance which the OpenAPI Generator
  * expects
  */
 @Slf4j
-class GenerationConfigurationConverter {
+class GenerationConfigurationConverter
+{
     private static final String IS_RELEASED_PROPERTY_KEY = "isReleased";
     private static final String JAVA_8_PROPERTY_KEY = "java8";
     private static final String DATE_LIBRARY_PROPERTY_KEY = "dateLibrary";
@@ -46,19 +50,20 @@ class GenerationConfigurationConverter {
     private static final String SOURCE_FOLDER_PROPERTY_KEY = "sourceFolder";
     private static final String OPEN_API_NULLABLE_PROPERTY_KEY = "openApiNullable";
     static final String COPYRIGHT_PROPERTY_KEY = "copyrightHeader";
-    
+
     static final String SAP_COPYRIGHT_HEADER =
         "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. All rights reserved.";
     static final String TEMPLATE_DIRECTORY = Paths.get("openapi-generator").resolve("mustache-templates").toString();
     static final String LIBRARY_NAME = JavaClientCodegen.RESTTEMPLATE;
-    
+
     @Nonnull
     static ClientOptInput convertGenerationConfiguration(
         @Nonnull final GenerationConfiguration generationConfiguration,
-        @Nonnull final Path inputSpec) {
+        @Nonnull final Path inputSpec )
+    {
         setGlobalSettings(generationConfiguration);
         final var inputSpecFile = inputSpec.toString();
-        
+
         final var config = createCodegenConfig(generationConfiguration);
         config.setOutputDir(generationConfiguration.getOutputDirectory());
         config.setLibrary(LIBRARY_NAME);
@@ -66,48 +71,54 @@ class GenerationConfigurationConverter {
         config.setModelPackage(generationConfiguration.getModelPackage());
         config.setTemplateDir(TEMPLATE_DIRECTORY);
         config.additionalProperties().putAll(getAdditionalProperties(generationConfiguration));
-        
+
         final var clientOptInput = new ClientOptInput();
         clientOptInput.config(config);
         clientOptInput.openAPI(parseOpenApiSpec(inputSpecFile));
         return clientOptInput;
     }
-    
-    private static JavaClientCodegen createCodegenConfig(@Nonnull final GenerationConfiguration config) {
+
+    private static JavaClientCodegen createCodegenConfig( @Nonnull final GenerationConfiguration config )
+    {
         final var primitives = Set.of("String", "Integer", "Long", "Double", "Float", "Byte");
-        return new JavaClientCodegen() {
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+        return new JavaClientCodegen()
+        {
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             protected void updatePropertyForArray(
                 @Nonnull final CodegenProperty property,
-                @Nonnull final CodegenProperty innerProperty) {
+                @Nonnull final CodegenProperty innerProperty )
+            {
                 super.updatePropertyForArray(property, innerProperty);
-                
-                if (USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray) {
+
+                if( USE_FLOAT_ARRAYS.isEnabled(config) && innerProperty.isNumber && property.isArray ) {
                     property.dataType = "float[]";
                     property.datatypeWithEnum = "float[]";
                     property.isArray = false; // set false to omit `add{{nameInPascalCase}}Item(...)` convenience method
-                    property.isByteArray = true;
+                    //property.isByteArray = true;
+                    property.vendorExtensions.put("isPrimitiveArray", true);
                 }
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             @Nullable
-            public String toDefaultValue(@Nonnull final CodegenProperty cp, @Nonnull final Schema schema) {
-                if (USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType)) {
+            public String toDefaultValue( @Nonnull final CodegenProperty cp, @Nonnull final Schema schema )
+            {
+                if( USE_FLOAT_ARRAYS.isEnabled(config) && "float[]".equals(cp.dataType) ) {
                     return null;
                 }
                 return super.toDefaultValue(cp, schema);
             }
-            
+
             // Custom processor to inject "x-return-nullable" extension
             @Override
             @Nonnull
             public OperationsMap postProcessOperationsWithModels(
                 @Nonnull final OperationsMap ops,
-                @Nonnull final List<ModelMap> allModels) {
-                for (final CodegenOperation op : ops.getOperations().getOperation()) {
+                @Nonnull final List<ModelMap> allModels )
+            {
+                for( final CodegenOperation op : ops.getOperations().getOperation() ) {
                     final var noContent =
                         op.isResponseOptional
                             || op.responses == null
@@ -116,51 +127,53 @@ class GenerationConfigurationConverter {
                 }
                 return super.postProcessOperationsWithModels(ops, allModels);
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
             protected void updateModelForComposedSchema(
                 @Nonnull final CodegenModel m,
                 @Nonnull final Schema schema,
-                @Nonnull final Map<String, Schema> allDefinitions) {
+                @Nonnull final Map<String, Schema> allDefinitions )
+            {
                 super.updateModelForComposedSchema(m, schema, allDefinitions);
-                
-                if (USE_ONE_OF_CREATORS.isEnabled(config)) {
+
+                if( USE_ONE_OF_CREATORS.isEnabled(config) ) {
                     useCreatorsForInterfaceSubtypes(m);
                 }
             }
-            
+
             /**
              * Use JsonCreator for interface sub-types in case there are any primitives.
              *
              * @param m
              *            The model to update.
              */
-            private void useCreatorsForInterfaceSubtypes(@Nonnull final CodegenModel m) {
-                if (m.discriminator != null) {
+            private void useCreatorsForInterfaceSubtypes( @Nonnull final CodegenModel m )
+            {
+                if( m.discriminator != null ) {
                     return;
                 }
                 boolean useCreators = false;
-                for (final Set<String> candidates : List.of(m.anyOf, m.oneOf)) {
+                for( final Set<String> candidates : List.of(m.anyOf, m.oneOf) ) {
                     int nonPrimitives = 0;
                     final var candidatesSingle = new HashSet<String>();
                     final var candidatesMultiple = new HashSet<String>();
-                    
-                    for (final String candidate : candidates) {
-                        if (candidate.startsWith("List<")) {
+
+                    for( final String candidate : candidates ) {
+                        if( candidate.startsWith("List<") ) {
                             final var c1 = candidate.substring(5, candidate.length() - 1);
                             candidatesMultiple.add(c1);
                             useCreators = true;
                         } else {
                             candidatesSingle.add(candidate);
                             useCreators |= primitives.contains(candidate);
-                            if (!primitives.contains(candidate)) {
+                            if( !primitives.contains(candidate) ) {
                                 nonPrimitives++;
                             }
                         }
                     }
-                    if (useCreators) {
-                        if (nonPrimitives > 1) {
+                    if( useCreators ) {
+                        if( nonPrimitives > 1 ) {
                             final var msg =
                                 "Generating interface with mixed multiple non-primitive and primitive sub-types: {}. Deserialization may not work.";
                             log.warn(msg, m.name);
@@ -172,10 +185,11 @@ class GenerationConfigurationConverter {
                     }
                 }
             }
-            
-            @SuppressWarnings({"rawtypes", "RedundantSuppression"})
+
+            @SuppressWarnings( { "rawtypes", "RedundantSuppression" } )
             @Override
-            protected void updateModelForObject(@Nonnull final CodegenModel m, @Nonnull final Schema schema) {
+            protected void updateModelForObject( @Nonnull final CodegenModel m, @Nonnull final Schema schema )
+            {
                 // Disable additional attributes to prevent model classes from extending "HashMap"
                 // SAP Cloud SDK offers custom field APIs to handle additional attributes already
                 schema.setAdditionalProperties(Boolean.FALSE);
@@ -183,15 +197,16 @@ class GenerationConfigurationConverter {
             }
         };
     }
-    
-    private static void setGlobalSettings(@Nonnull final GenerationConfiguration configuration) {
-        if (configuration.isGenerateApis()) {
+
+    private static void setGlobalSettings( @Nonnull final GenerationConfiguration configuration )
+    {
+        if( configuration.isGenerateApis() ) {
             GlobalSettings.setProperty(CodegenConstants.APIS, "");
         }
-        if (configuration.isGenerateModels()) {
+        if( configuration.isGenerateModels() ) {
             GlobalSettings.setProperty(CodegenConstants.MODELS, "");
         }
-        if (configuration.isDebugModels()) {
+        if( configuration.isDebugModels() ) {
             GlobalSettings.setProperty("debugModels", "true");
         }
         GlobalSettings.setProperty(CodegenConstants.MODEL_TESTS, Boolean.FALSE.toString());
@@ -201,31 +216,33 @@ class GenerationConfigurationConverter {
         GlobalSettings.clearProperty(CodegenConstants.SUPPORTING_FILES);
         GlobalSettings.setProperty(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
     }
-    
-    private static OpenAPI parseOpenApiSpec(@Nonnull final String inputSpecFile) {
+
+    private static OpenAPI parseOpenApiSpec( @Nonnull final String inputSpecFile )
+    {
         final List<AuthorizationValue> authorizationValues = List.of();
         final var options = new ParseOptions();
         options.setResolve(true);
         final var spec = new OpenAPIParser().readLocation(inputSpecFile, authorizationValues, options);
-        if (!spec.getMessages().isEmpty()) {
+        if( !spec.getMessages().isEmpty() ) {
             log.warn("Parsing the specification yielded the following messages: {}", spec.getMessages());
         }
         return spec.getOpenAPI();
     }
-    
-    private static Map<String, Object> getAdditionalProperties(@Nonnull final GenerationConfiguration config) {
+
+    private static Map<String, Object> getAdditionalProperties( @Nonnull final GenerationConfiguration config )
+    {
         log.info("Using {} as {}.", ApiMaturity.class.getSimpleName(), config.getApiMaturity());
-        
+
         final Map<String, Object> result = new HashMap<>();
         result.put(CodegenConstants.HIDE_GENERATION_TIMESTAMP, Boolean.TRUE.toString());
-        
-        switch (config.getApiMaturity()) {
+
+        switch( config.getApiMaturity() ) {
             case RELEASED -> result.put(IS_RELEASED_PROPERTY_KEY, true);
             case BETA -> result.remove(IS_RELEASED_PROPERTY_KEY);
         }
-        
+
         final var copyrightHeader = config.useSapCopyrightHeader() ? SAP_COPYRIGHT_HEADER : config.getCopyrightHeader();
-        if (!Strings.isNullOrEmpty(copyrightHeader)) {
+        if( !Strings.isNullOrEmpty(copyrightHeader) ) {
             result.put(COPYRIGHT_PROPERTY_KEY, copyrightHeader);
         }
         result.put(CodegenConstants.SERIALIZABLE_MODEL, "false");
@@ -236,10 +253,10 @@ class GenerationConfigurationConverter {
         // this is set to false, to prevent issues with the JsonNullable annotation
         // long term fix part of BLI CLOUDECOSYSTEM-9843
         result.put(OPEN_API_NULLABLE_PROPERTY_KEY, "false");
-        
+
         // this allows the customer to override the default Cloud SDK settings above
-        config.getAdditionalProperties().forEach((k, v) -> {
-            if (result.containsKey(k)) {
+        config.getAdditionalProperties().forEach(( k, v ) -> {
+            if( result.containsKey(k) ) {
                 final var msg =
                     "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user provided configuration.";
                 log.info(msg, result.get(k), k, v);

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/pojo.mustache
@@ -328,7 +328,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     }
     final {{classname}} {{classVarName}} = ({{classname}}) o;
     return Objects.equals(this.cloudSdkCustomFields, {{classVarName}}.cloudSdkCustomFields){{#hasVars}} &&
-        {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}Objects{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
+        {{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}equalsNullable(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{#isByteArray}}Arrays{{/isByteArray}}{{^isByteArray}}{{^vendorExtensions.isPrimitiveArray}}Objects{{/vendorExtensions.isPrimitiveArray}}{{#vendorExtensions.isPrimitiveArray}}Arrays{{/vendorExtensions.isPrimitiveArray}}{{/isByteArray}}.equals(this.{{name}}, {{classVarName}}.{{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}} &&
         {{/-last}}{{/vars}}{{/hasVars}}{{#parent}} &&
         super.equals(o){{/parent}};
   {{/useReflectionEqualsHashCode}}
@@ -344,7 +344,7 @@ public class {{classname}} {{#parent}}extends {{{.}}} {{/parent}}{{#vendorExtens
     return HashCodeBuilder.reflectionHashCode(this);
   {{/useReflectionEqualsHashCode}}
   {{^useReflectionEqualsHashCode}}
-    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{name}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#hasVars}}, {{/hasVars}}cloudSdkCustomFields{{#parent}}, super.hashCode(){{/parent}});
+    return Objects.hash({{#vars}}{{#vendorExtensions.x-is-jackson-optional-nullable}}hashCodeNullable({{name}}){{/vendorExtensions.x-is-jackson-optional-nullable}}{{^vendorExtensions.x-is-jackson-optional-nullable}}{{^isByteArray}}{{^vendorExtensions.isPrimitiveArray}}{{name}}{{/vendorExtensions.isPrimitiveArray}}{{#vendorExtensions.isPrimitiveArray}}Arrays.hashCode({{name}}){{/vendorExtensions.isPrimitiveArray}}{{/isByteArray}}{{#isByteArray}}Arrays.hashCode({{name}}){{/isByteArray}}{{/vendorExtensions.x-is-jackson-optional-nullable}}{{^-last}}, {{/-last}}{{/vars}}{{#hasVars}}, {{/hasVars}}cloudSdkCustomFields{{#parent}}, super.hashCode(){{/parent}});
   {{/useReflectionEqualsHashCode}}
   }{{#vendorExtensions.x-jackson-optional-nullable-helpers}}
 

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -1,14 +1,6 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationResult;
-import io.vavr.control.Try;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
+import static org.assertj.core.api.Assertions.assertThat;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -16,7 +8,17 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationResult;
+
+import io.vavr.control.Try;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 
 class DataModelGeneratorIntegrationTest
 {

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -1,6 +1,14 @@
 package com.sap.cloud.sdk.datamodel.openapi.generator;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
+import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationResult;
+import io.vavr.control.Try;
+import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
+import org.junit.jupiter.api.io.TempDir;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
 
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -8,17 +16,7 @@ import java.nio.file.Paths;
 import java.util.Map;
 import java.util.function.Predicate;
 
-import org.junit.jupiter.api.io.TempDir;
-import org.junit.jupiter.params.ParameterizedTest;
-import org.junit.jupiter.params.provider.EnumSource;
-
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.ApiMaturity;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationConfiguration;
-import com.sap.cloud.sdk.datamodel.openapi.generator.model.GenerationResult;
-
-import io.vavr.control.Try;
-import lombok.RequiredArgsConstructor;
-import lombok.SneakyThrows;
+import static org.assertj.core.api.Assertions.assertThat;
 
 class DataModelGeneratorIntegrationTest
 {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -219,7 +219,7 @@ public class Soda
    * @return The same instance of this {@link Soda} class
    */
   @Nonnull public Soda embedding( @Nonnull final float[] embedding) {
-    this.embedding = embedding.clone();
+    this.embedding = embedding;
     return this;
   }
 
@@ -229,7 +229,7 @@ public class Soda
    */
   @Nonnull
   public float[] getEmbedding() {
-    return embedding.clone();
+    return embedding;
   }
 
   /**

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -219,7 +219,7 @@ public class Soda
    * @return The same instance of this {@link Soda} class
    */
   @Nonnull public Soda embedding( @Nonnull final float[] embedding) {
-    this.embedding = embedding;
+    this.embedding = embedding.clone();
     return this;
   }
 
@@ -229,7 +229,7 @@ public class Soda
    */
   @Nonnull
   public float[] getEmbedding() {
-    return embedding;
+    return embedding.clone();
   }
 
   /**
@@ -314,12 +314,12 @@ public class Soda
         Objects.equals(this.brand, soda.brand) &&
         Objects.equals(this.flavor, soda.flavor) &&
         Objects.equals(this.price, soda.price) &&
-        Objects.equals(this.embedding, soda.embedding);
+        Arrays.equals(this.embedding, soda.embedding);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, brand, flavor, price, embedding, cloudSdkCustomFields);
+    return Objects.hash(id, name, brand, flavor, price, Arrays.hashCode(embedding), cloudSdkCustomFields);
   }
 
   @Override

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -353,7 +353,7 @@ public class Soda
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, brand, flavor, price, Arrays.hashCode(embedding), cloudSdkCustomFields);
+    return Objects.hash(id, name, brand, isAvailable, flavor, price, Arrays.hashCode(embedding), cloudSdkCustomFields);
   }
 
   @Override


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#170.

To fully replace `List<BigDecimal>` with `float[]` we need to adapt the generated model classes on a template layer.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Add new custom flag `isPrimitiveArray` for types likes `float[]`
- [x] `hashCode` and `equals` methods use `Arrays` class for `float[]
`
## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
