### PR TITLE
feat: support provider:client for IAS app-to-app

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -222,7 +222,9 @@ public final class BtpServiceOptions
          * @return An instance of {@link OptionsEnhancer} that will lead to the given application provider being used
          *         when retrieving an authentication token from the IAS service.
          *
-         * @see <a href="https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming APIs from Other Applications</a>
+         * @see <a href=
+         *      "https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming
+         *      APIs from Other Applications</a>
          */
         @Nonnull
         public static OptionsEnhancer<?> withApplicationName( @Nonnull final String applicationName )
@@ -231,8 +233,8 @@ public final class BtpServiceOptions
         }
 
         /**
-         * Creates an {@link OptionsEnhancer} that instructs an IAS-based destination to use the given provider client ID
-         * when performing token retrievals. This is needed in <b>App-To-App</b> communication scenarios.
+         * Creates an {@link OptionsEnhancer} that instructs an IAS-based destination to use the given provider client
+         * ID when performing token retrievals. This is needed in <b>App-To-App</b> communication scenarios.
          * <p>
          * <b>Hint:</b> This option is <b>mutually exclusive</b> with {@link #withConsumerClient(String)}.
          *
@@ -241,7 +243,9 @@ public final class BtpServiceOptions
          * @return An instance of {@link OptionsEnhancer} that will lead to the given application provider being used
          *         when retrieving an authentication token from the IAS service.
          *
-         * @see <a href="https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming APIs from Other Applications</a>
+         * @see <a href=
+         *      "https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming
+         *      APIs from Other Applications</a>
          */
         @Nonnull
         public static OptionsEnhancer<?> withProviderClient( @Nonnull final String providerClientId )
@@ -250,9 +254,10 @@ public final class BtpServiceOptions
         }
 
         /**
-         * Creates an {@link OptionsEnhancer} that instructs an IAS-based destination to use the given provider client ID
-         * and provider tenant ID when performing token retrievals. This is needed in <b>App-To-App</b> communication scenarios
-         * when having dependencies to <i>different tenants</i> of the <i>same, multi-tenant</i> provider application (fan-out / 1-N).
+         * Creates an {@link OptionsEnhancer} that instructs an IAS-based destination to use the given provider client
+         * ID and provider tenant ID when performing token retrievals. This is needed in <b>App-To-App</b> communication
+         * scenarios when having dependencies to <i>different tenants</i> of the <i>same, multi-tenant</i> provider
+         * application (fan-out / 1-N).
          * <p>
          * <b>Hint:</b> This option is <b>mutually exclusive</b> with {@link #withConsumerClient(String)}
          *
@@ -263,10 +268,14 @@ public final class BtpServiceOptions
          * @return An instance of {@link OptionsEnhancer} that will lead to the given application provider being used
          *         when retrieving an authentication token from the IAS service.
          *
-         * @see <a href="https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming APIs from Other Applications</a>
+         * @see <a href=
+         *      "https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/consume-apis-from-other-applications?locale=en-US">Consuming
+         *      APIs from Other Applications</a>
          */
         @Nonnull
-        public static OptionsEnhancer<?> withProviderClient( @Nonnull final String providerClientId, @Nonnull final String providerTenantId )
+        public static
+            OptionsEnhancer<?>
+            withProviderClient( @Nonnull final String providerClientId, @Nonnull final String providerTenantId )
         {
             return new IasCommunicationOptions(null, providerClientId, providerTenantId, null, null);
         }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -210,10 +210,10 @@ class BtpServicePropertySuppliers
                 return;
             }
 
