### PR TITLE
chore: Ignore incompatible spring boot updates

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -30,6 +30,10 @@ updates:
       test:
         dependency-type: "development"
     ignore:
+      - dependency-name: "org.springframework.boot:*"
+        versions: [ ">=4.0.0" ]
+      - dependency-name: "org.springframework:*"
+        versions: [ ">=7.0.0" ]
       # updating leads to ignoring our formatting rules
       - dependency-name: 'net.revelc.code.formatter:formatter-maven-plugin'
       # updating leads to unintended formatting of POM files


### PR DESCRIPTION
Spring Boot 4 and Spring Framework 7 are incompatible with our OpenAPI generated classes (i.e. core classes).

Related
https://github.com/SAP/cloud-sdk-java-backlog/issues/464

Can be reverted once the PR is merged (or similar)
https://github.com/SAP/cloud-sdk-java/pull/1046