### PR TITLE
fix: (odata-client) Move disable-buffer toggle from result object to request builder

### DIFF
--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestBatch.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestBatch.java
@@ -93,6 +93,7 @@ public class ODataRequestBatch extends ODataRequestGeneric
         this.uuidProvider = uuidProvider;
         this.batchUuid = uuidProvider.get();
         this.headers.remove(HttpHeaders.ACCEPT); // batch request does not require Accept header
+        this.bufferStrategy = ResponseBufferStrategy.DISABLED;
     }
 
     @Nonnull

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestGeneric.java
@@ -89,6 +89,12 @@ public abstract class ODataRequestGeneric implements ODataRequestExecutable
     @Setter
     protected CsrfTokenRetriever csrfTokenRetriever;
 
+    /**
+     * The response buffer strategy to use for this request.
+     */
+    @Nonnull
+    ResponseBufferStrategy bufferStrategy = ResponseBufferStrategy.ENABLED;
+
     ODataRequestGeneric(
         @Nonnull final String servicePath,
         @Nonnull final ODataResourcePath resourcePath,
@@ -141,6 +147,14 @@ public abstract class ODataRequestGeneric implements ODataRequestExecutable
     public void addListener( @Nonnull final ODataRequestListener listener )
     {
         listeners.add(listener);
+    }
+
+    /**
+     * Disable pre-buffering of http response entity.
+     */
+    public void disableHttpResponseBuffering()
+    {
+        bufferStrategy = ResponseBufferStrategy.DISABLED;
     }
 
     /**
@@ -229,6 +243,7 @@ public abstract class ODataRequestGeneric implements ODataRequestExecutable
     {
         return Try
             .ofSupplier(httpOperation)
+            .map(bufferStrategy.getHandler())
             .map(response -> new ODataRequestResultGeneric(this, response, httpClient))
             .andThenTry(ODataHealthyResponseValidator::requireHealthyResponse);
     }

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGeneric.java
@@ -22,9 +22,7 @@ import org.apache.http.HttpEntity;
 import org.apache.http.HttpResponse;
 import org.apache.http.StatusLine;
 import org.apache.http.client.HttpClient;
-import org.apache.http.entity.BufferedHttpEntity;
 import org.apache.http.entity.ContentType;
-import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.util.EntityUtils;
 
 import com.google.common.collect.Streams;
@@ -67,15 +65,12 @@ public class ODataRequestResultGeneric
 {
     private final ODataResponseDeserializer deserializer;
 
-    @Nullable
-    private volatile HttpResponse bufferedHttpResponse;
-    private volatile boolean isBufferHttpResponse = true;
-
     @Getter
     @Nonnull
     private final ODataRequestGeneric oDataRequest;
 
     @Nonnull
+    @Getter
     private final HttpResponse httpResponse;
 
     private NumberDeserializationStrategy numberStrategy = NumberDeserializationStrategy.DOUBLE;
@@ -152,63 +147,11 @@ public class ODataRequestResultGeneric
      * Method that allows consumers to disable buffering HTTP response entity. Note that once this is disabled, HTTP
      * responses can only be streamed/read once
      *
+     * @deprecated Please use {@link ODataRequestGeneric#disableHttpResponseBuffering()} instead.
      */
+    @Deprecated
     public void disableBufferingHttpResponse()
     {
-        if( bufferedHttpResponse == null ) {
-            isBufferHttpResponse = false;
-        } else {
-            log.warn("Buffering the HTTP response cannot be disabled! The content has already been buffered.");
-        }
-    }
-
-    /**
-     * Method that creates a {@link BufferedHttpEntity} from the {@link HttpEntity} if buffering the HTTP response is
-     * not turned off by using {@link ODataRequestResultGeneric#disableBufferingHttpResponse()}.
-     *
-     * @return An HttpResponse
-     */
-    @Nonnull
-    @Override
-    public HttpResponse getHttpResponse()
-    {
-        if( !isBufferHttpResponse ) {
-            log.debug("Buffering is disabled, returning unbuffered http response");
-            return httpResponse;
-        }
-
-        if( bufferedHttpResponse != null ) {
-            return Objects.requireNonNull(bufferedHttpResponse);
-        }
-
-        synchronized( this ) {
-            if( bufferedHttpResponse != null ) {
-                return Objects.requireNonNull(bufferedHttpResponse);
-            }
-
-            final StatusLine statusLine = httpResponse.getStatusLine();
-            final HttpEntity httpEntity = httpResponse.getEntity();
-            if( statusLine == null || httpEntity == null ) {
-                log
-                    .debug(
-                        "skipping buffering of http entity as either there is no http entity or response does not include a status-line.");
-                return httpResponse;
-            }
-
-            final Try<HttpEntity> entity = Try.of(() -> new BufferedHttpEntity(httpEntity));
-            if( entity.isFailure() ) {
-                log.warn("Failed to buffer HTTP response. Unable to buffer HTTP entity.", entity.getCause());
-                return httpResponse;
-            }
-
-            final BasicHttpResponse proxyResponse = new BasicHttpResponse(statusLine);
-            proxyResponse.setHeaders(httpResponse.getAllHeaders());
-            proxyResponse.setEntity(entity.get());
-            Option.of(httpResponse.getLocale()).peek(proxyResponse::setLocale);
-            bufferedHttpResponse = proxyResponse;
-        }
-
-        return Objects.requireNonNull(bufferedHttpResponse);
     }
 
     @Override

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultMultipartGeneric.java
@@ -125,7 +125,6 @@ public class ODataRequestResultMultipartGeneric
         }
 
         final ODataRequestResultGeneric result = new ODataRequestResultGeneric(batchRequest, response);
