### PR TITLE
test: [OpenAPI-Gen] Deserialising `oneOf` and `anyOf` with array of objects  

### DIFF
--- a/datamodel/openapi/openapi-api-sample/pom.xml
+++ b/datamodel/openapi/openapi-api-sample/pom.xml
@@ -98,6 +98,10 @@
 			<artifactId>jackson-datatype-jsr310</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter-params</artifactId>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/FantaFlavor.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/FantaFlavor.java
@@ -15,6 +15,8 @@
 
 package com.sap.cloud.sdk.datamodel.openapi.sample.model;
 
+import java.util.List;
+
 import javax.annotation.Nonnull;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
@@ -45,22 +47,22 @@ public interface FantaFlavor
     }
 
     /**
-     * Helper class to create a FantaFlavorOneOf that implements {@link FantaFlavor}.
+     * Helper class to create a FlavorType that implements {@link FantaFlavor}.
      */
-    record InnerFantaFlavorOneOf(@com.fasterxml.jackson.annotation.JsonValue @Nonnull FantaFlavorOneOf value) implements FantaFlavor {}
+    record InnerFlavorType(@com.fasterxml.jackson.annotation.JsonValue @Nonnull FlavorType value) implements FantaFlavor {}
 
     /**
-     * Creator to enable deserialization of a FantaFlavorOneOf.
+     * Creator to enable deserialization of a FlavorType.
      *
      * @param val
      *            the value to use
-     * @return a new instance of {@link InnerFantaFlavorOneOf}.
+     * @return a new instance of {@link InnerFlavorType}.
      */
     @com.fasterxml.jackson.annotation.JsonCreator
     @Nonnull
-    static InnerFantaFlavorOneOf create( @Nonnull final FantaFlavorOneOf val )
+    static InnerFlavorType create( @Nonnull final FlavorType val )
     {
-        return new InnerFantaFlavorOneOf(val);
+        return new InnerFlavorType(val);
     }
 
     /**
@@ -80,6 +82,25 @@ public interface FantaFlavor
     static InnerString create( @Nonnull final String val )
     {
         return new InnerString(val);
+    }
+
+    /**
+    * Helper class to create a list of FlavorType that implements {@link FantaFlavor}.
+    */
+    record InnerFlavorTypes(@com.fasterxml.jackson.annotation.JsonValue @Nonnull List<FlavorType> values) implements FantaFlavor {}
+
+    /**
+     * Creator to enable deserialization of a list of FlavorType.
+     *
+     * @param val
+     *            the value to use
+     * @return a new instance of {@link InnerFlavorTypes}.
+     */
+    @com.fasterxml.jackson.annotation.JsonCreator
+    @Nonnull
+    static InnerFlavorTypes create( @Nonnull final List<FlavorType> val )
+    {
+        return new InnerFlavorTypes(val);
     }
 
 }

--- a/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/FlavorType.java
+++ b/datamodel/openapi/openapi-api-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/sample/model/FlavorType.java
@@ -30,10 +30,10 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 /**
- * FantaFlavorOneOf
+ * FlavorType
  */
 // CHECKSTYLE:OFF
