### PR TITLE
feat: Offer `CircuitBreakerConfiguration` in DestinationService DestinationLoader builder

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -919,6 +919,8 @@ public class DestinationService implements DestinationLoader
         @Nullable
         private TimeLimiterConfiguration timeLimiterConfiguration = null;
         @Nullable
+        private CircuitBreakerConfiguration circuitBreakerConfiguration = null;
+        @Nullable
         private String providerTenantId;
 
         /**
@@ -935,6 +937,23 @@ public class DestinationService implements DestinationLoader
         public Builder withTimeLimiterConfiguration( @Nonnull final TimeLimiterConfiguration timeLimiterConfiguration )
         {
             this.timeLimiterConfiguration = timeLimiterConfiguration;
+            return this;
+        }
+
+        /**
+         * Create instance applying the given circuit breaker when retrieving destinations.
+         *
+         * @param circuitBreakerConfiguration
+         *            The circuit-breaker configuration to be applied for the request. Use
+         *            {@code TimeLimiterConfiguration.disabled()} to diable the circuit-breaker.
+         * @return The builder itself.
+         * @since 5.25.0
+         */
+        @Nonnull
+        public Builder withCircuitBreakerConfiguration(
+            @Nonnull final CircuitBreakerConfiguration circuitBreakerConfiguration )
+        {
+            this.circuitBreakerConfiguration = circuitBreakerConfiguration;
             return this;
         }
 
@@ -956,10 +975,12 @@ public class DestinationService implements DestinationLoader
         {
             final TimeLimiterConfiguration timeLimiter =
                 timeLimiterConfiguration != null ? timeLimiterConfiguration : DEFAULT_TIME_LIMITER;
+            final CircuitBreakerConfiguration circuitBreaker =
+                circuitBreakerConfiguration != null ? circuitBreakerConfiguration : DEFAULT_SINGLE_DEST_CIRCUIT_BREAKER;
             return new DestinationService(
                 new DestinationServiceAdapter(null, null, providerTenantId),
-                createResilienceConfiguration("singleDestResilience", timeLimiter, DEFAULT_SINGLE_DEST_CIRCUIT_BREAKER),
-                createResilienceConfiguration("allDestResilience", timeLimiter, DEFAULT_ALL_DEST_CIRCUIT_BREAKER));
+                createResilienceConfiguration("singleDestResilience", timeLimiter, circuitBreaker),
+                createResilienceConfiguration("allDestResilience", timeLimiter, circuitBreaker));
         }
     }
 }


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

Related
* https://github.com/SAP/cloud-sdk-java-backlog/issues/495


A property in builder could offer the option to disable circuit-breaker altogether.

This has the benefit that we do not change default behavior.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [ ] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
