### PR TITLE
docs: [Connectivity-Apache-Client4/5] Upate Cache TTL in javadoc

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultHttpClientCache.java
@@ -29,7 +29,7 @@ public class DefaultHttpClientCache extends AbstractHttpClientCache
     private final Cache<CacheKey, HttpClient> cache;
 
     /**
-     * Caches the {@code HttpClient} for the default duration of 5 minutes.
+     * Caches the {@code HttpClient} for the default duration of 1 hour.
      */
     DefaultHttpClientCache()
     {

--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientAccessor.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/HttpClientAccessor.java
@@ -24,7 +24,7 @@ public final class HttpClientAccessor
      * {@code #getHttpClient(Destination)} methods.
      * <p>
      * By default, this uses the {@link DefaultHttpClientCache} implementation, which caches the {@link HttpClient} for
-     * 5 minutes.
+     * 1 hour.
      * <p>
      * <strong>CAUTION:</strong> This factory is accessed concurrently. Therefore, you have to make sure that you do not
      * introduce any concurrency issues when changing the factory. Furthermore, be aware that setting a custom factory

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Accessor.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5Accessor.java
@@ -25,7 +25,7 @@ public final class ApacheHttpClient5Accessor
      * Configures the {@code HttpClient5Cache} that is used by the {@code #getHttpClient(String)} and
      * {@code #getHttpClient(Destination)} methods.
      * <p>
-     * By default, this uses an implementation, which caches the {@link HttpClient} for 5 minutes.
+     * By default, this uses an implementation, which caches the {@link HttpClient} for 1 hour.
      * <p>
      * <strong>CAUTION:</strong> This factory is accessed concurrently. Therefore, you have to make sure that you do not
      * introduce any concurrency issues when changing the factory. Furthermore, be aware that setting a custom factory

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5CacheBuilder.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5CacheBuilder.java
@@ -21,7 +21,7 @@ public class ApacheHttpClient5CacheBuilder
     /**
      * Sets the duration for which {@link HttpClient} instances will be cached.
      * <p>
-     * This is an <b>optional</b> parameter. By default, the cache duration is set to 5 minutes.
+     * This is an <b>optional</b> parameter. By default, the cache duration is set to 1 hour.
      * </p>
      *
      * @param durationInMilliseconds
@@ -38,7 +38,7 @@ public class ApacheHttpClient5CacheBuilder
     /**
      * Sets the duration for which {@link HttpClient} instances will be cached.
      * <p>
-     * This is an <b>optional</b> parameter. By default, the cache duration is set to 5 minutes.
+     * This is an <b>optional</b> parameter. By default, the cache duration is set to 1 hour.
      * </p>
      *
      * @param duration


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Issue: https://github.com/SAP/cloud-sdk-java/issues/755

Fix the javadoc to match the actual TTL in client cache.

### Feature scope:

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ]  Documentation updated
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
