### PR TITLE
chore: Remove buildpacks declaration from archetype

### DIFF
--- a/archetypes/spring-boot3/src/main/resources/archetype-resources/manifest.yml
+++ b/archetypes/spring-boot3/src/main/resources/archetype-resources/manifest.yml
@@ -6,8 +6,6 @@ applications:
   timeout: 300
   random-route: true
   path: application/target/${artifactId}-application.jar
-  buildpacks:
-    - sap_java_buildpack
   env:
     TARGET_RUNTIME: main
     SPRING_PROFILES_ACTIVE: 'cloud'


### PR DESCRIPTION
Related:
https://github.com/SAP/cloud-sdk-java/pull/987

We do not need SAP Java Buildpack, and certainly don't want to advertise.