### PR TITLE
chore: Add release note for updated Apache HttpClient 5.6

### DIFF
--- a/release_notes.md
+++ b/release_notes.md
@@ -8,7 +8,9 @@
 
 ### 🔧 Compatibility Notes
 
-- 
+- We noticed an implicit behavior change for updated Apache HttpClient from `5.5.1` to `5.6`.
+  TLS/SSL connections are now checked for hostname verification on behalf of the provided server certificate.
+  Even with enabled trust-all-certificates flag, connections to servers with mismatching hostnames will be rejected.
 
 ### ✨ New Functionality
 


### PR DESCRIPTION
Related change (already merged): https://github.com/SAP/cloud-sdk-java/pull/1043
See slack discussion: https://sap-cpe.slack.com/archives/C01AMF777GA/p1767698977047229