### PR TITLE
fix: (OData) Disable HttpResponse entity buffering

### DIFF
--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
@@ -68,7 +68,6 @@ public class ODataRequestResultGeneric
 {
     private final ODataResponseDeserializer deserializer;
 
-    @Nullable
     private volatile boolean isBufferHttpResponse = true;
 
     @Getter

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
@@ -744,14 +744,15 @@ public class ODataRequestResultGeneric
             if( !bufferingEnabled.getAsBoolean() || isAlreadyBuffered() ) {
                 return originalEntity;
             }
-
-            final Try<HttpEntity> entity = Try.of(() -> new BufferedHttpEntity(originalEntity));
-            if( entity.isFailure() ) {
-                log.warn("Failed to buffer HTTP response. Unable to buffer HTTP entity.", entity.getCause());
+            try {
+                final BufferedHttpEntity entity = new BufferedHttpEntity(originalEntity);
+                httpResponse.setEntity(entity);
+                return entity;
+            }
+            catch( final Exception e ) {
+                log.warn("Failed to buffer HTTP response. Unable to buffer HTTP entity.", e);
                 return originalEntity;
             }
-            httpResponse.setEntity(entity.get());
-            return entity.get();
         }
 
         public boolean isAlreadyBuffered()

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
@@ -17,7 +17,6 @@ import java.util.function.Function;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import lombok.RequiredArgsConstructor;
 import org.apache.commons.lang3.ClassUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.HttpEntity;
@@ -52,6 +51,7 @@ import io.vavr.control.Try;
 import lombok.AccessLevel;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import lombok.experimental.Delegate;
 import lombok.extern.slf4j.Slf4j;
 

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
@@ -12,7 +12,6 @@ import static org.mockito.Mockito.when;
 
 import javax.annotation.Nonnull;
 
-import lombok.SneakyThrows;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -38,6 +37,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.ToString;
 
 class ModificationResponseTest

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
@@ -5,12 +5,14 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import javax.annotation.Nonnull;
 
+import lombok.SneakyThrows;
 import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
@@ -18,6 +20,7 @@ import org.apache.http.HttpVersion;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.jupiter.api.Test;
 
@@ -124,6 +127,7 @@ class ModificationResponseTest
         assertThat(modification.getResponseHeaders()).isEmpty();
     }
 
+    @SneakyThrows
     @Test
     void testResponseIsOnlyEvaluatedOnce()
     {
@@ -132,13 +136,9 @@ class ModificationResponseTest
         final ODataRequestGeneric request = mock(ODataRequestGeneric.class);
         when(request.getProtocol()).thenReturn(ODataProtocol.V4);
 
-        final Header[] responseHeaders = {};
-
-        final HttpResponse response = mock(HttpResponse.class);
-        doReturn(responseHeaders).when(response).getAllHeaders();
-        doReturn(responseHeaders).when(response).getHeaders("ETag");
-        doReturn(new StringEntity("{\"foo\":\"bar\"}", UTF_8)).when(response).getEntity();
-        doReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK")).when(response).getStatusLine();
+        final HttpResponse response = new BasicHttpResponse(HttpVersion.HTTP_1_1, 200, "OK");
+        final StringEntity entity = spy(new StringEntity("{\"foo\":\"bar\"}", UTF_8));
+        response.setEntity(entity);
 
         final ODataRequestResultGeneric result = new ODataRequestResultGeneric(request, response);
         final ModificationResponse<TestObject> modification = ModificationResponse.of(result, inputObject);
@@ -151,6 +151,6 @@ class ModificationResponseTest
         final TestObject modifiedEntity = modification.getModifiedEntity();
         assertThat(modifiedEntity).isNotNull();
 
-        verify(response, times(1)).getEntity();
+        verify(entity, times(1)).getContent();
     }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -21,3 +21,4 @@
 ### 🐛 Fixed Issues
 
 - Fix `CVE-2025-48734` by transitive dependency update in `connectivity-ztis`.
+- For OData Generic Client: Fix `disableBufferingHttpResponse()` in `ODataRequestResultGeneric`.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://github.com/SAP/cloud-sdk-java-backlog/issues/475
https://github.com/SAP/cloud-sdk-java/issues/834

Change the implementation such that `ODataHealthyResponseValidator` no longer fetches and buffers the `HttpEntity` associated `InputStream` by accident.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Change buffer trigger to act on `#getHttpResponse().getEntity()` instead of `#getHttpResponse()`
- [x] Confirm with disabled integration test
- [x] Add unit test

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
