### PR TITLE
feature: HttpClient health-check in default cache implementation

### DIFF
--- a/cloudplatform/connectivity-apache-httpclient4/pom.xml
+++ b/cloudplatform/connectivity-apache-httpclient4/pom.xml
@@ -96,6 +96,10 @@
 				</exclusion>
 			</exclusions>
 		</dependency>
+		<dependency>
+			<groupId>org.apache.commons</groupId>
+			<artifactId>commons-lang3</artifactId>
+		</dependency>
 		<!-- scope "provided" -->
 		<dependency>
 			<groupId>org.projectlombok</groupId>

--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
@@ -6,7 +6,11 @@ import java.util.function.Supplier;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
+import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.http.client.HttpClient;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
+import org.apache.http.pool.AbstractConnPool;
 
 import com.github.benmanes.caffeine.cache.Cache;
 import com.sap.cloud.sdk.cloudplatform.cache.CacheKey;
@@ -14,6 +18,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstanti
 
 import io.vavr.control.Try;
 import lombok.extern.slf4j.Slf4j;
+import lombok.val;
 
 /**
  * Provides caching functionality to the {@code HttpClientAccessor}.
@@ -89,9 +94,16 @@ public abstract class AbstractHttpClientCache implements HttpClientCache
         final Cache<CacheKey, HttpClient> cache = maybeCache.get();
         final CacheKey cacheKey = maybeKey.get();
 
-        final HttpClient httpClient;
+        HttpClient httpClient;
         try {
             httpClient = cache.get(cacheKey, anyKey -> createHttpClient.get());
+
+            if( !isHealthy(httpClient) ) {
+                log.warn("The HttpClient retrieved from the cache has a shutdown connection pool.");
+                cache.invalidate(cacheKey);
+                httpClient = cache.get(cacheKey, anyKey -> createHttpClient.get());
+            }
+
             Objects
                 .requireNonNull(
                     httpClient,
@@ -107,6 +119,22 @@ public abstract class AbstractHttpClientCache implements HttpClientCache
             return Try.success(((HttpClientWrapper) httpClient).withDestination(destination));
         }
         return Try.success(httpClient);
+    }
+
+    private static boolean isHealthy( final HttpClient httpClient )
+        throws IllegalArgumentException,
+            NullPointerException
+    {
+        try {
+            val hc = (CloseableHttpClient) FieldUtils.readField(httpClient, "httpClient", true);
+            val cm = (PoolingHttpClientConnectionManager) FieldUtils.readField(hc, "connManager", true);
+            val cp = (AbstractConnPool<?, ?, ?>) FieldUtils.readField(cm, "pool", true);
+            return !cp.isShutdown();
+        }
+        catch( final Exception e ) {
+            log.warn("Failed to access connection manager.", e);
+            return true;
+        }
     }
 
     /**

--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
@@ -125,6 +125,10 @@ public abstract class AbstractHttpClientCache implements HttpClientCache
         throws IllegalArgumentException,
             NullPointerException
     {
+        if( !(httpClient instanceof HttpClientWrapper) ) {
+            log.trace("Cannot verify health of HttpClient: {}", httpClient);
+            return true;
+        }
         try {
             val hc = (CloseableHttpClient) FieldUtils.readField(httpClient, "httpClient", true);
             val cm = (PoolingHttpClientConnectionManager) FieldUtils.readField(hc, "connManager", true);

--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
@@ -121,6 +121,7 @@ public abstract class AbstractHttpClientCache implements HttpClientCache
         return Try.success(httpClient);
     }
 
+    @SuppressWarnings( "PMD.CloseResource" ) // no new resource is opened
     private static boolean isHealthy( final HttpClient httpClient )
         throws IllegalArgumentException,
             NullPointerException

--- a/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCacheTest.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCacheTest.java
@@ -1,0 +1,38 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import org.apache.http.client.methods.HttpHead;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.junit.jupiter.api.Test;
+
+import lombok.SneakyThrows;
+import lombok.val;
+
+public class AbstractHttpClientCacheTest
+{
+    @SneakyThrows
+    @Test
+    void testClosedPool()
+    {
+        val d = DefaultHttpDestination.builder("https://sap.com").build();
+
+        val httpClient1 = HttpClientAccessor.getHttpClient(d);
+        httpClient1.execute(new HttpHead());
+        httpClient1.execute(new HttpHead());
+
+        ((CloseableHttpClient) httpClient1).close();
+        assertThatThrownBy(() -> httpClient1.execute(new HttpHead()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Connection pool shut down");
+        assertThatThrownBy(() -> httpClient1.execute(new HttpHead()))
+            .isInstanceOf(IllegalStateException.class)
+            .hasMessage("Connection pool shut down");
+
+        val httpClient2 = HttpClientAccessor.getHttpClient(d);
+        assertThat(httpClient1).isNotSameAs(httpClient2);
+        httpClient2.execute(new HttpHead());
+        httpClient2.execute(new HttpHead());
+    }
+}


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Related issue
https://github.com/SAP/cloud-sdk-java/issues/970

Adding a health check that uses reflection to check boolean flag on connection pool whether it's shutdown or not.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [ ] Confirmed to be working by user
- [ ] No unexpected behavior change from E2E tests, etc.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
