### PR TITLE
fix: Correct OAuth2 parameter for IAS refresh token workaround

### DIFF
--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -230,7 +230,7 @@ class OAuth2Service
             additionalParameters.put("app_tid", tenantId);
             if( onBehalfOf == OnBehalfOf.NAMED_USER_CURRENT_TENANT ) {
                 // workaround until a fix is provided by IAS
-                additionalParameters.put("refresh_token", "0");
+                additionalParameters.put("refresh_expiry", "0");
             }
         }
     }

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
@@ -244,7 +244,7 @@ class OAuth2ServiceTest
                     2,
                     postRequestedFor(urlEqualTo("/oauth/token"))
                         .withRequestBody(containing("app_tid=" + tenant.getTenantId()))
-                        .withRequestBody(containing("refresh_token=0"))
+                        .withRequestBody(containing("refresh_expiry=0"))
                         .withRequestBody(
                             containing("grant_type=urn:ietf:params:oauth:grant-type:jwt-bearer".replace(":", "%3A")))
                         .withRequestBody(containing("assertion=")));

--- a/release_notes.md
+++ b/release_notes.md
@@ -24,4 +24,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- Fixed IAS OAuth2 token requests to use correct `refresh_expiry=0` parameter instead of `refresh_token=0` to disable refresh token issuance in certain cases.


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#ISSUENUMBER.

This changes the OAuth2 token request parameter from `refresh_token` to `refresh_expiry` for named user current with `app_tid` to disable refresh token issuance.

The documented approach for disabling refresh token issuance is `refresh_expiry=0`, but currently `refresh_token=0` is set instead. The [issue](https://jira.tools.sap/browse/SECREQ-5220) that lead to the workaround being added also talks about `refresh_expiry` and the [API documentation](https://help.sap.com/docs/cloud-identity-services/cloud-identity-services/configure-client-to-call-identity-authentication-jwt-bearer-token?locale=en-US) only mentions `refresh_expiry`.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Update parameter being set 
- [x] Update existing unit test 

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [x] Tests created / updated _according to the scope_ above
- [ ] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
