### PR TITLE
chore: Increase archetype SapMachineJre version with wildcard

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/manifest.yml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/manifest.yml
@@ -13,7 +13,7 @@ applications:
     SPRING_PROFILES_ACTIVE: 'cloud'
     JBP_CONFIG_SAPJVM_MEMORY_SIZES: 'metaspace:128m..'
     JBP_CONFIG_COMPONENTS: 'jres: [''com.sap.xs.java.buildpack.jre.SAPMachineJRE'']'
-    JBP_CONFIG_SAP_MACHINE_JRE: '{ use_offline_repository: false, version: 17.0.15 }'
+    JBP_CONFIG_SAP_MACHINE_JRE: '{ use_offline_repository: false, version: 17.+ }'
 #  services:
 #  - my-application-logs
 #  - my-xsuaa


### PR DESCRIPTION
Related:
* https://github.com/SAP/cloud-sdk-java/pull/803
* https://github.com/sap-tutorials/Tutorials/issues/23939

Reference:
* https://help.sap.com/docs/SAP_HANA_PLATFORM/4505d0bdaf4948449b7f7379d24d0f0d/5176fc47760c4c6f89612af5551715f2.html#set-the-java-virtual-machine-jvm-


Reproduction:
```
[2025-05-15T08:27:59.217Z] info  cloudFoundryDeploy -    Finalizing Java application...
[2025-05-15T08:27:59.467Z] info  cloudFoundryDeploy -    Configuration from /tmp/buildpacks/126c302c6313d766/config/components.yml modified with: jres: ['com.sap.xs.java.buildpack.jre.SAPMachineJRE']
[2025-05-15T08:27:59.467Z] info  cloudFoundryDeploy -    Configuration from /tmp/buildpacks/126c302c6313d766/config/sap_machine_jre.yml modified with: { use_offline_repository: false, version: 17.+ }
[2025-05-15T08:28:01.329Z] info  cloudFoundryDeploy -    SAP Java Buildpack Version: 1.112.0
[2025-05-15T08:28:02.672Z] info  cloudFoundryDeploy -    Downloaded 'SAP Machine JRE', version '17.0.15_0.0.b0' in 1.431 s.
```
https://sdk-v2.cpe.c.eu-de-1.cloud.sap/job/end-to-end-tests/job/v5-scp-cf-spring/741/