-public class FantaFlavorOneOf
+public class FlavorType
 // CHECKSTYLE:ON
 {
     @JsonProperty( "intensity" )
@@ -47,30 +47,30 @@ public class FantaFlavorOneOf
     private final Map<String, Object> cloudSdkCustomFields = new LinkedHashMap<>();
 
     /**
-     * Default constructor for FantaFlavorOneOf.
+     * Default constructor for FlavorType.
      */
-    protected FantaFlavorOneOf()
+    protected FlavorType()
     {
     }
 
     /**
-     * Set the intensity of this {@link FantaFlavorOneOf} instance and return the same instance.
+     * Set the intensity of this {@link FlavorType} instance and return the same instance.
      *
      * @param intensity
-     *            The intensity of this {@link FantaFlavorOneOf}
-     * @return The same instance of this {@link FantaFlavorOneOf} class
+     *            The intensity of the flavor
+     * @return The same instance of this {@link FlavorType} class
      */
     @Nonnull
-    public FantaFlavorOneOf intensity( @Nullable final Integer intensity )
+    public FlavorType intensity( @Nullable final Integer intensity )
     {
         this.intensity = intensity;
         return this;
     }
 
     /**
-     * Get intensity
+     * The intensity of the flavor
      *
-     * @return intensity The intensity of this {@link FantaFlavorOneOf} instance.
+     * @return intensity The intensity of this {@link FlavorType} instance.
      */
     @Nonnull
     public Integer getIntensity()
@@ -79,10 +79,10 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Set the intensity of this {@link FantaFlavorOneOf} instance.
+     * Set the intensity of this {@link FlavorType} instance.
      *
      * @param intensity
-     *            The intensity of this {@link FantaFlavorOneOf}
+     *            The intensity of the flavor
      */
     public void setIntensity( @Nullable final Integer intensity )
     {
@@ -90,23 +90,23 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Set the nuance of this {@link FantaFlavorOneOf} instance and return the same instance.
+     * Set the nuance of this {@link FlavorType} instance and return the same instance.
      *
      * @param nuance
-     *            The nuance of this {@link FantaFlavorOneOf}
-     * @return The same instance of this {@link FantaFlavorOneOf} class
+     *            The nuance of the flavor
+     * @return The same instance of this {@link FlavorType} class
      */
     @Nonnull
-    public FantaFlavorOneOf nuance( @Nullable final String nuance )
+    public FlavorType nuance( @Nullable final String nuance )
     {
         this.nuance = nuance;
         return this;
     }
 
     /**
-     * Get nuance
+     * The nuance of the flavor
      *
-     * @return nuance The nuance of this {@link FantaFlavorOneOf} instance.
+     * @return nuance The nuance of this {@link FlavorType} instance.
      */
     @Nonnull
     public String getNuance()
@@ -115,10 +115,10 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Set the nuance of this {@link FantaFlavorOneOf} instance.
+     * Set the nuance of this {@link FlavorType} instance.
      *
      * @param nuance
-     *            The nuance of this {@link FantaFlavorOneOf}
+     *            The nuance of the flavor
      */
     public void setNuance( @Nullable final String nuance )
     {
@@ -126,7 +126,7 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Get the names of the unrecognizable properties of the {@link FantaFlavorOneOf}.
+     * Get the names of the unrecognizable properties of the {@link FlavorType}.
      *
      * @return The set of properties names
      */
@@ -138,7 +138,7 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Get the value of an unrecognizable property of this {@link FantaFlavorOneOf} instance.
+     * Get the value of an unrecognizable property of this {@link FlavorType} instance.
      *
      * @deprecated Use {@link #toMap()} instead.
      * @param name
@@ -153,13 +153,13 @@ public class FantaFlavorOneOf
         throws NoSuchElementException
     {
         if( !cloudSdkCustomFields.containsKey(name) ) {
-            throw new NoSuchElementException("FantaFlavorOneOf has no field with name '" + name + "'.");
+            throw new NoSuchElementException("FlavorType has no field with name '" + name + "'.");
         }
         return cloudSdkCustomFields.get(name);
     }
 
     /**
-     * Get the value of all properties of this {@link FantaFlavorOneOf} instance including unrecognized properties.
+     * Get the value of all properties of this {@link FlavorType} instance including unrecognized properties.
      *
      * @return The map of all properties
      */
@@ -176,8 +176,8 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Set an unrecognizable property of this {@link FantaFlavorOneOf} instance. If the map previously contained a
-     * mapping for the key, the old value is replaced by the specified value.
+     * Set an unrecognizable property of this {@link FlavorType} instance. If the map previously contained a mapping for
+     * the key, the old value is replaced by the specified value.
      *
      * @param customFieldName
      *            The name of the property
@@ -199,10 +199,10 @@ public class FantaFlavorOneOf
         if( o == null || getClass() != o.getClass() ) {
             return false;
         }
-        final FantaFlavorOneOf fantaFlavorOneOf = (FantaFlavorOneOf) o;
-        return Objects.equals(this.cloudSdkCustomFields, fantaFlavorOneOf.cloudSdkCustomFields)
-            && Objects.equals(this.intensity, fantaFlavorOneOf.intensity)
-            && Objects.equals(this.nuance, fantaFlavorOneOf.nuance);
+        final FlavorType flavorType = (FlavorType) o;
+        return Objects.equals(this.cloudSdkCustomFields, flavorType.cloudSdkCustomFields)
+            && Objects.equals(this.intensity, flavorType.intensity)
+            && Objects.equals(this.nuance, flavorType.nuance);
     }
 
     @Override
@@ -216,7 +216,7 @@ public class FantaFlavorOneOf
     public String toString()
     {
         final StringBuilder sb = new StringBuilder();
-        sb.append("class FantaFlavorOneOf {\n");
+        sb.append("class FlavorType {\n");
         sb.append("    intensity: ").append(toIndentedString(intensity)).append("\n");
         sb.append("    nuance: ").append(toIndentedString(nuance)).append("\n");
         cloudSdkCustomFields
@@ -237,11 +237,11 @@ public class FantaFlavorOneOf
     }
 
     /**
-     * Create a new {@link FantaFlavorOneOf} instance. No arguments are required.
+     * Create a new {@link FlavorType} instance. No arguments are required.
      */
-    public static FantaFlavorOneOf create()
+    public static FlavorType create()
     {
-        return new FantaFlavorOneOf();
+        return new FlavorType();
     }
 
 }

--- a/datamodel/openapi/openapi-api-sample/src/main/resources/sodastore.yaml
+++ b/datamodel/openapi/openapi-api-sample/src/main/resources/sodastore.yaml
@@ -165,12 +165,19 @@ components:
           oneOf:
             - type: string
             - type: integer
-            - type: object
-              properties:
-                intensity:
-                  type: integer
-                nuance:
-                  type: string
+            - type: array
+              items:
+                $ref: '#/components/schemas/FlavorType'
+            - $ref: '#/components/schemas/FlavorType'
+    FlavorType:
+      type: object
+      properties:
+        intensity:
+          type: integer
+          description: The intensity of the flavor
+        nuance:
+          type: string
+          description: The nuance of the flavor
 paths:
   /sodas:
     get:

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
@@ -164,6 +164,7 @@ class OneOfDeserializationTest
         var flavorTypes = (FantaFlavor.InnerFlavorTypes) fanta.getFlavor();
         assertThat(flavorTypes.values())
             .describedAs("Flavor should be deserialized as a list of FlavorType instances")
+            .isNotEmpty()
             .allMatch(FlavorType.class::isInstance);
 
     }

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
@@ -1,11 +1,15 @@
 package com.sap.cloud.sdk.datamodel.openapi.sample.api;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+
+import java.util.stream.Stream;
 
 import javax.annotation.Nonnull;
 
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import com.fasterxml.jackson.annotation.JsonAutoDetect;
@@ -20,7 +24,7 @@ import com.sap.cloud.sdk.datamodel.openapi.sample.model.Bar;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.Cola;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.Fanta;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.FantaFlavor;
-import com.sap.cloud.sdk.datamodel.openapi.sample.model.FantaFlavorOneOf;
+import com.sap.cloud.sdk.datamodel.openapi.sample.model.FlavorType;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.Foo;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.OneOf;
 import com.sap.cloud.sdk.datamodel.openapi.sample.model.OneOfWithDiscriminator;
@@ -37,7 +41,7 @@ class OneOfDeserializationTest
             .create()
             .color("orange")
             .sodaType("Fanta")
-            .flavor(new FantaFlavor.InnerFantaFlavorOneOf(FantaFlavorOneOf.create().intensity(3).nuance("wood")));
+            .flavor(new FantaFlavor.InnerFlavorType(FlavorType.create().intensity(3).nuance("wood")));
     private static final String COLA_JSON = """
         {
           "sodaType": "Cola",
@@ -48,6 +52,15 @@ class OneOfDeserializationTest
           "sodaType": "Fanta",
           "color": "orange",
           "flavor": {"intensity":3,"nuance":"wood"}
+        }""";
+    private static final String FANTA_FLAVOR_ARRAY_JSON = """
+        {
+          "sodaType": "Fanta",
+          "color": "orange",
+          "flavor": [
+            {"intensity":3,"nuance":"wood"},
+            {"intensity":5,"nuance":"citrus"}
+          ]
         }""";
     private static final String UNKNOWN_JSON = """
         {
@@ -93,7 +106,8 @@ class OneOfDeserializationTest
             .isInstanceOf(Fanta.class)
             .isEqualTo(FANTA_OBJECT);
 
-        assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminator.class));
+        assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminator.class))
+            .isInstanceOf(JsonProcessingException.class);
     }
 
     @Test
@@ -126,6 +140,32 @@ class OneOfDeserializationTest
 
         assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminatorAndMapping.class))
             .isInstanceOf(JsonProcessingException.class);
+
+    }
+
+    static Stream<Class<?>> oneOfStrategiesProvider()
+    {
+        return Stream.of(OneOf.class, OneOfWithDiscriminator.class, OneOfWithDiscriminatorAndMapping.class);
+    }
+
+    @ParameterizedTest( name = "Deserialization with strategy: {0}" )
+    @MethodSource( "oneOfStrategiesProvider" )
+    void oneOfWithNestedArrayOfObjects( Class<?> strategy )
+        throws JsonProcessingException
+    {
+        Object actual = objectMapper.readValue(FANTA_FLAVOR_ARRAY_JSON, strategy);
+
+        assertThat(actual)
+            .describedAs("Object should automatically be deserialized as Fanta with JSON subtype deduction")
+            .isInstanceOf(Fanta.class);
+        var fanta = (Fanta) actual;
+        assertThat(fanta.getFlavor())
+            .describedAs("Flavor should be deserialized as wrapper class for a list of FlavorType instances")
+            .isInstanceOf(FantaFlavor.InnerFlavorTypes.class);
+        var flavorTypes = (FantaFlavor.InnerFlavorTypes) fanta.getFlavor();
+        assertThat(flavorTypes.values())
+            .describedAs("Flavor should be deserialized as a list of FlavorType instances")
+            .allMatch(FlavorType.class::isInstance);
 
     }
 

--- a/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
+++ b/datamodel/openapi/openapi-api-sample/src/test/java/com/sap/cloud/sdk/datamodel/openapi/sample/api/OneOfDeserializationTest.java
@@ -140,7 +140,6 @@ class OneOfDeserializationTest
 
         assertThatThrownBy(() -> objectMapper.readValue(UNKNOWN_JSON, OneOfWithDiscriminatorAndMapping.class))
             .isInstanceOf(JsonProcessingException.class);
-
     }
 
     static Stream<Class<?>> oneOfStrategiesProvider()
@@ -182,6 +181,13 @@ class OneOfDeserializationTest
         assertThat(anyOfFanta.getSodaType()).isEqualTo("Fanta");
         assertThat(anyOfFanta.getColor()).isEqualTo("orange");
         assertThat(anyOfFanta.isCaffeine()).isNull();
+
+        AnyOf actual = objectMapper.readValue(FANTA_FLAVOR_ARRAY_JSON, AnyOf.class);
+
+        assertThat(actual.getSodaType()).isEqualTo("Fanta");
+        assertThat(actual.getColor()).isEqualTo("orange");
+        assertThat(actual.getFlavor()).isInstanceOf(FantaFlavor.InnerFlavorTypes.class);
+        assertThat(((FantaFlavor.InnerFlavorTypes) actual.getFlavor()).values()).allMatch(FlavorType.class::isInstance);
     }
 
     @Test


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

AI/ai-sdk-java-backlog#681.

We aim to test if the [proposed OpenAPI spec](https://github.tools.sap/AI/llm-orchestration/pull/1163/files) definition may hinder Java SDK development.  

Specifically, the specification contains properties that may be `oneOf` types, including both primitive and complex types. The tests are designed to verify the deserialization for both `oneOf` and `anyOf` scenarios.  

Note: The spec doesn't contain `anyOf` case yet.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
