### PR TITLE
[BlackDuck] Fix CVE-2024-7254

### DIFF
--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -32,11 +32,6 @@
 		<dependencies>
 			<!-- resolve inconsistent versions coming from spiffe -> io.grpc -->
 			<dependency>
-				<groupId>com.google.protobuf</groupId>
-				<artifactId>protobuf-java</artifactId>
-				<version>3.25.8</version>
-			</dependency>
-			<dependency>
 				<groupId>io.grpc</groupId>
 				<artifactId>grpc-bom</artifactId>
 				<version>1.73.0</version>
@@ -92,6 +87,19 @@
 		<dependency>
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
+			<scope>runtime</scope>
+			<exclusions>
+				<exclusion>
+					<groupId>com.google.protobuf</groupId>
+					<artifactId>protobuf-java</artifactId>
+				</exclusion>
+			</exclusions>
+		</dependency>
+		<!-- Fix CVE-2024-7254 -->
+		<dependency>
+			<groupId>com.google.protobuf</groupId>
+			<artifactId>protobuf-java</artifactId>
+			<version>3.25.8</version>
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>


### PR DESCRIPTION
Blackduck is failing today for dependency `protobuf-java`.
https://github.com/SAP/cloud-sdk-java/actions/runs/16661849685/job/47180048733

* We are using fixed version in `connectivity-ztis` with `3.25.8:runtime`.
* Maven detects flawed version in `connectivity-oauth` with `3.25.5:runtime (optional)`

See more available versions and their vulnerabilities here:
https://mvnrepository.com/artifact/com.google.protobuf/protobuf-java?p=3

The problem was identified today.
The symptom can be found in older versions.

Options:
1️⃣ We ignore the BlackDuck finding, mark it as false-positive (is it?)
2️⃣ We change from implicit `<dependencyManagement>` to explicit `<dependency>` (+ exclusion)