### PR TITLE
chore: Resolve `protobuf-java` transitive dependency convergence

### DIFF
--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -88,19 +88,6 @@
 			<groupId>io.grpc</groupId>
 			<artifactId>grpc-protobuf</artifactId>
 			<scope>runtime</scope>
-			<exclusions>
-				<exclusion>
-					<groupId>com.google.protobuf</groupId>
-					<artifactId>protobuf-java</artifactId>
-				</exclusion>
-			</exclusions>
-		</dependency>
-		<!-- Fix CVE-2024-7254 -->
-		<dependency>
-			<groupId>com.google.protobuf</groupId>
-			<artifactId>protobuf-java</artifactId>
-			<version>3.25.8</version>
-			<scope>runtime</scope>
 		</dependency>
 		<dependency>
 			<groupId>io.grpc</groupId>


### PR DESCRIPTION
Current version of `grpc-protobuf:1.75.0` depends on "fixed" version `protobuf-java:3.25.8`.
We do not need the explicit version fix anymore.

Related:
* https://github.com/SAP/cloud-sdk-java/pull/874
* https://mvnrepository.com/artifact/io.grpc/grpc-protobuf/1.75.0
* [BlackDuck: protobuf-java:3.25.8](https://sap.blackducksoftware.com/api/components/e896bf6b-61ee-4ef6-bd8a-c034d78986b7/versions/90871567-d55b-4507-932a-5395a488f05e)
* [BlackDuck: protobuf-java:3.25.5](https://sap.blackducksoftware.com/api/components/e896bf6b-61ee-4ef6-bd8a-c034d78986b7/versions/fc2424c6-5aba-4d16-a6db-d977fc96deaa)