### PR TITLE
fix: Handle incompatible license in dependencies

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -36,6 +36,15 @@ updates:
       - dependency-name: 'com.github.ekryd.sortpom:sortpom-maven-plugin'
       # used by deprecated code only, not worth updating for now
       - dependency-name: 'org.apache.axis2:*'
+      # Ignore problematic license versions
+      - dependency-name: 'com.sap.cloud.security:java-security'
+        versions: ['3.6.1', '3.6.2']
+      - dependency-name: 'com.sap.cloud.security.xsuaa:token-client'
+        versions: ['3.6.1', '3.6.2']
+      - dependency-name: 'com.sap.cloud.security:java-api'
+        versions: ['3.6.1', '3.6.2']
+      - dependency-name: 'com.sap.cloud.security:env'
+        versions: ['3.6.1', '3.6.2']
 
   # archetype updates
   # Dependabot seems to be unable to handle those, so this is disabled for now

--- a/dependency-bundles/bom/pom.xml
+++ b/dependency-bundles/bom/pom.xml
@@ -51,7 +51,7 @@
 		<!-- XSUAA -->
 		<!-- Keep this version consistent with the one from the SAP Java Buildpack (after their 2.0 release) -->
 		<!-- see https://github.wdf.sap.corp/xs2-java/xs-java-buildpack/blob/master/resources/pom.xml -->
-		<scp-cf.xsuaa-client.version>3.6.1</scp-cf.xsuaa-client.version>
+		<scp-cf.xsuaa-client.version>3.6.0</scp-cf.xsuaa-client.version>
 		<java-jwt.version>4.5.0</java-jwt.version>
 		<!-- Utility stuff -->
 		<slf4j.version>2.0.17</slf4j.version>


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#ISSUENUMBER.

Blackduck scan failed because of dependencies under namespace com.sap.cloud.security had (an unintended) license update.
As per maven central, the licenses changed from The Apache Software License (v3.6.0) -> SAP DEVELOPER LICENSE AGREEMENT (v3.6.1) ([check here](https://central.sonatype.com/artifact/com.sap.cloud.security/java-security/3.6.0))

BlackDuck does not recognise the new license and categorizes it as Basic Proprietary Commercial License.

The following 4 dependencies are affected.
1. [com.sap.cloud.security:java-security:3.6.1](https://sap.blackducksoftware.com/api/components/3950bb81-936d-444a-8dc8-0bfb3878b422)
2. [com.sap.cloud.security.xsuaa:token-client:3.6.1](https://sap.blackducksoftware.com/api/components/7112f084-38d8-49ce-9271-f8e90f001c03/versions/af71f662-8e3e-490f-aa3f-fa297c82d380)
3. [com.sap.cloud.security:java-api:3.6.1](https://sap.blackducksoftware.com/api/components/9d737faf-6e54-4286-9b11-12bb96faca53/versions/8d2aa36c-f465-475f-a8f7-864c8b1642d4)
4. [com.sap.cloud.security:env:3.6.1](https://sap.blackducksoftware.com/api/components/87cf1ec4-dab9-43c0-842f-72ee7c727069/versions/d19828fa-c7e7-481f-b2db-d539a6bd0c4b)

**Additionally, v3.6.2 is also affected.**

### Feature scope:

- Pin the version to 3.6.0
- Ignore dependabot action for affected version 3.6.1 and 3.6.2

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [ ] ~Functionality scope stated & covered~
- [ ] ~Tests cover the scope above~
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
