### PR TITLE
fix: CircuitBreaker stack-trace

### DIFF
--- a/cloudplatform/connectivity-destination-service/pom.xml
+++ b/cloudplatform/connectivity-destination-service/pom.xml
@@ -205,6 +205,11 @@
 			<artifactId>java-sap-vcap-services</artifactId>
 			<scope>test</scope>
 		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-circuitbreaker</artifactId>
+			<scope>test</scope>
+		</dependency>
 	</dependencies>
 	<build>
 		<plugins>

--- a/cloudplatform/resilience4j/pom.xml
+++ b/cloudplatform/resilience4j/pom.xml
@@ -64,6 +64,10 @@
 		</dependency>
 		<dependency>
 			<groupId>io.github.resilience4j</groupId>
+			<artifactId>resilience4j-core</artifactId>
+		</dependency>
+		<dependency>
+			<groupId>io.github.resilience4j</groupId>
 			<artifactId>resilience4j-circuitbreaker</artifactId>
 		</dependency>
 		<dependency>

--- a/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/DefaultCircuitBreakerProvider.java
+++ b/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/DefaultCircuitBreakerProvider.java
@@ -66,6 +66,7 @@ public class DefaultCircuitBreakerProvider implements CircuitBreakerProvider, Ge
         return circuitBreaker;
     }
 
+    @SuppressWarnings( "PMD.PreserveStackTrace" ) // The circuit breaker stack-trace doesn't contain any info
     @Nonnull
     @Override
     public <T> Callable<T> decorateCallable(

--- a/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/Resilience4jDecorationStrategy.java
+++ b/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/Resilience4jDecorationStrategy.java
@@ -188,6 +188,9 @@ public class Resilience4jDecorationStrategy implements ResilienceDecorationStrat
                 callableResult = callableResult.recover(fallbackFunction);
             }
             return callableResult.onFailure(t -> {
+                if( t instanceof ResilienceRuntimeException e ) {
+                    throw e;
+                }
                 throw new ResilienceRuntimeException(t);
             }).get();
         };

--- a/cloudplatform/resilience4j/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience4j/CircuitBreakerTest.java
+++ b/cloudplatform/resilience4j/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience4j/CircuitBreakerTest.java
@@ -19,8 +19,8 @@ import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceConfiguration.CircuitBreakerConfiguration;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceDecorator;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceRuntimeException;
+import com.sap.cloud.sdk.cloudplatform.thread.exception.ThreadContextExecutionException;
 
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 
@@ -78,7 +78,10 @@ class CircuitBreakerTest
 
         assertThatThrownBy(wrappedCallable::call)
             .isExactlyInstanceOf(ResilienceRuntimeException.class)
-            .hasCauseExactlyInstanceOf(CallNotPermittedException.class);
+            .hasCauseExactlyInstanceOf(ThreadContextExecutionException.class)
+            .hasRootCauseExactlyInstanceOf(Exception.class)
+            .hasMessage(
+                "com.sap.cloud.sdk.cloudplatform.thread.exception.ThreadContextExecutionException: java.lang.Exception: Simulated failure, attempt nr: 3");
 
         verify(callable, times(circuitBreakerConfiguration.closedBufferSize())).call();
     }

--- a/cloudplatform/resilience4j/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience4j/RetryTest.java
+++ b/cloudplatform/resilience4j/src/test/java/com/sap/cloud/sdk/cloudplatform/resilience4j/RetryTest.java
@@ -26,8 +26,6 @@ import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceDecorator;
 import com.sap.cloud.sdk.cloudplatform.resilience.ResilienceRuntimeException;
 import com.sap.cloud.sdk.cloudplatform.thread.exception.ThreadContextExecutionException;
 
-import io.github.resilience4j.circuitbreaker.CallNotPermittedException;
-
 class RetryTest
 {
     @Test
@@ -169,7 +167,7 @@ class RetryTest
 
         assertThatThrownBy(wrappedCallable::call)
             .isExactlyInstanceOf(ResilienceRuntimeException.class)
-            .hasCauseExactlyInstanceOf(CallNotPermittedException.class);
+            .hasCauseExactlyInstanceOf(ThreadContextExecutionException.class);
         verify(callable, times(circuitBreakerClosedBuffer)).call();
     }
 

--- a/dependency-bundles/bom/pom.xml
+++ b/dependency-bundles/bom/pom.xml
@@ -236,6 +236,11 @@
 			</dependency>
 			<dependency>
 				<groupId>io.github.resilience4j</groupId>
+				<artifactId>resilience4j-core</artifactId>
+				<version>${resilience4j.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.github.resilience4j</groupId>
 				<artifactId>resilience4j-circuitbreaker</artifactId>
 				<version>${resilience4j.version}</version>
 			</dependency>

--- a/release_notes.md
+++ b/release_notes.md
@@ -18,7 +18,7 @@
 
 ### 📈 Improvements
 
-- 
+- Circuit breaker exceptions `CallNotPermittedException` have been replaced in favor of the previously thrown exception to provide more context on the failure.
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#476.


- previously: `CircuitBreaker is OPEN and does not permit further calls`
- now: `Failed to get destination ... Caused by: Destination could not be found for path destination-configuration/v1/destinations/xxxx.`


### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Restored stack-trace for circuit breaker exception

⚠️ Note that there is a bug in the circuit breaker. **All destination calls use the same circuit breaker.**
## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