-        result.disableBufferingHttpResponse(); // the artificial HttpResponse is static, no buffer required
         ODataHealthyResponseValidator.requireHealthyResponse(result);
         return result;
     }

--- a/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ResponseBufferStrategy.java
+++ b/datamodel/odata-client/src/main/java/com/sap/cloud/sdk/datamodel/odata/client/request/ResponseBufferStrategy.java
@@ -1,0 +1,40 @@
+package com.sap.cloud.sdk.datamodel.odata.client.request;
+
+import java.util.function.UnaryOperator;
+
+import org.apache.http.HttpResponse;
+import org.apache.http.entity.BufferedHttpEntity;
+import org.apache.http.message.BasicHttpResponse;
+
+import io.vavr.control.Option;
+import io.vavr.control.Try;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Enum representing the strategy for buffering HTTP responses.
+ */
+@RequiredArgsConstructor
+@Slf4j
+@Getter
+enum ResponseBufferStrategy
+{
+    /**
+     * Strategy that does not buffer the response.
+     */
+    DISABLED(response -> response),
+
+    /**
+     * Strategy that buffers the response by creating a copy of it.
+     */
+    ENABLED(response -> {
+        final BasicHttpResponse copy = new BasicHttpResponse(response.getStatusLine());
+        Option.of(response.getLocale()).peek(copy::setLocale);
+        Option.of(response.getAllHeaders()).peek(copy::setHeaders);
+        Option.of(response.getEntity()).peek(entity -> Try.run(() -> copy.setEntity(new BufferedHttpEntity(entity))));
+        return copy;
+    });
+
+    private final UnaryOperator<HttpResponse> handler;
+}

--- a/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGenericTest.java
+++ b/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataRequestResultGenericTest.java
@@ -182,8 +182,8 @@ class ODataRequestResultGenericTest
         httpResponse.setEntity(new InputStreamEntity(inputStream, json.length()));
 
         // system under test
+        oDataRequest.disableHttpResponseBuffering();
         final ODataRequestResultGeneric testResult = new ODataRequestResultGeneric(oDataRequest, httpResponse);
-        testResult.disableBufferingHttpResponse();
 
         // sanity checks do not consume the response
         assertThat(testResult.getHeaderValues("Content-Length")).isEmpty();

--- a/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataResponseParsingIntegrationTest.java
+++ b/datamodel/odata-client/src/test/java/com/sap/cloud/sdk/datamodel/odata/client/request/ODataResponseParsingIntegrationTest.java
@@ -1,6 +1,5 @@
 package com.sap.cloud.sdk.datamodel.odata.client.request;
 
-import static com.github.tomakehurst.wiremock.client.WireMock.get;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
@@ -311,8 +310,8 @@ class ODataResponseParsingIntegrationTest
         final ODataRequestRead request =
             new ODataRequestRead("TripPinRESTierService", "People", "$count=true&$format=json", ODataProtocol.V4);
 
+        request.disableHttpResponseBuffering();
         final ODataRequestResultGeneric result = request.execute(httpClient);