-            if (o.getProviderClientId() != null) {
-                String resource = "urn:sap:identity:application:provider:clientid:" +  o.getProviderClientId();
-                if (o.getProviderTenantId() != null) {
-                    resource += ":apptid:" +  o.getProviderTenantId();
+            if( o.getProviderClientId() != null ) {
+                String resource = "urn:sap:identity:application:provider:clientid:" + o.getProviderClientId();
+                if( o.getProviderTenantId() != null ) {
+                    resource += ":apptid:" + o.getProviderTenantId();
                 }
                 optionsBuilder.withTokenRetrievalParameter("resource", resource);
                 return;

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -594,10 +594,10 @@ class BtpServicePropertySuppliersTest
         {
             @SuppressWarnings( "deprecation" )
             final ServiceBindingDestinationOptions options =
-                    ServiceBindingDestinationOptions
-                            .forService(BINDING)
-                            .withOption(IasOptions.withProviderClient("provider-client-id"))
-                            .build();
+                ServiceBindingDestinationOptions
+                    .forService(BINDING)
+                    .withOption(IasOptions.withProviderClient("provider-client-id"))
+                    .build();
 
             final OAuth2PropertySupplier sut = IDENTITY_AUTHENTICATION.resolve(options);
 
@@ -610,13 +610,13 @@ class BtpServicePropertySuppliersTest
             assertThat(oAuth2Options.getClientKeyStore()).isNotNull();
             assertThatClientCertificateIsContained(oAuth2Options.getClientKeyStore());
             assertThat(oAuth2Options.getAdditionalTokenRetrievalParameters())
-                    .containsExactlyInAnyOrderEntriesOf(
-                            Map
-                                    .of(
-                                            "resource",
-                                            "urn:sap:identity:application:provider:clientid:provider-client-id",
-                                            "app_tid",
-                                            PROVIDER_TENANT_ID));
+                .containsExactlyInAnyOrderEntriesOf(
+                    Map
+                        .of(
+                            "resource",
+                            "urn:sap:identity:application:provider:clientid:provider-client-id",
+                            "app_tid",
+                            PROVIDER_TENANT_ID));
         }
 
         @Test
@@ -624,10 +624,10 @@ class BtpServicePropertySuppliersTest
         {
             @SuppressWarnings( "deprecation" )
             final ServiceBindingDestinationOptions options =
-                    ServiceBindingDestinationOptions
-                            .forService(BINDING)
-                            .withOption(IasOptions.withProviderClient("provider-client-id", "provider-tenant-id"))
-                            .build();
+                ServiceBindingDestinationOptions
+                    .forService(BINDING)
+                    .withOption(IasOptions.withProviderClient("provider-client-id", "provider-tenant-id"))
+                    .build();
 
             final OAuth2PropertySupplier sut = IDENTITY_AUTHENTICATION.resolve(options);
 
@@ -640,13 +640,13 @@ class BtpServicePropertySuppliersTest
             assertThat(oAuth2Options.getClientKeyStore()).isNotNull();
             assertThatClientCertificateIsContained(oAuth2Options.getClientKeyStore());
             assertThat(oAuth2Options.getAdditionalTokenRetrievalParameters())
-                    .containsExactlyInAnyOrderEntriesOf(
-                            Map
-                                    .of(
-                                            "resource",
-                                            "urn:sap:identity:application:provider:clientid:provider-client-id:apptid:provider-tenant-id",
-                                            "app_tid",
-                                            PROVIDER_TENANT_ID));
+                .containsExactlyInAnyOrderEntriesOf(
+                    Map
+                        .of(
+                            "resource",
+                            "urn:sap:identity:application:provider:clientid:provider-client-id:apptid:provider-tenant-id",
+                            "app_tid",
+                            PROVIDER_TENANT_ID));
         }
 
         @AllArgsConstructor


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#ISSUENUMBER.

Add support for the `resource=urn:sap:identity:application:provider:clientid:` resource definition for app2app token requests to reduce the number of required tokens from one per app2app "Dependency Name" to one per provider application

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Add support for `resource=urn:sap:identity:application:provider:clientid:<client-id-provider>:apptid:<tenant-id-provider>` for app2app token reuests - ref [Exposing APIs (SAP-internal)](https://github.wdf.sap.corp/pages/CPSecurity/sci-dev-guide/docs/Authentication/Exposing-APIs#consumer-consuming-apis)

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [x] Documentation updated
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
