### PR TITLE
fix: Fix `dependency tree` field in bug-report.yml

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.yml
+++ b/.github/ISSUE_TEMPLATE/bug-report.yml
@@ -44,12 +44,13 @@ body:
         - Java and Maven version via `mvn --version`: ...
         - SAP Cloud SDK version: ...
         - Spring Boot or CAP version: ...
-        - <details><summary>Dependency tree via `mvn dependency:tree`</summary>
+        
+        <details><summary>Dependency tree via `mvn dependency:tree`</summary>
             
-            ```
-            Dependency tree here
-            ```
-          </details>
+        ```
+        Dependency tree here
+        ```
+        </details>
     validations:
       required: true
   - type: textarea


### PR DESCRIPTION
## Context

This PR fixes the "Dependency tree via `mvn dependency:tree`" part of the bug-report template.

- related PR for AI SDK: 