-        result.disableBufferingHttpResponse();
         assertThat(result.asMap()).containsKeys("value", "@odata.count");
         assertThatExceptionOfType(ODataDeserializationException.class).isThrownBy(() -> result.getInlineCount());
     }
@@ -323,9 +322,9 @@ class ODataResponseParsingIntegrationTest
         final ODataRequestRead request =
             new ODataRequestRead("TripPinRESTierService", "People", "$count=true&$format=json", ODataProtocol.V4);
 
+        request.disableHttpResponseBuffering();
         final ODataRequestResultGeneric result = request.execute(httpClient);
         assertThat(result.asMap()).containsKeys("value", "@odata.count");
-        result.disableBufferingHttpResponse();
         assertThat(result.getInlineCount()).isEqualTo(20);
     }
 }

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/CollectionValueActionRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/CollectionValueActionRequestBuilder.java
@@ -99,7 +99,6 @@ public class CollectionValueActionRequestBuilder<ResultT>
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric response = toRequest().execute(httpClient);
-        response.getHttpResponse(); // ensure HTTP response consumption
 
         return ActionResponseCollection.of(response, resultClass);
     }

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/CreateRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/CreateRequestBuilder.java
@@ -103,7 +103,6 @@ public class CreateRequestBuilder<EntityT extends VdmEntity<?>>
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric response = toRequest().execute(httpClient);
-        response.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(response, getEntity());
     }

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/DeleteRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/DeleteRequestBuilder.java
@@ -95,7 +95,6 @@ public class DeleteRequestBuilder<EntityT extends VdmEntity<?>>
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric response = toRequest().execute(httpClient);
-        response.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(response, getEntity());
     }

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/SingleValueActionRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/SingleValueActionRequestBuilder.java
@@ -100,7 +100,6 @@ public class SingleValueActionRequestBuilder<ResultT>
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric response = toRequest().execute(httpClient);
-        response.getHttpResponse(); // ensure HTTP response consumption
 
         return ActionResponseSingle.of(response, resultClass);
     }

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/UpdateRequestBuilder.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/core/UpdateRequestBuilder.java
@@ -117,7 +117,6 @@ public class UpdateRequestBuilder<EntityT extends VdmEntity<?>>
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric response = toRequest().execute(httpClient);
-        response.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(response, getEntity());
     }

--- a/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
+++ b/datamodel/odata-v4/odata-v4-core/src/test/java/com/sap/cloud/sdk/datamodel/odatav4/core/ModificationResponseTest.java
@@ -2,12 +2,17 @@ package com.sap.cloud.sdk.datamodel.odatav4.core;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
+import static com.sap.cloud.sdk.datamodel.odata.client.ODataProtocol.V4;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+
+import java.util.Map;
 
 import javax.annotation.Nonnull;
 
@@ -15,18 +20,23 @@ import org.apache.http.Header;
 import org.apache.http.HttpResponse;
 import org.apache.http.HttpStatus;
 import org.apache.http.HttpVersion;
+import org.apache.http.client.HttpClient;
 import org.apache.http.entity.BasicHttpEntity;
 import org.apache.http.entity.StringEntity;
 import org.apache.http.message.BasicHeader;
+import org.apache.http.message.BasicHttpResponse;
 import org.apache.http.message.BasicStatusLine;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import com.google.gson.annotations.JsonAdapter;
-import com.sap.cloud.sdk.datamodel.odata.client.ODataProtocol;
+import com.sap.cloud.sdk.cloudplatform.connectivity.CsrfTokenRetriever;
+import com.sap.cloud.sdk.datamodel.odata.client.request.ODataEntityKey;
 import com.sap.cloud.sdk.datamodel.odata.client.request.ODataRequestGeneric;
 import com.sap.cloud.sdk.datamodel.odata.client.request.ODataRequestResultGeneric;
+import com.sap.cloud.sdk.datamodel.odata.client.request.ODataRequestUpdate;
+import com.sap.cloud.sdk.datamodel.odata.client.request.UpdateStrategy;
 import com.sap.cloud.sdk.result.ElementName;
 
 import io.vavr.control.Option;
@@ -35,6 +45,7 @@ import lombok.Data;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.ToString;
 
 class ModificationResponseTest
@@ -72,7 +83,7 @@ class ModificationResponseTest
         final TestObject inputObject = new TestObject();
 
         final ODataRequestGeneric request = mock(ODataRequestGeneric.class);
