### PR TITLE
feat: Extend error message for 401 errors

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -205,7 +205,7 @@ class OAuth2Service
         if( e instanceof OAuth2ServiceException
             && ((OAuth2ServiceException) e).getHttpStatusCode().equals(401)
             && tenant != null ) {
-            String extension;
+            final String extension;
             if( serviceIdentifier != null ) {
                 extension =
                     " In case you are accessing a multi-tenant BTP service on behalf of a subscriber tenant, ensure that the service instance (here, of the "

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -43,7 +43,6 @@ import com.sap.cloud.security.xsuaa.client.OAuth2TokenService;
 import io.vavr.CheckedFunction0;
 import io.vavr.control.Try;
 import lombok.AccessLevel;
-import lombok.AllArgsConstructor;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +51,6 @@ import lombok.extern.slf4j.Slf4j;
  * This interface handles the communication with an OAuth2 service.
  */
 @RequiredArgsConstructor( access = AccessLevel.PACKAGE )
-@AllArgsConstructor( access = AccessLevel.PRIVATE )
 @Slf4j
 class OAuth2Service
 {
@@ -91,8 +89,6 @@ class OAuth2Service
     @Nonnull
     @Getter( AccessLevel.PACKAGE )
     private final ResilienceConfiguration resilienceConfiguration;
-    @Nullable
-    private ServiceIdentifier serviceIdentifier;
 
     // package-private for testing
     @Nonnull
@@ -205,18 +201,9 @@ class OAuth2Service
         if( e instanceof OAuth2ServiceException
             && ((OAuth2ServiceException) e).getHttpStatusCode().equals(401)
             && tenant != null ) {
-            final String extension;
-            if( serviceIdentifier != null ) {
-                extension =
-                    " In case you are accessing a multi-tenant BTP service on behalf of a subscriber tenant, ensure that the service instance (here, of the "
-                        + serviceIdentifier
-                        + " service) is declared as dependency to SaaS Provisioning Service or Subscription Manager (SMS) and subscribed for the current tenant.";
-            } else {
-                extension =
-                    " In case you are accessing a multi-tenant BTP service on behalf of a subscriber tenant, ensure that the service instance"
-                        + " is declared as dependency to SaaS Provisioning Service or Subscription Manager (SMS) and subscribed for the current tenant.";
-            }
-            message += extension;
+            message +=
+                " In case you are accessing a multi-tenant BTP service on behalf of a subscriber tenant, ensure that the service instance"
+                    + " is declared as dependency to SaaS Provisioning Service or Subscription Manager (SMS) and subscribed for the current tenant.";
         }
         return new TokenRequestFailedException(message, e);
     }
@@ -348,7 +335,6 @@ class OAuth2Service
         private TenantPropagationStrategy tenantPropagationStrategy = TenantPropagationStrategy.ZID_HEADER;
         private final Map<String, String> additionalParameters = new HashMap<>();
         private ResilienceConfiguration.TimeLimiterConfiguration timeLimiter = OAuth2Options.DEFAULT_TIMEOUT;
-        private ServiceIdentifier serviceIdentifier;
 
         @Nonnull
         Builder withTokenUri( @Nonnull final String tokenUri )
@@ -394,7 +380,6 @@ class OAuth2Service
         @Nonnull
         Builder withTenantPropagationStrategyFrom( @Nullable final ServiceIdentifier serviceIdentifier )
         {
-            this.serviceIdentifier = serviceIdentifier;
             final TenantPropagationStrategy tenantPropagationStrategy;
             if( ServiceIdentifier.IDENTITY_AUTHENTICATION.equals(serviceIdentifier) ) {
                 tenantPropagationStrategy = TenantPropagationStrategy.TENANT_SUBDOMAIN;
@@ -455,8 +440,7 @@ class OAuth2Service
                 onBehalfOf,
                 tenantPropagationStrategy,
                 additionalParameters,
-                resilienceConfig,
-                serviceIdentifier);
+                resilienceConfig);
         }
     }
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -190,7 +190,7 @@ class OAuth2Service
                         tenantSubdomain,
                         additionalParameters,
                         false))
