### PR TITLE
feat: [Connectivity] Introduce OAuth2Option for token cache parameters 

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -134,7 +134,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
     {
         final OAuth2Options.Builder builder = OAuth2Options.builder();
         options.getOption(OAuth2Options.TokenRetrievalTimeout.class).peek(builder::withTimeLimiter);
-        options.getOption(OAuth2Options.TokenCacheOption.class).peek(builder::withTokenCacheConfiguration);
+        options.getOption(OAuth2Options.TokenCacheParameters.class).peek(builder::withTokenCacheParameters);
         return builder.build();
     }
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplier.java
@@ -134,6 +134,7 @@ public class DefaultOAuth2PropertySupplier implements OAuth2PropertySupplier
     {
         final OAuth2Options.Builder builder = OAuth2Options.builder();
         options.getOption(OAuth2Options.TokenRetrievalTimeout.class).peek(builder::withTimeLimiter);
+        options.getOption(OAuth2Options.TokenCacheOption.class).peek(builder::withTokenCacheConfiguration);
         return builder.build();
     }
 

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Options.java
@@ -10,7 +10,6 @@ import javax.annotation.Nullable;
 
 import com.sap.cloud.sdk.cloudplatform.connectivity.ServiceBindingDestinationOptions.OptionsEnhancer;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration.TimeLimiterConfiguration;
-import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -34,23 +33,22 @@ public final class OAuth2Options
      * @since 5.12.0
      */
     public static final TimeLimiterConfiguration DEFAULT_TIMEOUT = TimeLimiterConfiguration.of(Duration.ofSeconds(10));
-    
+
     /**
-     * The default cache duration is 10 minutes, with cache size of 1000 tokens, expiration delta of 30 sec and
-     * no cache statistics enabled.
+     * The default cache duration is 10 minutes, with cache size of 1000 tokens, expiration delta of 30 sec and no cache
+     * statistics enabled.
      *
      * @since 5.21.0
-     *
      */
-    public static final TokenCacheConfiguration DEFAULT_TOKEN_CACHE_CONFIGURATION =
-        TokenCacheConfiguration.defaultConfiguration();
+    public static final TokenCacheParameters DEFAULT_TOKEN_CACHE_PARAMETERS =
+        TokenCacheParameters.of(Duration.ofMinutes(10), 1000, Duration.ofSeconds(30));
 
     /**
      * The default {@link OAuth2Options} instance that does not alter the token retrieval process and does not use mTLS
      * for the target system connection.
      */
     public static final OAuth2Options DEFAULT =
-        new OAuth2Options(false, Map.of(), DEFAULT_TIMEOUT, null, DEFAULT_TOKEN_CACHE_CONFIGURATION);
+        new OAuth2Options(false, Map.of(), DEFAULT_TIMEOUT, null, DEFAULT_TOKEN_CACHE_PARAMETERS);
 
     private final boolean skipTokenRetrieval;
     @Nonnull
@@ -78,7 +76,7 @@ public final class OAuth2Options
      */
     @Nonnull
     @Getter( AccessLevel.PACKAGE )
-    private final TokenCacheConfiguration tokenCacheConfiguration;
+    private final TokenCacheParameters tokenCacheParameters;
 
     /**
      * Indicates whether to skip the OAuth2 token flow.
@@ -123,7 +121,7 @@ public final class OAuth2Options
         private final Map<String, String> additionalTokenRetrievalParameters = new HashMap<>();
         private KeyStore clientKeyStore;
         private TimeLimiterConfiguration timeLimiter = DEFAULT_TIMEOUT;
-        private TokenCacheConfiguration tokenCacheConfiguration = DEFAULT_TOKEN_CACHE_CONFIGURATION;
+        private TokenCacheParameters tokenCacheParameters = DEFAULT_TOKEN_CACHE_PARAMETERS;
 
         /**
          * Indicates whether to skip the OAuth2 token flow.
@@ -202,17 +200,17 @@ public final class OAuth2Options
         }
 
         /**
-         * Set a custom token cache configuration. {@link #DEFAULT_TOKEN_CACHE_CONFIGURATION} by default.
+         * Set a custom token cache configuration. {@link #DEFAULT_TOKEN_CACHE_PARAMETERS} by default.
          *
-         * @param tokenCacheConfiguration
-         *            The custom token cache configuration.
+         * @param tokenCacheParameters
+         *            The custom token cache parameters.
          * @return This {@link Builder}.
          * @since 5.21.0
          */
         @Nonnull
