### PR TITLE
chore: Fix CVE-2025-48734

### DIFF
--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -118,6 +118,7 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
+			<scope>runtime</scope>
 			<exclusions>
 				<exclusion>
 					<artifactId>commons-logging</artifactId>

--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -112,6 +112,10 @@
 			<artifactId>slf4j-api</artifactId>
 		</dependency>
 		<dependency>
+			<groupId>commons-beanutils</groupId>
+			<artifactId>commons-beanutils</artifactId>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<scope>provided</scope>

--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -79,6 +79,10 @@
 					<artifactId>commons-logging</artifactId>
 					<groupId>commons-logging</groupId>
 				</exclusion>
+				<exclusion>
+					<artifactId>commons-beanutils</artifactId>
+					<groupId>commons-beanutils</groupId>
+				</exclusion>
 			</exclusions>
 		</dependency>
 		<dependency>
@@ -114,6 +118,12 @@
 		<dependency>
 			<groupId>commons-beanutils</groupId>
 			<artifactId>commons-beanutils</artifactId>
+			<exclusions>
+				<exclusion>
+					<artifactId>commons-logging</artifactId>
+					<groupId>commons-logging</groupId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -740,6 +740,8 @@
 							<ignoredUnusedDeclaredDependency>org.projectlombok:lombok</ignoredUnusedDeclaredDependency>
 							<!-- By default, JUnit5 adapters are added to every module to ensure no tests are skipped -->
 							<ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
+							<!-- Transitive dependencies explicitly declared to fic CVEs-->
+							<ignoredUnusedDeclaredDependency>commons-beanutils:commons-beanutils</ignoredUnusedDeclaredDependency>
 						</ignoredUnusedDeclaredDependencies>
 					</configuration>
 				</plugin>


### PR DESCRIPTION
## Context

Add explicit dependency to connectivity-ztis pom to fix CVE-2025-48734.

Related customer issue: 
- https://github.com/SAP/cloud-sdk-java/issues/843