-        when(request.getProtocol()).thenReturn(ODataProtocol.V4);
+        when(request.getProtocol()).thenReturn(V4);
 
         final Header[] responseHeaders = { new BasicHeader("fizz", "buzz"), new BasicHeader("fizz", "fuzz, bizz=1") };
 
@@ -103,7 +114,7 @@ class ModificationResponseTest
         final TestObject inputObject = new TestObject();
 
         final ODataRequestGeneric request = mock(ODataRequestGeneric.class);
-        when(request.getProtocol()).thenReturn(ODataProtocol.V4);
+        when(request.getProtocol()).thenReturn(V4);
 
         final HttpResponse response = mock(HttpResponse.class);
         doReturn(new Header[0]).when(response).getAllHeaders();
@@ -124,23 +135,25 @@ class ModificationResponseTest
         assertThat(modification.getResponseHeaders()).isEmpty();
     }
 
+    @SneakyThrows
     @Test
     void testResponseIsOnlyEvaluatedOnce()
     {
         final TestObject inputObject = new TestObject();
 
-        final ODataRequestGeneric request = mock(ODataRequestGeneric.class);
-        when(request.getProtocol()).thenReturn(ODataProtocol.V4);
+        final HttpResponse response = spy(new BasicHttpResponse(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK"));
+        response.setHeaders(new Header[0]);
+        response.setEntity(new StringEntity("{\"foo\":\"bar\"}", UTF_8));
 
-        final Header[] responseHeaders = {};
+        final ODataEntityKey key = ODataEntityKey.of(Map.of("id", 42), V4);
+        final ODataRequestUpdate request =
+            new ODataRequestUpdate("service/path", "EntitySet", key, "{}", UpdateStrategy.REPLACE_WITH_PUT, null, V4);
+        request.setCsrfTokenRetriever(CsrfTokenRetriever.DISABLED_CSRF_TOKEN_RETRIEVER);
 
-        final HttpResponse response = mock(HttpResponse.class);
-        doReturn(responseHeaders).when(response).getAllHeaders();
-        doReturn(responseHeaders).when(response).getHeaders("ETag");
-        doReturn(new StringEntity("{\"foo\":\"bar\"}", UTF_8)).when(response).getEntity();
-        doReturn(new BasicStatusLine(HttpVersion.HTTP_1_1, HttpStatus.SC_OK, "OK")).when(response).getStatusLine();
+        final HttpClient httpClient = mock(HttpClient.class);
+        when(httpClient.execute(any())).thenReturn(response);
 
-        final ODataRequestResultGeneric result = new ODataRequestResultGeneric(request, response);
+        final ODataRequestResultGeneric result = request.execute(httpClient);
         final ModificationResponse<TestObject> modification = ModificationResponse.of(result, inputObject);
 
         modification.getResponseEntity();
@@ -152,5 +165,6 @@ class ModificationResponseTest
         assertThat(modifiedEntity).isNotNull();
 
         verify(response, times(1)).getEntity();
+        verify(httpClient, times(1)).execute(any());
     }
 }

--- a/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperCreate.java
+++ b/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperCreate.java
@@ -72,7 +72,6 @@ public abstract class FluentHelperCreate<FluentHelperT, EntityT extends VdmEntit
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric result = toRequest().execute(httpClient);
-        result.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(result, getEntity(), destination);
     }

--- a/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperDelete.java
+++ b/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperDelete.java
@@ -97,7 +97,6 @@ public abstract class FluentHelperDelete<FluentHelperT, EntityT extends VdmEntit
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric result = toRequest().execute(httpClient);
-        result.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(result, getEntity(), destination);
     }

--- a/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperUpdate.java
+++ b/datamodel/odata/odata-core/src/main/java/com/sap/cloud/sdk/datamodel/odata/helper/FluentHelperUpdate.java
@@ -111,7 +111,6 @@ public abstract class FluentHelperUpdate<FluentHelperT, EntityT extends VdmEntit
         final HttpClient httpClient = HttpClientAccessor.getHttpClient(destination);
 
         final ODataRequestResultGeneric result = toRequest().execute(httpClient);
-        result.getHttpResponse(); // ensure HTTP response consumption
 
         return ModificationResponse.of(result, getEntity(), destination);
     }


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#ISSUENUMBER.


Please provide a short description of what your change does and why it is needed.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [ ] Task1 
- [ ] Task2 
  - [ ] SubTask1 

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
