### PR TITLE
fix: [OpenAPI] Revert making Spring optional in OpenAPI

### DIFF
--- a/datamodel/openapi/openapi-core/pom.xml
+++ b/datamodel/openapi/openapi-core/pom.xml
@@ -59,12 +59,10 @@
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-core</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>org.springframework</groupId>
 			<artifactId>spring-web</artifactId>
-			<optional>true</optional>
 		</dependency>
 		<dependency>
 			<groupId>com.fasterxml.jackson.core</groupId>


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#464.

Marking spring dependencies as optional is **breaking** to users who expects them but haven't declare them explicitly in their application's `pom.xml`. Without `<optional>true<optional>`, users could leave out the explicit declaration of spring dependencies since they will be pulled in transitively anyway.

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
