### PR TITLE
fix: [OpenAPI] Correct `@Nullable` on inner enum `fromValue(String)` methods

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/modelInnerEnum.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/modelInnerEnum.mustache
@@ -65,7 +65,7 @@
 {{#jackson}}
     @JsonCreator
 {{/jackson}}
-    @Nonnull public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(@Nonnull final {{{dataType}}} value) {
+    {{#isNullable}}@Nullable{{/isNullable}}{{^isNullable}}@Nonnull{{/isNullable}} public static {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} fromValue(@Nonnull final {{{dataType}}} value) {
       for ({{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}} b : {{{datatypeWithEnum}}}{{^datatypeWithEnum}}{{{classname}}}{{/datatypeWithEnum}}.values()) {
         if (b.value.{{^isString}}equals{{/isString}}{{#isString}}{{#useEnumCaseInsensitive}}equalsIgnoreCase{{/useEnumCaseInsensitive}}{{^useEnumCaseInsensitive}}equals{{/useEnumCaseInsensitive}}{{/isString}}(value)) {
           return b;

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/input/sodastore.json
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/input/sodastore.json
@@ -179,6 +179,11 @@
             "type": "number",
             "format": "float"
           },
+          "diet": {
+            "type": "string",
+            "enum": ["sugar", "zero", "light"],
+            "nullable": true
+          },
           "embedding":{
             "type": "array",
             "items": {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -63,6 +63,68 @@ public class Soda
   @JsonProperty("price")
   private Float price;
 
+  /**
+   * Gets or Sets diet
+   */
+  public enum DietEnum {
+    /**
+    * The SUGAR option of this Soda
+    */
+    SUGAR("sugar"),
+    
+    /**
+    * The ZERO option of this Soda
+    */
+    ZERO("zero"),
+    
+    /**
+    * The LIGHT option of this Soda
+    */
+    LIGHT("light");
+
+    private String value;
+
+    DietEnum(String value) {
+      this.value = value;
+    }
+
+    /**
+    * Get the value of the enum
+    * @return The enum value
+    */
+    @JsonValue
+    @Nonnull public String getValue() {
+      return value;
+    }
+
+    /**
+    * Get the String value of the enum value.
+    * @return The enum value as String
+    */
+    @Override
+    @Nonnull public String toString() {
+      return String.valueOf(value);
+    }
+
+    /**
+    * Get the enum value from a String value
+    * @param value The String value
+    * @return The enum value of type Soda
+    */
+    @JsonCreator
+    @Nonnull public static DietEnum fromValue(@Nonnull final String value) {
+      for (DietEnum b : DietEnum.values()) {
+        if (b.value.equals(value)) {
+          return b;
+        }
+      }
+      return null;
+    }
+  }
+
+  @JsonProperty("diet")
+  private DietEnum diet;
+
   @JsonProperty("embedding")
   private float[] embedding;
 
@@ -245,6 +307,35 @@ public class Soda
   }
 
   /**
+   * Set the diet of this {@link Soda} instance and return the same instance.
+   *
+   * @param diet  The diet of this {@link Soda}
+   * @return The same instance of this {@link Soda} class
+   */
+  @Nonnull public Soda diet( @Nullable final DietEnum diet) {
+    this.diet = diet;
+    return this;
+  }
+
+  /**
+   * Get diet
+   * @return diet  The diet of this {@link Soda} instance.
+   */
+  @Nullable
+  public DietEnum getDiet() {
+    return diet;
+  }
+
+  /**
+   * Set the diet of this {@link Soda} instance.
+   *
+   * @param diet  The diet of this {@link Soda}
+   */
+  public void setDiet( @Nullable final DietEnum diet) {
+    this.diet = diet;
+  }
+
+  /**
    * Set the embedding of this {@link Soda} instance and return the same instance.
    *
    * @param embedding  The embedding of this {@link Soda}
@@ -315,6 +406,7 @@ public class Soda
     if( isAvailable != null ) declaredFields.put("isAvailable", isAvailable);
     if( flavor != null ) declaredFields.put("flavor", flavor);
     if( price != null ) declaredFields.put("price", price);
+    if( diet != null ) declaredFields.put("diet", diet);
     if( embedding != null ) declaredFields.put("embedding", embedding);
     return declaredFields;
   }
@@ -348,12 +440,13 @@ public class Soda
         Objects.equals(this.isAvailable, soda.isAvailable) &&
         Objects.equals(this.flavor, soda.flavor) &&
         Objects.equals(this.price, soda.price) &&
+        Objects.equals(this.diet, soda.diet) &&
         Arrays.equals(this.embedding, soda.embedding);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(id, name, brand, isAvailable, flavor, price, Arrays.hashCode(embedding), cloudSdkCustomFields);
+    return Objects.hash(id, name, brand, isAvailable, flavor, price, diet, Arrays.hashCode(embedding), cloudSdkCustomFields);
   }
 
   @Override
@@ -366,6 +459,7 @@ public class Soda
     sb.append("    isAvailable: ").append(toIndentedString(isAvailable)).append("\n");
     sb.append("    flavor: ").append(toIndentedString(flavor)).append("\n");
     sb.append("    price: ").append(toIndentedString(price)).append("\n");
+    sb.append("    diet: ").append(toIndentedString(diet)).append("\n");
     sb.append("    embedding: ").append(toIndentedString(embedding)).append("\n");
     cloudSdkCustomFields.forEach((k,v) -> sb.append("    ").append(k).append(": ").append(toIndentedString(v)).append("\n"));
     sb.append("}");

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/model/Soda.java
@@ -112,7 +112,7 @@ public class Soda
     * @return The enum value of type Soda
     */
     @JsonCreator
-    @Nonnull public static DietEnum fromValue(@Nonnull final String value) {
+    @Nullable public static DietEnum fromValue(@Nonnull final String value) {
       for (DietEnum b : DietEnum.values()) {
         if (b.value.equals(value)) {
           return b;


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

I've noticed the issue while working on this https://github.com/SAP/ai-sdk-java/pull/370

### Before

The following spec

```json
  "components": {
    "schemas": {
      "Soda": {
        "type": "object",
        "properties": {
          "diet": {
            "type": "string",
            "enum": ["sugar", "zero", "light"],
            "nullable": true
          },
  ...
```

evaluates to

```java
public class Soda 
{
  public enum DietEnum {
    ...

    @JsonCreator
    @Nonnull public static DietEnum fromValue(@Nonnull final String value) {
      for (DietEnum b : DietEnum.values()) {
        if (b.value.equals(value)) {
          return b;
        }
      }
      return null; // WARNING: returned null on @Nonnull method
    }
  }
```
### After

```diff
- @Nonnull
+ @Nullable
             public static DietEnum fromValue(@Nonnull final String value) {
```


## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