-        public Builder withTokenCacheConfiguration( @Nonnull final TokenCacheConfiguration tokenCacheConfiguration )
+        public Builder withTokenCacheParameters( @Nonnull final TokenCacheParameters tokenCacheParameters )
         {
-            this.tokenCacheConfiguration = tokenCacheConfiguration;
+            this.tokenCacheParameters = tokenCacheParameters;
             return this;
         }
 
@@ -237,7 +235,7 @@ public final class OAuth2Options
                 new HashMap<>(additionalTokenRetrievalParameters),
                 timeLimiter,
                 clientKeyStore,
-                tokenCacheConfiguration);
+                tokenCacheParameters);
         }
     }
 
@@ -255,15 +253,27 @@ public final class OAuth2Options
     }
 
     /**
-     * Configure the {@link TokenCacheConfiguration} to be used for caching OAuth2 tokens.
+     * Configure the {@link TokenCacheParameters} to be used for caching OAuth2 tokens.
      *
      * @since 5.21.0
      */
     @Getter
     @RequiredArgsConstructor( staticName = "of" )
-    public static class TokenCacheOption implements OptionsEnhancer<TokenCacheConfiguration>
+    public static class TokenCacheParameters implements OptionsEnhancer<TokenCacheParameters>
     {
         @Nonnull
-        private final TokenCacheConfiguration value;
+        private final Duration cacheDuration;
+        @Nonnull
+        private final Integer cacheSize;
+        @Nonnull
+        private final Duration tokenExpirationDelta;
+
+        @Override
+        @Nonnull
+        public TokenCacheParameters getValue()
+        {
+            return this;
+        }
     }
+
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -326,7 +326,7 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
                 .withTenantPropagationStrategyFrom(serviceIdentifier)
                 .withAdditionalParameters(oAuth2Options.getAdditionalTokenRetrievalParameters())
                 .withTimeLimiter(oAuth2Options.getTimeLimiter())
-                .withTokenCacheConfiguration(oAuth2Options.getTokenCacheConfiguration())
+                .withTokenCacheParameters(oAuth2Options.getTokenCacheParameters())
                 .build();
         return new OAuth2HeaderProvider(oAuth2Service, authHeader);
     }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceBindingDestinationLoader.java
@@ -326,6 +326,7 @@ public class OAuth2ServiceBindingDestinationLoader implements ServiceBindingDest
                 .withTenantPropagationStrategyFrom(serviceIdentifier)
                 .withAdditionalParameters(oAuth2Options.getAdditionalTokenRetrievalParameters())
                 .withTimeLimiter(oAuth2Options.getTimeLimiter())
+                .withTokenCacheConfiguration(oAuth2Options.getTokenCacheConfiguration())
                 .build();
         return new OAuth2HeaderProvider(oAuth2Service, authHeader);
     }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
@@ -25,7 +25,6 @@ import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration.TimeLimiterConfiguration;
 import com.sap.cloud.security.config.ClientCertificate;
 import com.sap.cloud.security.config.CredentialType;
-import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 
 import lombok.RequiredArgsConstructor;
 
@@ -244,21 +243,18 @@ class DefaultOAuth2PropertySupplierTest
 
         sut = new DefaultOAuth2PropertySupplier(options);
 
