### PR TITLE
feat: [IAS] Harden IAS Subdomain Resolution in OAuth2Service

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -40,6 +40,7 @@ import com.sap.cloud.security.xsuaa.client.OAuth2TokenResponse;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 
 import io.vavr.CheckedFunction0;
+import io.vavr.control.Option;
 import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.Getter;
@@ -229,12 +230,15 @@ class OAuth2Service
             return null;
         }
 
-        if( !(tenant instanceof TenantWithSubdomain) ) {
-            final String msg = "Unable to get subdomain of tenant '%s' because the instance is not an instance of %s.";
-            throw new DestinationAccessException(msg.formatted(tenant, TenantWithSubdomain.class.getSimpleName()));
+        if( tenant instanceof TenantWithSubdomain tenantWithSubdomain ) {
+            return Option
+                .of(tenantWithSubdomain.getSubdomain())
+                .getOrElseThrow(
+                    () -> new DestinationAccessException(
+                        "The given tenant '%s' does not have a subdomain defined.".formatted(tenant)));
         }
-
-        return ((TenantWithSubdomain) tenant).getSubdomain();
+        final String msg = "Unable to get subdomain of tenant '%s' because the instance is not an instance of %s.";
+        throw new DestinationAccessException(msg.formatted(tenant, TenantWithSubdomain.class.getSimpleName()));
     }
 
     @Nullable

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -45,7 +45,6 @@ import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import lombok.val;
 
 /**
  * This interface handles the communication with an OAuth2 service.
@@ -234,7 +233,7 @@ class OAuth2Service
             final String msg = "Unable to get subdomain of tenant '%s' because the instance is not an instance of %s.";
             throw new DestinationAccessException(msg.formatted(tenant, TenantWithSubdomain.class.getSimpleName()));
         }
-        val subdomain = tenantWithSubdomain.getSubdomain();
+        final var subdomain = tenantWithSubdomain.getSubdomain();
         if( subdomain == null ) {
             throw new DestinationAccessException(
                 "The given tenant '%s' does not have a subdomain defined.".formatted(tenant));

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -40,12 +40,12 @@ import com.sap.cloud.security.xsuaa.client.OAuth2TokenResponse;
 import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 
 import io.vavr.CheckedFunction0;
-import io.vavr.control.Option;
 import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * This interface handles the communication with an OAuth2 service.
@@ -230,15 +230,16 @@ class OAuth2Service
             return null;
         }
 
-        if( tenant instanceof TenantWithSubdomain tenantWithSubdomain ) {
-            return Option
-                .of(tenantWithSubdomain.getSubdomain())
-                .getOrElseThrow(
-                    () -> new DestinationAccessException(
-                        "The given tenant '%s' does not have a subdomain defined.".formatted(tenant)));
+        if( !(tenant instanceof TenantWithSubdomain tenantWithSubdomain) ) {
+            final String msg = "Unable to get subdomain of tenant '%s' because the instance is not an instance of %s.";
+            throw new DestinationAccessException(msg.formatted(tenant, TenantWithSubdomain.class.getSimpleName()));
         }
-        final String msg = "Unable to get subdomain of tenant '%s' because the instance is not an instance of %s.";
-        throw new DestinationAccessException(msg.formatted(tenant, TenantWithSubdomain.class.getSimpleName()));
+        val subdomain = tenantWithSubdomain.getSubdomain();
+        if( subdomain == null ) {
+            throw new DestinationAccessException(
+                "The given tenant '%s' does not have a subdomain defined.".formatted(tenant));
+        }
+        return subdomain;
     }
 
     @Nullable

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
@@ -175,6 +175,11 @@ class OAuth2ServiceTest
             TenantAccessor.executeWithTenant(new DefaultTenant("t1", "localhost"), service::retrieveAccessToken);
             TenantAccessor.executeWithTenant(new DefaultTenant("t2", "localhost"), service::retrieveAccessToken);
 
+            // if a tenant is explicitly defined, the subdomain is mandatory for the subdomain strategy
+            assertThatThrownBy(
+                () -> TenantAccessor.executeWithTenant(new DefaultTenant("t3"), service::retrieveAccessToken))
+                .hasMessageContaining("does not have a subdomain");
+
             SERVER_1
                 .verify(
                     1,

--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,8 @@
 
 ### 🔧 Compatibility Notes
 
-- 
+- Changed a behavior details when obtaining tokens from IAS with the default strategy `CURRENT_TENANT`. 
+  In case the current tenant is the provider tenant, and `TenantAccessor.getCurrentTenant()` is returning a `Tenant` object, this object is now required to have a subdomain != null.
 
 ### ✨ New Functionality
 


### PR DESCRIPTION
## Context

Improves our code to explicitly throw in case the subdomain is missing. The IAS server will reject any requests where `tenantId != provider && subdomian == null`. This PR throws an explicit error instead of allowing the request.

See #736

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

