### PR TITLE
chore: replace guava identity function reference with java.util.function

### DIFF
--- a/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeSingleDestinationCommand.java
+++ b/cloudplatform/connectivity-destination-service/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/GetOrComputeSingleDestinationCommand.java
@@ -8,13 +8,13 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.function.Supplier;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
 import com.github.benmanes.caffeine.cache.Cache;
-import com.google.common.base.Functions;
 import com.sap.cloud.sdk.cloudplatform.cache.CacheKey;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.security.principal.exception.PrincipalAccessException;
@@ -273,7 +273,7 @@ class GetOrComputeSingleDestinationCommand
         return destination
             .get(DestinationProperty.CERTIFICATES)
             .toStream()
-            .flatMap(Functions.identity())
+            .flatMap(Function.identity())
             .map(t -> ((DestinationServiceV1Response.DestinationCertificate) t).getExpiryTimestamp())
             .filter(Objects::nonNull)
             .min()
@@ -286,7 +286,7 @@ class GetOrComputeSingleDestinationCommand
         return destination
             .get(DestinationProperty.AUTH_TOKENS)
             .toStream()
-            .flatMap(Functions.identity())
+            .flatMap(Function.identity())
             .map(t -> ((DestinationServiceV1Response.DestinationAuthToken) t).getExpiryTimestamp())
             .filter(Objects::nonNull)
             .min()

--- a/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/adapter/JacksonVdmObjectSerializer.java
+++ b/datamodel/odata-v4/odata-v4-core/src/main/java/com/sap/cloud/sdk/datamodel/odatav4/adapter/JacksonVdmObjectSerializer.java
@@ -5,6 +5,7 @@ import java.lang.reflect.Field;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 
 import javax.annotation.Nonnull;
@@ -20,7 +21,6 @@ import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotationMap;
 import com.fasterxml.jackson.databind.ser.ContextualSerializer;
 import com.fasterxml.jackson.databind.ser.std.StdSerializer;
-import com.google.common.base.Functions;
 import com.sap.cloud.sdk.datamodel.odatav4.core.VdmEntity;
 import com.sap.cloud.sdk.datamodel.odatav4.core.VdmObject;
 import com.sap.cloud.sdk.result.ElementName;
@@ -79,7 +79,7 @@ public class JacksonVdmObjectSerializer extends StdSerializer<VdmObject<?>> impl
             Arrays
                 .stream(object.getClass().getDeclaredFields())
                 .filter(f -> f.getAnnotation(ElementName.class) != null)
-                .collect(Collectors.toMap(Functions.identity(), f -> getFieldValue(f, object)));
+                .collect(Collectors.toMap(Function.identity(), f -> getFieldValue(f, object)));
 
         for( final Map.Entry<Field, Option<Object>> propertyEntry : fieldValues.entrySet() ) {
             final Option<Object> propertyValueOption = propertyEntry.getValue();


### PR DESCRIPTION
This came up while looking at following issue https://github.com/SAP/cloud-sdk-java/issues/1054

