### PR TITLE
feat: Temporary: Use `email` as fallback principal id when `user_uuid` is missing.

### DIFF
--- a/cloudplatform/security/src/main/java/com/sap/cloud/sdk/cloudplatform/security/principal/OidcAuthTokenPrincipalExtractor.java
+++ b/cloudplatform/security/src/main/java/com/sap/cloud/sdk/cloudplatform/security/principal/OidcAuthTokenPrincipalExtractor.java
@@ -16,6 +16,7 @@ import io.vavr.control.Try;
 class OidcAuthTokenPrincipalExtractor implements PrincipalExtractor
 {
     private static final String JWT_USER_UUID_CLAIM = "user_uuid";
+    private static final String JWT_EMAIL_CLAIM = "email";
 
     @Override
     @Nonnull
@@ -43,11 +44,16 @@ class OidcAuthTokenPrincipalExtractor implements PrincipalExtractor
         return Try.of(() -> {
             final Claim userUuidClaim = jwt.getClaim(JWT_USER_UUID_CLAIM);
 
-            if( userUuidClaim.isMissing() || userUuidClaim.isNull() ) {
-                throw new PrincipalAccessException("The current JWT does not contain the IAS user uuid.");
+            if( userUuidClaim != null && !userUuidClaim.isMissing() && !userUuidClaim.isNull() ) {
+                return userUuidClaim.asString();
             }
 
-            return userUuidClaim.asString();
+            final Claim emailClaim = jwt.getClaim(JWT_EMAIL_CLAIM);
+            if( emailClaim != null && !emailClaim.isMissing() && !emailClaim.isNull() ) {
+                return emailClaim.asString();
+            }
+
+            throw new PrincipalAccessException("The current JWT does not contain the IAS user uuid or an email.");
         });
     }
 }

--- a/cloudplatform/security/src/test/java/com/sap/cloud/sdk/cloudplatform/security/principal/OidcAuthTokenPrincipalExtractorTest.java
+++ b/cloudplatform/security/src/test/java/com/sap/cloud/sdk/cloudplatform/security/principal/OidcAuthTokenPrincipalExtractorTest.java
@@ -56,6 +56,16 @@ class OidcAuthTokenPrincipalExtractorTest
         assertThat(principal.getPrincipalId()).isEqualTo("principal id");
     }
 
+    @Test
+    void testReadPrincipalFromEmailFallback()
+    {
+        mockAuthTokenFacade(JWT.create().withClaim("email", "fallback@example.com"));
+
+        final Principal principal = new OidcAuthTokenPrincipalExtractor().tryGetCurrentPrincipal().get();
+
+        assertThat(principal.getPrincipalId()).isEqualTo("fallback@example.com");
+    }
+
     private void mockAuthTokenFacadeWithMissingAuthToken()
     {
         AuthTokenAccessor.setAuthTokenFacade(() -> Try.failure(new AuthTokenAccessException("Auth token not mocked.")));

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,7 +14,7 @@
 
 ### ✨ New Functionality
 
-- 
+- Temporary: Use `email` as fallback principal id when `user_uuid` is missing. Will switch to using `sub` once IAS exposes `idtype` (tracked in [SCICAI-1323](https://jira.tools.sap/browse/SCICAI-1323)).
 
 ### 📈 Improvements
 


### PR DESCRIPTION
## Context

- #1041
- Temporary: Use `email` as fallback principal id when `user_uuid` is missing. Will switch to using `sub` once IAS supports it.

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