-            .getOrElseThrow(e -> buildException(e, tenant)); // thrown here
+            .getOrElseThrow(e -> buildException(e, tenant));
     }
 
     private TokenRequestFailedException buildException( Throwable e, Tenant tenant )

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -190,7 +190,17 @@ class OAuth2Service
                         tenantSubdomain,
                         additionalParameters,
                         false))
-            .getOrElseThrow(e -> new TokenRequestFailedException("Failed to resolve access token.", e));
+            .getOrElseThrow(e -> buildException(e, tenant)); // thrown here
+    }
+
+    private TokenRequestFailedException buildException( Throwable e, Tenant tenant )
+    {
+        String msg = "Failed to resolve access token.";
+        //        In case where tenant is subscriber, and we get 401 error, add hint to error message.
+        if( e.getMessage().contains("Http status code 401") && tenant != null ) {
+            msg += " This might be due to missing or wrongly set up dependencies in your SaaS registry.";
+        }
+        return new TokenRequestFailedException(msg, e);
     }
 
     private void setAppTidInCaseOfIAS( @Nullable final String tenantId )

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -193,7 +193,7 @@ class OAuth2Service
             .getOrElseThrow(e -> buildException(e, tenant));
     }
 
-    private TokenRequestFailedException buildException( Throwable e, Tenant tenant )
+    private TokenRequestFailedException buildException(@Nonnull final Throwable e, @Nullable final Tenant tenant )
     {
         String msg = "Failed to resolve access token.";
         //        In case where tenant is subscriber, and we get 401 error, add hint to error message.

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
@@ -191,6 +191,7 @@ class OAuth2IntegrationTest
             TenantAccessor.executeWithTenant(new DefaultTenant("subscriber", "subscriber"), () -> {
                 assertThatCode(destination::getHeaders)
                     .isInstanceOf(DestinationAccessException.class)
+                    .hasMessageContaining("identity service")
                     .hasMessageEndingWith("subscribed for the current tenant.")
                     .hasRootCauseInstanceOf(OAuth2ServiceException.class);
             });

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
@@ -191,7 +191,7 @@ class OAuth2IntegrationTest
             TenantAccessor.executeWithTenant(new DefaultTenant("subscriber", "subscriber"), () -> {
                 assertThatCode(destination::getHeaders)
                     .isInstanceOf(DestinationAccessException.class)
-                    .hasMessageEndingWith("wrongly set up dependencies in your SaaS registry.")
+                    .hasMessageEndingWith("subscribed for the current tenant.")
                     .hasRootCauseInstanceOf(OAuth2ServiceException.class);
             });
         }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2IntegrationTest.java
@@ -163,8 +163,8 @@ class OAuth2IntegrationTest
             bindingWithCredentials(
                 ServiceIdentifier.IDENTITY_AUTHENTICATION,
                 entry("credential-type", "binding-secret"),
-                entry("clientid", "myClientId"),
-                entry("clientsecret", "myClientSecret"),
+                entry("clientid", "myClientId2"),
+                entry("clientsecret", "myClientSecret2"),
                 entry("url", "http://provider.ias.domain"),
                 entry("app_tid", "provider"));
         final ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();


### PR DESCRIPTION
## Context

SAP/cloud-sdk-java-backlog#474

There have been user issues where the underlying problem is that the SaaS dependencies were not setup correctly, resulting in a 401 - Bad Credentials error when the user was doing a OAuth2 token request.

This PR extends the relevant error message in this case to include a hint that the reason for the 401 might be a wrong setup of the SaaS registry.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] error message is extended in the relevant case

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] Documentation updated: https://github.com/SAP/cloud-sdk/pull/2116
- [ ] ~Release notes updated~

