### PR TITLE
fix: Improve caching logic in `GetOrComputeAllDestinationsCommand`

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -390,8 +390,7 @@ public class DestinationService implements DestinationLoader
 
     private boolean preLookupCheckSuccessful( final String destinationName, final DestinationOptions options )
     {
-          return new ArrayList<>(
-              Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get())
+        return getAllDestinationProperties(DestinationServiceOptionsAugmenter.getRetrievalStrategy(options).get())
             .stream()
             .anyMatch(properties -> properties.get(DestinationProperty.NAME).contains(destinationName));
     }

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationService.java
@@ -120,7 +120,7 @@ public class DestinationService implements DestinationLoader
         Try<Destination>
         tryGetDestination( @Nonnull final String destinationName, @Nonnull final DestinationOptions options )
     {
-        if( Cache.preLookupCheckEnabled && !preLookupCheckSuccessful(destinationName) ) {
+        if( Cache.preLookupCheckEnabled && !preLookupCheckSuccessful(destinationName, options) ) {
             final String msg = "Destination %s was not found among the destinations of the current tenant.";
             return Try.failure(new DestinationNotFoundException(String.format(msg, destinationName)));
         }
@@ -388,9 +388,10 @@ public class DestinationService implements DestinationLoader
         return ExceptionUtils.getThrowableList(t).stream().map(Throwable::getClass).anyMatch(cls::isAssignableFrom);
     }
 
-    private boolean preLookupCheckSuccessful( final String destinationName )
+    private boolean preLookupCheckSuccessful( final String destinationName, final DestinationOptions options )
     {
-        return getAllDestinationProperties()
+          return new ArrayList<>(
+              Cache.getOrComputeAllDestinations(options, this::getAllDestinationsByRetrievalStrategy).get())
             .stream()
             .anyMatch(properties -> properties.get(DestinationProperty.NAME).contains(destinationName));
     }

--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeAllDestinationsCommand.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeAllDestinationsCommand.java
@@ -41,7 +41,7 @@ class GetOrComputeAllDestinationsCommand
 
         final CacheKey cacheKey = CacheKey.ofTenantOptionalIsolation();
 
-        cacheKey.append(destinationOptions);
+        cacheKey.append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(destinationOptions));
 
         final ReentrantLock isolationLock =
             Objects.requireNonNull(isolationLocks.get(cacheKey, any -> new ReentrantLock()));

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DestinationServiceTest.java
@@ -1267,9 +1267,13 @@ class DestinationServiceTest
         assertThat(DestinationService.Cache.isolationLocks().asMap())
             .containsOnlyKeys(
                 CacheKey.fromIds("TenantA", null).append(destinationName, options),
-                CacheKey.fromIds("TenantA", null).append(options),
+                CacheKey
+                    .fromIds("TenantA", null)
+                    .append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(options)),
                 CacheKey.fromIds("TenantB", null).append(destinationName, options),
-                CacheKey.fromIds("TenantB", null).append(options));
+                CacheKey
+                    .fromIds("TenantB", null)
+                    .append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(options)));
 
         // assert cache entries for one get-single command for each tenant
         assertThat(DestinationService.Cache.instanceSingle().asMap())
@@ -1339,7 +1343,9 @@ class DestinationServiceTest
             .containsOnlyKeys(
                 CacheKey.of(subscriberTenant, principal1).append(destinationName, options),
                 CacheKey.of(subscriberTenant, principal2).append(destinationName, options),
-                CacheKey.of(subscriberTenant, null).append(options));
+                CacheKey
+                    .of(subscriberTenant, null)
+                    .append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(options)));
 
         assertThat(DestinationService.Cache.instanceSingle().asMap())
             .containsOnlyKeys(
@@ -1383,7 +1389,9 @@ class DestinationServiceTest
         assertThat(DestinationService.Cache.isolationLocks().asMap())
             .containsOnlyKeys(
                 CacheKey.of(subscriberTenant, null).append(destinationName, options),
-                CacheKey.of(subscriberTenant, null).append(options));
+                CacheKey
+                    .of(subscriberTenant, null)
+                    .append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(options)));
 
         assertThat(DestinationService.Cache.instanceSingle().asMap())
             .containsOnlyKeys(

--- a/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeAllDestinationsCommandTest.java
+++ b/cloudplatform/connectivity-destination-service/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeAllDestinationsCommandTest.java
@@ -90,7 +90,12 @@ class GetOrComputeAllDestinationsCommandTest
         assertThat(result.get()).containsExactly(destination);
 
         assertThat(allDestinationsCache.estimatedSize()).isEqualTo(1);
-        assertThat(allDestinationsCache.getIfPresent(CacheKey.ofNoIsolation().append(EMPTY_OPTIONS)))
+        assertThat(
+            allDestinationsCache
+                .getIfPresent(
+                    CacheKey
+                        .ofNoIsolation()
+                        .append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(EMPTY_OPTIONS))))
             .containsExactly(destination);
         verify(tryGetAllDestinations, times(1)).get();
     }
@@ -104,8 +109,10 @@ class GetOrComputeAllDestinationsCommandTest
         final CountDownLatch mainThreadLatch = new CountDownLatch(1);
         final CountDownLatch getAllLatch = new CountDownLatch(1);
         final AtomicInteger lockInvocations = new AtomicInteger();
-        final CacheKey t1Key = CacheKey.of(t1, null).append(EMPTY_OPTIONS);
-        final CacheKey t2Key = CacheKey.of(t2, null).append(EMPTY_OPTIONS);
+        final CacheKey t1Key =
+            CacheKey.of(t1, null).append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(EMPTY_OPTIONS));
+        final CacheKey t2Key =
+            CacheKey.of(t2, null).append(DestinationServiceOptionsAugmenter.getRetrievalStrategy(EMPTY_OPTIONS));
         final ReentrantLock tenantIsolationLock = spy(ReentrantLock.class);
 
         doAnswer(invocation -> {


### PR DESCRIPTION
Follow-up to
- https://github.com/SAP/cloud-sdk-java/pull/1037

## Context
This is a follow up to the above mentioned PR. It changes the over-eager caching logic of the `GetOrComputeAllDestinationsCommand` class. Instead of building cache key out of entire `DestinationOptions` objects (which might contain many unnecessary information and therefor lead to differing keys and subsequently to unnecessary cache isolation) it only uses the retrieval strategy of the `DestinationOptions` object.

For more context, see the above PR.