-        assertThat(sut.getOAuth2Options().getTokenCacheConfiguration())
-            .isSameAs(OAuth2Options.DEFAULT_TOKEN_CACHE_CONFIGURATION);
+        assertThat(sut.getOAuth2Options().getTokenCacheParameters())
+            .isSameAs(OAuth2Options.DEFAULT_TOKEN_CACHE_PARAMETERS);
 
         options =
             ServiceBindingDestinationOptions
                 .forService(binding)
-                .withOption(
-                    OAuth2Options.TokenCacheOption
-                        .of(
-                            TokenCacheConfiguration
-                                .getInstance(Duration.ofSeconds(10), 5, Duration.ofSeconds(1), false)))
+                .withOption(OAuth2Options.TokenCacheParameters.of(Duration.ofSeconds(10), 5, Duration.ofSeconds(1)))
                 .build();
         sut = new DefaultOAuth2PropertySupplier(options);
-        assertThat(sut.getOAuth2Options().getTokenCacheConfiguration())
-            .isEqualTo(TokenCacheConfiguration.getInstance(Duration.ofSeconds(10), 5, Duration.ofSeconds(1), false));
+        assertThat(sut.getOAuth2Options().getTokenCacheParameters())
+            .usingRecursiveComparison()
+            .isEqualTo(OAuth2Options.TokenCacheParameters.of(Duration.ofSeconds(10), 5, Duration.ofSeconds(1)));
     }
 
     @RequiredArgsConstructor

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultOAuth2PropertySupplierTest.java
@@ -25,6 +25,7 @@ import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration.TimeLimiterConfiguration;
 import com.sap.cloud.security.config.ClientCertificate;
 import com.sap.cloud.security.config.CredentialType;
+import com.sap.cloud.security.xsuaa.tokenflows.TokenCacheConfiguration;
 
 import lombok.RequiredArgsConstructor;
 
@@ -232,6 +233,32 @@ class DefaultOAuth2PropertySupplierTest
         sut = new DefaultOAuth2PropertySupplier(options);
         assertThat(sut.getOAuth2Options().getTimeLimiter())
             .isEqualTo(TimeLimiterConfiguration.of(Duration.ofSeconds(100)));
+    }
+
+    @Test
+    void testTokenCacheConfigurationOption()
+    {
+        final ServiceBinding binding =
+            new ServiceBindingBuilder(ServiceIdentifier.DESTINATION).with("name", "asdf").build();
+        ServiceBindingDestinationOptions options = ServiceBindingDestinationOptions.forService(binding).build();
+
+        sut = new DefaultOAuth2PropertySupplier(options);
+
+        assertThat(sut.getOAuth2Options().getTokenCacheConfiguration())
+            .isSameAs(OAuth2Options.DEFAULT_TOKEN_CACHE_CONFIGURATION);
+
+        options =
+            ServiceBindingDestinationOptions
+                .forService(binding)
+                .withOption(
+                    OAuth2Options.TokenCacheOption
+                        .of(
+                            TokenCacheConfiguration
+                                .getInstance(Duration.ofSeconds(10), 5, Duration.ofSeconds(1), false)))
+                .build();
+        sut = new DefaultOAuth2PropertySupplier(options);
+        assertThat(sut.getOAuth2Options().getTokenCacheConfiguration())
+            .isEqualTo(TokenCacheConfiguration.getInstance(Duration.ofSeconds(10), 5, Duration.ofSeconds(1), false));
     }
 
     @RequiredArgsConstructor

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,7 @@
 
 ### ✨ New Functionality
 
-- 
+- Add `TokenCacheParameters` to `OAuth2Options` to configurate token cache duration, expiration delta and cache size.
 
 ### 📈 Improvements
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#[#296](https://github.com/SAP/ai-sdk-java-backlog/issues/296).


Please provide a short description of what your change does and why it is needed.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [ ] Add a new OAuth2Option called TokenCacheParameters that allows to configure token cache duration, expiration delta and cache su

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
