### PR TITLE
fix: Revert Javadoc Plugin back to 3.11.2

### DIFF
--- a/dependency-bundles/bom/pom.xml
+++ b/dependency-bundles/bom/pom.xml
@@ -339,7 +339,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>3.11.3</version>
+							<version>3.11.2</version>
 							<executions>
 								<execution>
 									<id>javadoc-jar</id>

--- a/dependency-bundles/modules-bom/pom.xml
+++ b/dependency-bundles/modules-bom/pom.xml
@@ -272,7 +272,7 @@
 						<plugin>
 							<groupId>org.apache.maven.plugins</groupId>
 							<artifactId>maven-javadoc-plugin</artifactId>
-							<version>3.11.3</version>
+							<version>3.11.2</version>
 							<executions>
 								<execution>
 									<id>javadoc-jar</id>

--- a/pom.xml
+++ b/pom.xml
@@ -514,7 +514,7 @@
 				<plugin>
 					<groupId>org.apache.maven.plugins</groupId>
 					<artifactId>maven-javadoc-plugin</artifactId>
-					<version>3.11.3</version>
+					<version>3.11.2</version>
 				</plugin>
 				<plugin>
 					<groupId>com.sap.cloud.sdk.datamodel</groupId>


### PR DESCRIPTION
## Context

Version `3.11.3` of the `maven-javadoc-plugin` seems to cause issues with our release process (see failed run [here](https://github.com/SAP/cloud-sdk-java/actions/runs/17299953885/job/49108138176#step:6:2064)). This PR reverts the version back to `3.11.2` again.