### PR TITLE
fix: Fix preLookup check by correctly propagating destination options

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -390,8 +390,8 @@ public class DestinationService implements DestinationLoader
 
     private boolean preLookupCheckSuccessful( final String destinationName, final DestinationOptions options )
     {
-          return new ArrayList<>(
-              Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get())
+        return new ArrayList<>(
+            Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get())
             .stream()
             .anyMatch(properties -> properties.get(DestinationProperty.NAME).contains(destinationName));
     }

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -120,7 +120,7 @@ public class DestinationService implements DestinationLoader
         Try<Destination>
         tryGetDestination( @Nonnull final String destinationName, @Nonnull final DestinationOptions options )
     {
-        if( Cache.preLookupCheckEnabled && !preLookupCheckSuccessful(destinationName) ) {
+        if( Cache.preLookupCheckEnabled && !preLookupCheckSuccessful(destinationName, options) ) {
             final String msg = "Destination %s was not found among the destinations of the current tenant.";
             return Try.failure(new DestinationNotFoundException(String.format(msg, destinationName)));
         }
@@ -388,9 +388,10 @@ public class DestinationService implements DestinationLoader
         return ExceptionUtils.getThrowableList(t).stream().map(Throwable::getClass).anyMatch(cls::isAssignableFrom);
     }
 
-    private boolean preLookupCheckSuccessful( final String destinationName )
+    private boolean preLookupCheckSuccessful( final String destinationName, final DestinationOptions options )
     {
-        return getAllDestinationProperties()
+          return new ArrayList<>(
+              Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get())
             .stream()
             .anyMatch(properties -> properties.get(DestinationProperty.NAME).contains(destinationName));
     }


### PR DESCRIPTION
## Context

This PR fixes a problem with the new PreLookup check. The issue was that the destination options (more precisely, the retrieval strategy) was not used when performing the call to get all destinations. This led to situations where some destinations where not correctly found. To fix this, these options are now propagated to the getAllDestinations call.

### Important Note 
During investigation of this issue we realised that the caching logic of the `GetOrComputeAllDestinationsCommand` class has a flaw: In `GetOrComputeAllDestinationsCommand`, cache keys are build from the entire `DestinationOptions` object. These options might very well contain information that is irrelevant for the call to get all destinations. This will lead to (potentially many) unnecessary HTTP calls due to over-eager cache isolation. 
(This was most-probably also already an issue before the addition of the PreLookup check: When change detection was enabled and `DestinationService.tryGetDestination` was called, we also invoke `GetOrComputeAllDestinationsCommand` which then uses an unnecessarily struct cache. But in that case the outcome is merely an unnecessary cache-miss, which is probably why we did not notice it before.)

**Example**
Assume there are 2 different destinations, dest1 and dest2, with the same destination options, but the options of dest1 include a custom header that is only relevant for getting this single destination. If we now call `tryGetDestination(dest1, options1)` and afterwards `tryGetDestination(dest2, options2)`, the invocation of `getOrComputeAllDestinations` in `preLookupCheckSuccessful` in the second call will not hit the cache as the cache key build from `options2` differs from the one from `options1`.

There is [a second PR](https://github.com/SAP/cloud-sdk-java/pull/1038) to solve this problem by adapting the caching logic in `GetOrComputeAllDestinationsCommand` to only use the relevant retrieval strategy as cache key.
