### PR TITLE
[PoC] [Option 1] Destination Service V2 API Support

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -130,7 +130,7 @@ public class DestinationService implements DestinationLoader
     {
         final String servicePath = PATH_DEFAULT + destName;
         final Function<DestinationRetrievalStrategy, DestinationServiceV1Response> destinationRetriever =
-            strategy -> resilientCall(() -> retrieveDestination(strategy, servicePath), singleDestResilience);
+            strategy -> resilientCall(() -> retrieveDestination(strategy, servicePath, options), singleDestResilience);
 
         final DestinationRetrievalStrategyResolver destinationRetrievalStrategyResolver =
             DestinationRetrievalStrategyResolver
@@ -145,7 +145,16 @@ public class DestinationService implements DestinationLoader
     DestinationServiceV1Response
         retrieveDestination( final DestinationRetrievalStrategy strategy, final String servicePath )
     {
-        final String response = adapter.getConfigurationAsJson(servicePath, strategy);
+        return retrieveDestination(strategy, servicePath, DestinationOptions.builder().build());
+    }
+
+    @Nonnull
+    DestinationServiceV1Response retrieveDestination(
+        final DestinationRetrievalStrategy strategy,
+        final String servicePath,
+        final DestinationOptions options )
+    {
+        final String response = adapter.getConfigurationAsJson(servicePath, strategy, options);
 
         return deserializeDestinationResponse(response);
     }

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapter.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceAdapter.java
@@ -120,13 +120,24 @@ class DestinationServiceAdapter
         throws DestinationAccessException,
             DestinationNotFoundException
     {
+        return getConfigurationAsJson(servicePath, strategy, DestinationOptions.builder().build());
+    }
+
+    @Nonnull
+    String getConfigurationAsJson(
+        @Nonnull final String servicePath,
+        @Nonnull final DestinationRetrievalStrategy strategy,
+        @Nonnull final DestinationOptions options )
+        throws DestinationAccessException,
+            DestinationNotFoundException
+    {
         final HttpDestination serviceDestination =
             Objects
                 .requireNonNull(
                     serviceDestinationLoader.apply(strategy.behalf()),
                     () -> "Destination for Destination Service on behalf of " + strategy.behalf() + " not found.");
 
-        final HttpUriRequest request = prepareRequest(servicePath, strategy);
+        final HttpUriRequest request = prepareRequest(servicePath, strategy, options);
 
         final HttpResponse response;
         try {
@@ -174,9 +185,20 @@ class DestinationServiceAdapter
 
     private HttpUriRequest prepareRequest( final String servicePath, final DestinationRetrievalStrategy strategy )
     {
+        return prepareRequest(servicePath, strategy, DestinationOptions.builder().build());
+    }
+
+    private HttpUriRequest prepareRequest(
+        final String servicePath,
+        final DestinationRetrievalStrategy strategy,
+        final DestinationOptions options )
+    {
+        final String apiVersion = DestinationServiceOptionsAugmenter.getApiVersion(options).getOrElse("v1");
+        final String basePath = "destination-configuration/" + apiVersion;
+
         final URI requestUri;
         try {
-            requestUri = new URI(SERVICE_PATH + servicePath);
+            requestUri = new URI(basePath + servicePath);
         }
         catch( final URISyntaxException e ) {
             throw new DestinationAccessException(e);

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceOptionsAugmenter.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceOptionsAugmenter.java
@@ -20,6 +20,7 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
     static final String DESTINATION_TOKEN_EXCHANGE_STRATEGY_KEY = "scp.cf.destinationTokenExchangeStrategy";
     static final String X_REFRESH_TOKEN_KEY = "x-refresh-token";
     static final String X_FRAGMENT_KEY = "X-fragment-name";
+    static final String DESTINATION_SERVICE_API_VERSION_KEY = "scp.cf.destinationServiceApiVersion";
 
     private final Map<String, Object> parameters = new HashMap<>();
 
@@ -105,6 +106,22 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
         return this;
     }
 
+    /**
+     * Sets the API version to use when calling the destination service. This allows opting into newer API versions. If
+     * not set, the default API version (v1) will be used.
+     *
+     * @param apiVersion
+     *            The API version to use (e.g., "v1", "v2").
+     * @return The same augmenter that called this method.
+     * @since 5.22.0
+     */
+    @Nonnull
+    public DestinationServiceOptionsAugmenter apiVersion( @Nonnull final String apiVersion )
+    {
+        parameters.put(DESTINATION_SERVICE_API_VERSION_KEY, apiVersion);
+        return this;
+    }
+
     @Override
     public void augmentBuilder( @Nonnull final DestinationOptions.Builder builder )
     {
@@ -169,5 +186,23 @@ public class DestinationServiceOptionsAugmenter implements DestinationOptionsAug
     static Option<String> getFragmentName( @Nonnull final DestinationOptions options )
     {
         return options.get(X_FRAGMENT_KEY).filter(String.class::isInstance).map(String.class::cast);
+    }
+
+    /**
+     * Retrieves the configured API version to use when calling the destination service.
+     *
+     * @param options
+     *            The destination options instance that stores the key/value pair.
+     * @return An {@link Option} wrapping the API version if the parameter is present, otherwise a
+     *         {@link io.vavr.control.Option.None}.
+     * @since 5.22.0
+     */
+    @Nonnull
+    static Option<String> getApiVersion( @Nonnull final DestinationOptions options )
+    {
+        return options
+            .get(DESTINATION_SERVICE_API_VERSION_KEY)
+            .filter(String.class::isInstance)
+            .map(String.class::cast);
     }
 }

--- a/release_notes.md
+++ b/release_notes.md
@@ -12,7 +12,17 @@
 
 ### ✨ New Functionality
 
-- 
+- **Destination Service API Version Support**: Added support for specifying the API version when calling the destination service. Users can now opt into newer API versions (e.g., v2) by using the new `apiVersion()` method on `DestinationServiceOptionsAugmenter`. If not specified, the default API version (v1) is used, ensuring backward compatibility.
+
+  Example usage:
+  ```java
+  // Use the new v2 API
+  DestinationOptions options = DestinationOptions.builder()
+      .augmentBuilder(DestinationServiceOptionsAugmenter.augmenter().apiVersion("v2"))
+      .build();
+  
+  Destination destination = DestinationAccessor.getDestination("my-destination", options);
+  ```
 
 ### 📈 Improvements
 
@@ -20,4 +30,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+-


### PR DESCRIPTION
## Context

SAP/ai-sdk-java-backlog#304.

### API Proposal

New option under `DestinationOptions`.

* (+) Not very prominent
* (+/-) Can / have to set the API version per-request
* (-) Complex implementation

### Other Options 

* `DestinationService.builder().withExperimentalApiVersion2()` or similar
* `static DestinationService.setApiVersion2()` or similar

## Definition of Done


- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

