### PR TITLE
feat: Add opt-in HttpClient5 connection-pool-manager caching with tenant-aware strategies

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/IsOnBehalfOf.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/IsOnBehalfOf.java
@@ -1,0 +1,22 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import javax.annotation.Nullable;
+
+/**
+ * Interface to be implemented by classes that can provide information about the behalf upon which an action is run.
+ *
+ * @since 4.27.0
+ */
+interface IsOnBehalfOf
+{
+    /**
+     * Returns the behalf upon which an action is run.
+     *
+     * @return The behalf upon which an action is run, or {@code null} if no information about the behalf is available.
+     */
+    @Nullable
+    default OnBehalfOf getOnBehalfOf()
+    {
+        return null;
+    }
+}

--- a/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
+++ b/cloudplatform/connectivity-apache-httpclient4/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/AbstractHttpClientCache.java
@@ -79,11 +79,8 @@ public abstract class AbstractHttpClientCache implements HttpClientCache
         final Try<CacheKey> maybeKey = destination != null ? getCacheKey(destination) : getCacheKey();
 
         if( maybeKey.isFailure() ) {
-            return Try
-                .failure(
-                    new HttpClientInstantiationException(
-                        "Failed to create cache key for HttpClient",
-                        maybeKey.getCause()));
+            final String msg = "Failed to create cache key for HttpClient";
+            return Try.failure(new HttpClientInstantiationException(msg, maybeKey.getCause()));
         }
 
         final Cache<CacheKey, HttpClient> cache = maybeCache.get();

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
@@ -3,7 +3,10 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import java.time.Duration;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
+import lombok.Setter;
+import lombok.experimental.Accessors;
 import org.apache.hc.client5.http.classic.HttpClient;
 
 import com.google.common.annotations.Beta;
@@ -13,13 +16,77 @@ import com.google.common.annotations.Beta;
  *
  * @since 4.20.0
  */
+@Accessors( fluent = true )
 public class ApacheHttpClient5FactoryBuilder
 {
+    /**
+     * The {@code Upgrade} header. Only {@link ProxyType#INTERNET} has the {@code Upgrade} header by default.
+     * <p>
+     * <b>{@link TlsUpgrade#DISABLED} only works for {@link ProxyType#INTERNET}</b>
+     * <p>
+     * <b>{@link TlsUpgrade#ENABLED} only works for {@link ProxyType#ON_PREMISE}</b>
+     *
+     * @since 5.14.0
+     */
+    @Setter
     @Nonnull
-    private Duration timeout = DefaultApacheHttpClient5Factory.DEFAULT_TIMEOUT;
     private TlsUpgrade tlsUpgrade = TlsUpgrade.AUTOMATIC;
-    private int maxConnectionsTotal = DefaultApacheHttpClient5Factory.DEFAULT_MAX_CONNECTIONS_TOTAL;
-    private int maxConnectionsPerRoute = DefaultApacheHttpClient5Factory.DEFAULT_MAX_CONNECTIONS_PER_ROUTE;
+
+    /**
+     * The {@link ConnectionPoolSettings} to use for configuring connection pool managers and request timeouts.
+     * <p>
+     * This replaces any previously configured settings from {@link #timeout(Duration)},
+     * {@link #maxConnectionsTotal(int)}, or {@link #maxConnectionsPerRoute(int)}.
+     * </p>
+     * <p>
+     * This is an <b>optional</b> parameter. By default, settings use the default values.
+     * </p>
+     *
+     * @see DefaultConnectionPoolSettings#ofDefaults()
+     * @see DefaultConnectionPoolSettings#builder()
+     * @since 5.XX.0
+     */
+    @Setter( onMethod_ = @Beta )
+    @Nonnull
+    private DefaultConnectionPoolSettings settings = DefaultConnectionPoolSettings.ofDefaults();
+
+    /**
+     * A custom {@link ConnectionPoolManagerProvider} for creating and managing HTTP connection pool managers.
+     * <p>
+     * This allows customization of how connection managers are created and cached. Use
+     * {@link ConnectionPoolManagerProviders} to obtain pre-built implementations with common caching strategies:
+     * </p>
+     * <ul>
+     * <li>{@link ConnectionPoolManagerProviders#noCache()} - No caching (default behavior)</li>
+     * <li>{@link ConnectionPoolManagerProviders#byTenant()} - Cache by current tenant</li>
+     * <li>{@link ConnectionPoolManagerProviders#byDestinationName()} - Cache by destination name</li>
+     * <li>{@link ConnectionPoolManagerProviders#global()} - Single global connection manager</li>
+     * <li>{@link ConnectionPoolManagerProviders#withCacheKey(java.util.function.Function)} - Custom cache key</li>
+     * </ul>
+     * <p>
+     * This is an <b>optional</b> parameter. By default, a new connection manager is created for each HTTP client
+     * without caching.
+     * </p>
+     *
+     * <h3>Example Usage</h3>
+     *
+     * <pre>
+     * {@code
+     * // Cache connection managers by tenant to reduce memory consumption
+     * ApacheHttpClient5Factory factory =
+     *     new ApacheHttpClient5FactoryBuilder()
+     *         .connectionPoolManagerProvider(ConnectionPoolManagerProviders.byTenant())
+     *         .build();
+     * }
+     * </pre>
+     *
+     * @see ConnectionPoolManagerProvider
+     * @see ConnectionPoolManagerProviders
+     * @since 5.XX.0
+     */
+    @Setter( onMethod_ = @Beta )
+    @Nonnull
+    private ConnectionPoolManagerProvider connectionPoolManagerProvider = ConnectionPoolManagerProviders.noCache();
 
     /**
      * Enum to control the automatic TLS upgrade feature for insecure connections.
@@ -88,7 +155,8 @@ public class ApacheHttpClient5FactoryBuilder
     @Nonnull
     public ApacheHttpClient5FactoryBuilder timeout( @Nonnull final Duration timeout )
     {
-        this.timeout = timeout;
+        settings =
+            settings.withConnectTimeout(timeout).withSocketTimeout(timeout).withConnectionRequestTimeout(timeout);
         return this;
     }
 
@@ -106,23 +174,7 @@ public class ApacheHttpClient5FactoryBuilder
     @Nonnull
     public ApacheHttpClient5FactoryBuilder maxConnectionsTotal( final int maxConnectionsTotal )
     {
-        this.maxConnectionsTotal = maxConnectionsTotal;
-        return this;
-    }
-
-    /**
-     * Sets the {@code Upgrade} header. Only {@link ProxyType#INTERNET} has the {@code Upgrade} header by default.
-     * <p>
-     * <b>{@link TlsUpgrade#DISABLED} only works for {@link ProxyType#INTERNET}</b>
-     * <p>
-     * <b>{@link TlsUpgrade#ENABLED} only works for {@link ProxyType#ON_PREMISE}</b>
-     *
-     * @since 5.14.0
-     */
-    @Nonnull
-    public ApacheHttpClient5FactoryBuilder tlsUpgrade( @Nonnull final TlsUpgrade tlsUpgrade )
-    {
-        this.tlsUpgrade = tlsUpgrade;
+        settings = settings.withMaxConnectionsTotal(maxConnectionsTotal);
         return this;
     }
 
@@ -141,7 +193,7 @@ public class ApacheHttpClient5FactoryBuilder
     @Nonnull
     public ApacheHttpClient5FactoryBuilder maxConnectionsPerRoute( final int maxConnectionsPerRoute )
     {
-        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
+        settings = settings.withMaxConnectionsPerRoute(maxConnectionsPerRoute);
         return this;
     }
 
@@ -153,11 +205,6 @@ public class ApacheHttpClient5FactoryBuilder
     @Nonnull
     public ApacheHttpClient5Factory build()
     {
-        return new DefaultApacheHttpClient5Factory(
-            timeout,
-            maxConnectionsTotal,
-            maxConnectionsPerRoute,
-            null,
-            tlsUpgrade);
+        return new DefaultApacheHttpClient5Factory(settings, connectionPoolManagerProvider, null, tlsUpgrade);
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
@@ -3,13 +3,13 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import java.time.Duration;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-import lombok.Setter;
-import lombok.experimental.Accessors;
 import org.apache.hc.client5.http.classic.HttpClient;
 
 import com.google.common.annotations.Beta;
+
+import lombok.Setter;
+import lombok.experimental.Accessors;
 
 /**
  * Builder class for a default implementation of the {@link ApacheHttpClient5Factory} interface.

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ApacheHttpClient5FactoryBuilder.java
@@ -44,7 +44,7 @@ public class ApacheHttpClient5FactoryBuilder
      *
      * @see DefaultConnectionPoolSettings#ofDefaults()
      * @see DefaultConnectionPoolSettings#builder()
-     * @since 5.XX.0
+     * @since 5.27.0
      */
     @Setter( onMethod_ = @Beta )
     @Nonnull
@@ -82,7 +82,7 @@ public class ApacheHttpClient5FactoryBuilder
      *
      * @see ConnectionPoolManagerProvider
      * @see ConnectionPoolManagerProviders
-     * @since 5.XX.0
+     * @since 5.27.0
      */
     @Setter( onMethod_ = @Beta )
     @Nonnull

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvider.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvider.java
@@ -1,0 +1,66 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+
+import com.google.common.annotations.Beta;
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstantiationException;
+
+/**
+ * Functional interface for creating or retrieving {@link HttpClientConnectionManager} instances.
+ * <p>
+ * Implementations can choose to cache connection managers based on various strategies (e.g., by tenant, by destination
+ * name, globally) to reduce memory consumption. Each connection manager typically consumes around 100KB of memory.
+ * </p>
+ * <p>
+ * Use {@link ConnectionPoolManagerProviders} to obtain pre-built implementations with common caching strategies.
+ * </p>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>
+ * {@code
+ * // Simple lambda implementation (no caching)
+ * ConnectionPoolManagerProvider provider =
+ *     ( settings, dest ) -> PoolingHttpClientConnectionManagerBuilder
+ *         .create()
+ *         .setMaxConnTotal(settings.maxConnectionsTotal())
+ *         .build();
+ *
+ * // Using pre-built providers
+ * ConnectionPoolManagerProvider cachingProvider = ConnectionPoolManagerProviders.byTenant();
+ * }
+ * </pre>
+ *
+ * @see ConnectionPoolManagerProviders
+ * @see ApacheHttpClient5FactoryBuilder#connectionPoolManagerProvider(ConnectionPoolManagerProvider)
+ * @since 5.XX.0
+ */
+@Beta
+@FunctionalInterface
+public interface ConnectionPoolManagerProvider
+{
+    /**
+     * Gets or creates an {@link HttpClientConnectionManager} for the given destination.
+     * <p>
+     * Implementations may cache connection managers based on destination properties, tenant context, or other criteria.
+     * The settings parameter provides the configuration for creating new connection managers.
+     * </p>
+     *
+     * @param settings
+     *            The connection pool settings to use when creating a new connection manager.
+     * @param destination
+     *            The destination properties to create the connection manager for, or {@code null} for a generic
+     *            connection manager.
+     * @return A connection manager suitable for the given destination.
+     * @throws HttpClientInstantiationException
+     *             If the connection manager cannot be created.
+     */
+    @Nonnull
+    HttpClientConnectionManager getConnectionManager(
+        @Nonnull ConnectionPoolSettings settings,
+        @Nullable HttpDestinationProperties destination )
+        throws HttpClientInstantiationException;
+}

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvider.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvider.java
@@ -36,7 +36,7 @@ import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstanti
  *
  * @see ConnectionPoolManagerProviders
  * @see ApacheHttpClient5FactoryBuilder#connectionPoolManagerProvider(ConnectionPoolManagerProvider)
- * @since 5.XX.0
+ * @since 5.27.0
  */
 @Beta
 @FunctionalInterface

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
@@ -238,7 +238,7 @@ public final class ConnectionPoolManagerProviders
         }
 
         @Nonnull
-        public ConnectionPoolManagerProvider byIndicatedBehalfOf()
+        public ConnectionPoolManagerProvider byOnBehalfOf()
         {
             return by(destination -> {
                 // Check if the destination has any OnBehalfOf indicators in its custom header providers

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
@@ -14,8 +14,6 @@ import javax.annotation.Nullable;
 import javax.net.ssl.HostnameVerifier;
 import javax.net.ssl.SSLContext;
 
-import com.github.benmanes.caffeine.cache.Cache;
-import com.github.benmanes.caffeine.cache.Caffeine;
 import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
@@ -26,6 +24,8 @@ import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import com.google.common.annotations.Beta;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstantiationException;
 import com.sap.cloud.sdk.cloudplatform.tenant.Tenant;

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
@@ -1,0 +1,269 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import java.io.IOException;
+import java.security.GeneralSecurityException;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.function.Function;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLContext;
+
+import com.sap.cloud.sdk.cloudplatform.tenant.Tenant;
+import org.apache.hc.client5.http.config.ConnectionConfig;
+import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
+import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
+import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
+import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
+import org.apache.hc.core5.http.io.SocketConfig;
+import org.apache.hc.core5.util.Timeout;
+
+import com.google.common.annotations.Beta;
+import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstantiationException;
+import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
+import com.sap.cloud.sdk.cloudplatform.util.StringUtils;
+
+import lombok.AccessLevel;
+import lombok.NoArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+/**
+ * Factory class providing pre-built {@link ConnectionPoolManagerProvider} implementations with various caching
+ * strategies.
+ * <p>
+ * Connection pool managers can consume significant memory (~100KB each). By caching and reusing connection managers
+ * based on appropriate keys, applications can reduce memory consumption while maintaining proper isolation where
+ * needed.
+ * </p>
+ *
+ * <h2>Usage Examples</h2>
+ *
+ * <pre>
+ * {@code
+ * // Cache connection managers by tenant
+ * ApacheHttpClient5Factory factory =
+ *     new ApacheHttpClient5FactoryBuilder()
+ *         .connectionPoolManagerProvider(ConnectionPoolManagerProviders.byTenant())
+ *         .build();
+ *
+ * // Use a single global connection manager
+ * ApacheHttpClient5Factory factory =
+ *     new ApacheHttpClient5FactoryBuilder()
+ *         .connectionPoolManagerProvider(ConnectionPoolManagerProviders.global())
+ *         .build();
+ *
+ * // Custom caching strategy
+ * ApacheHttpClient5Factory factory =
+ *     new ApacheHttpClient5FactoryBuilder()
+ *         .connectionPoolManagerProvider(
+ *             ConnectionPoolManagerProviders
+ *                 .withCacheKey(dest -> dest.get(DestinationProperty.NAME).getOrElse("default")))
+ *         .build();
+ * }
+ * </pre>
+ *
+ * @see ConnectionPoolManagerProvider
+ * @see ConnectionPoolSettings
+ * @see ApacheHttpClient5FactoryBuilder#connectionPoolManagerProvider(ConnectionPoolManagerProvider)
+ * @since 5.XX.0
+ */
+@Beta
+@Slf4j
+@NoArgsConstructor( access = AccessLevel.PRIVATE )
+public final class ConnectionPoolManagerProviders
+{
+    // Constant keys for cache entries
+    private static final String GLOBAL_KEY = "__GLOBAL__";
+    private static final String NULL_KEY = "__NULL__";
+
+    /**
+     * Creates a provider that does not cache connection managers.
+     * <p>
+     * A new {@link HttpClientConnectionManager} is created for each call. This is the default behavior and provides
+     * maximum isolation but highest memory consumption.
+     * </p>
+     *
+     * @return A provider that creates a new connection manager for each request.
+     */
+    @Nonnull
+    public static ConnectionPoolManagerProvider noCache()
+    {
+        return ConnectionPoolManagerProviders::createConnectionManager;
+    }
+
+    /**
+     * Creates a provider that caches connection managers by the current tenant.
+     * <p>
+     * Connection managers are shared among all destinations accessed within the same tenant context. This is useful
+     * when tenant isolation is required but destination-level isolation is not necessary.
+     * </p>
+     * <p>
+     * If no tenant is available in the current context, a shared "no-tenant" connection manager is used.
+     * </p>
+     *
+     * @return A provider that caches connection managers by tenant.
+     * @see TenantAccessor#tryGetCurrentTenant()
+     */
+    @Nonnull
+    public static ConnectionPoolManagerProvider byTenant()
+    {
+        return withCacheKey(dest -> TenantAccessor.tryGetCurrentTenant().map(Tenant::getTenantId).getOrNull());
+    }
+
+    /**
+     * Creates a provider that caches connection managers by destination name.
+     * <p>
+     * Connection managers are shared among all requests to destinations with the same name. This is useful when
+     * different destinations may have different TLS or proxy configurations.
+     * </p>
+     * <p>
+     * If the destination has no name or is {@code null}, a shared "unnamed" connection manager is used.
+     * </p>
+     *
+     * @return A provider that caches connection managers by destination name.
+     */
+    @Nonnull
+    public static ConnectionPoolManagerProvider byDestinationName()
+    {
+        return withCacheKey(dest -> dest != null ? dest.get(DestinationProperty.NAME).getOrNull() : null);
+    }
+
+    /**
+     * Creates a provider that uses a single global connection manager for all destinations.
+     * <p>
+     * This provides the lowest memory consumption but no isolation between tenants or destinations. Use this only when
+     * all destinations have compatible TLS configurations and isolation is not required.
+     * </p>
+     * <p>
+     * <strong>Warning:</strong> This strategy does not support destination-specific TLS configurations. All
+     * destinations will use the default TLS settings.
+     * </p>
+     *
+     * @return A provider that uses a single global connection manager.
+     */
+    @Nonnull
+    public static ConnectionPoolManagerProvider global()
+    {
+        return withCacheKey(dest -> GLOBAL_KEY);
+    }
+
+    /**
+     * Creates a provider that caches connection managers using a custom cache key extractor.
+     * <p>
+     * The cache key extractor function is called for each request to determine which cached connection manager to use.
+     * Requests that produce equal cache keys (via {@link Object#equals(Object)}) will share the same connection
+     * manager.
+     * </p>
+     * <p>
+     * <strong>Note:</strong> The cache key extractor should return consistent keys for destinations that can safely
+     * share a connection manager. Consider TLS configuration, proxy settings, and isolation requirements when designing
+     * the key extraction logic.
+     * </p>
+     *
+     * @param cacheKeyExtractor
+     *            A function that extracts a cache key from the destination. The function receives {@code null} when
+     *            creating a generic (non-destination-specific) connection manager. The returned key may be {@code null}
+     *            to indicate a shared "null-key" bucket.
+     * @return A provider that caches connection managers using the custom key extractor.
+     */
+    @Nonnull
+    public static ConnectionPoolManagerProvider withCacheKey(
+        @Nonnull final Function<HttpDestinationProperties, Object> cacheKeyExtractor )
+    {
+        Objects.requireNonNull(cacheKeyExtractor, "Cache key extractor must not be null");
+        return new CachingProvider(cacheKeyExtractor);
+    }
+
+    /**
+     * Provider that caches connection managers using a custom key extractor.
+     */
+    private static final class CachingProvider implements ConnectionPoolManagerProvider
+    {
+        private final Function<HttpDestinationProperties, Object> cacheKeyExtractor;
+        private final ConcurrentMap<Object, HttpClientConnectionManager> cache = new ConcurrentHashMap<>();
+
+        CachingProvider( final Function<HttpDestinationProperties, Object> cacheKeyExtractor )
+        {
+            this.cacheKeyExtractor = cacheKeyExtractor;
+        }
+
+        @Nonnull
+        @Override
+        public HttpClientConnectionManager getConnectionManager(
+            @Nonnull final ConnectionPoolSettings settings,
+            @Nullable final HttpDestinationProperties destination )
+            throws HttpClientInstantiationException
+        {
+            final Object rawKey = cacheKeyExtractor.apply(destination);
+            final Object cacheKey = rawKey != null ? rawKey : NULL_KEY;
+
+            return cache.computeIfAbsent(cacheKey, key -> {
+                log.debug("Creating new connection manager for cache key: {}", rawKey);
+                return createConnectionManager(settings, destination);
+            });
+        }
+    }
+
+    /**
+     * Creates a new connection manager with the given settings and destination-specific TLS configuration.
+     */
+    @Nonnull
+    private static HttpClientConnectionManager createConnectionManager(
+        @Nonnull final ConnectionPoolSettings settings,
+        @Nullable final HttpDestinationProperties destination )
+        throws HttpClientInstantiationException
+    {
+        try {
+            final Timeout timeoutSocket = Timeout.of(settings.getSocketTimeout());
+            final Timeout timeoutConnect = Timeout.of(settings.getConnectTimeout());
+
+            return PoolingHttpClientConnectionManagerBuilder
+                .create()
+                .setTlsSocketStrategy(getTlsSocketStrategy(destination))
+                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutSocket).build())
+                .setDefaultConnectionConfig(
+                    ConnectionConfig.custom().setConnectTimeout(timeoutConnect).setSocketTimeout(timeoutSocket).build())
+                .setMaxConnTotal(settings.getMaxConnectionsTotal())
+                .setMaxConnPerRoute(settings.getMaxConnectionsPerRoute())
+                .build();
+        }
+        catch( final GeneralSecurityException | IOException e ) {
+            throw new HttpClientInstantiationException("Failed to create HTTP client connection manager.", e);
+        }
+    }
+
+    @Nullable
+    private static TlsSocketStrategy getTlsSocketStrategy( @Nullable final HttpDestinationProperties destination )
+        throws GeneralSecurityException,
+            IOException
+    {
+        if( !supportsTls(destination) ) {
+            return null;
+        }
+
+        log.debug("The destination uses HTTPS for target \"{}\".", destination.getUri());
+        final SSLContext sslContext = new SSLContextFactory().createSSLContext(destination);
+        final HostnameVerifier hostnameVerifier = getHostnameVerifier(destination);
+
+        return new DefaultClientTlsStrategy(sslContext, hostnameVerifier);
+    }
+
+    private static HostnameVerifier getHostnameVerifier( @Nonnull final HttpDestinationProperties destination )
+    {
+        return destination.isTrustingAllCertificates() ? new NoopHostnameVerifier() : new DefaultHostnameVerifier();
+    }
+
+    private static boolean supportsTls( @Nullable final HttpDestinationProperties destination )
+    {
+        if( destination == null ) {
+            return false;
+        }
+        final String scheme = destination.getUri().getScheme();
+        return "https".equalsIgnoreCase(scheme) || StringUtils.isEmpty(scheme);
+    }
+}

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProviders.java
@@ -237,6 +237,19 @@ public final class ConnectionPoolManagerProviders
             return by(dest -> dest != null ? dest.get(DestinationProperty.NAME).getOrNull() : null);
         }
 
+        /**
+         * Creates a provider that reuses the connection managers for different tenants if the destination is
+         * tenant-independent.
+         * <p>
+         * The provider checks for the presence of {@link OnBehalfOf} indicators in the destination's custom header
+         * providers. If all indicators show that the destination is on behalf of a provider tenant, the same connection
+         * manager is reused across tenants. Otherwise, tenant information is included in the cache key to ensure
+         * isolation.
+         * </p>
+         *
+         * @return A provider that reuses the connection managers for different tenants if the destination is
+         *         tenant-independent.
+         */
         @Nonnull
         public ConnectionPoolManagerProvider byOnBehalfOf()
         {

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolSettings.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolSettings.java
@@ -19,7 +19,7 @@ import com.google.common.annotations.Beta;
  *
  * @see ConnectionPoolManagerProviders
  * @see DefaultConnectionPoolSettings
- * @since 5.XX.0
+ * @since 5.27.0
  */
 @Beta
 public interface ConnectionPoolSettings

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolSettings.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolSettings.java
@@ -1,0 +1,79 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import java.time.Duration;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.annotations.Beta;
+
+/**
+ * Configuration settings for HTTP connection pool managers and HTTP client request configuration.
+ * <p>
+ * These settings control the behavior of {@link org.apache.hc.client5.http.io.HttpClientConnectionManager} instances
+ * created by {@link ConnectionPoolManagerProvider} implementations, as well as the request-level timeout configuration.
+ * </p>
+ * <p>
+ * Use {@link DefaultConnectionPoolSettings#ofDefaults()} or {@link DefaultConnectionPoolSettings#builder()} to create
+ * instances. Users can also implement this interface to provide custom settings implementations.
+ * </p>
+ *
+ * @see ConnectionPoolManagerProviders
+ * @see DefaultConnectionPoolSettings
+ * @since 5.XX.0
+ */
+@Beta
+public interface ConnectionPoolSettings
+{
+    /**
+     * Default timeout of 2 minutes (applies to connect, socket, and connection request timeouts).
+     */
+    Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2L);
+
+    /**
+     * Default maximum total connections of 200.
+     */
+    int DEFAULT_MAX_CONNECTIONS_TOTAL = 200;
+
+    /**
+     * Default maximum connections per route of 100.
+     */
+    int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 100;
+
+    /**
+     * Returns the timeout until a new connection is fully established.
+     *
+     * @return The connect timeout.
+     */
+    @Nonnull
+    Duration getConnectTimeout();
+
+    /**
+     * Returns the default socket timeout value for I/O operations on connections.
+     *
+     * @return The socket timeout.
+     */
+    @Nonnull
+    Duration getSocketTimeout();
+
+    /**
+     * Returns the timeout when requesting a connection lease from the connection pool.
+     *
+     * @return The connection request timeout.
+     */
+    @Nonnull
+    Duration getConnectionRequestTimeout();
+
+    /**
+     * Returns the maximum number of total connections in the pool.
+     *
+     * @return The maximum total connections.
+     */
+    int getMaxConnectionsTotal();
+
+    /**
+     * Returns the maximum number of connections per route (e.g., per remote host).
+     *
+     * @return The maximum connections per route.
+     */
+    int getMaxConnectionsPerRoute();
+}

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
@@ -1,71 +1,43 @@
 package com.sap.cloud.sdk.cloudplatform.connectivity;
 
-import java.io.IOException;
 import java.net.URI;
-import java.security.GeneralSecurityException;
-import java.time.Duration;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
 
 import org.apache.hc.client5.http.classic.HttpClient;
-import org.apache.hc.client5.http.config.ConnectionConfig;
 import org.apache.hc.client5.http.config.RequestConfig;
 import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
 import org.apache.hc.client5.http.impl.classic.HttpClientBuilder;
 import org.apache.hc.client5.http.impl.classic.HttpClients;
-import org.apache.hc.client5.http.impl.io.PoolingHttpClientConnectionManagerBuilder;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
-import org.apache.hc.client5.http.ssl.DefaultClientTlsStrategy;
-import org.apache.hc.client5.http.ssl.DefaultHostnameVerifier;
-import org.apache.hc.client5.http.ssl.NoopHostnameVerifier;
-import org.apache.hc.client5.http.ssl.TlsSocketStrategy;
 import org.apache.hc.core5.http.HttpHost;
 import org.apache.hc.core5.http.HttpRequestInterceptor;
-import org.apache.hc.core5.http.io.SocketConfig;
 import org.apache.hc.core5.util.Timeout;
 
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.DestinationAccessException;
 import com.sap.cloud.sdk.cloudplatform.connectivity.exception.HttpClientInstantiationException;
-import com.sap.cloud.sdk.cloudplatform.util.StringUtils;
 
 import io.vavr.control.Option;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
+@RequiredArgsConstructor
 class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
 {
-    static final Duration DEFAULT_TIMEOUT = Duration.ofMinutes(2L);
-    static final int DEFAULT_MAX_CONNECTIONS_TOTAL = 200;
-    static final int DEFAULT_MAX_CONNECTIONS_PER_ROUTE = 100;
+    @Nonnull
+    private final ConnectionPoolSettings settings;
 
     @Nonnull
-    private final Timeout timeout;
-    private final int maxConnectionsTotal;
-    private final int maxConnectionsPerRoute;
+    private final ConnectionPoolManagerProvider connectionPoolManagerProvider;
 
     @Nullable
     private final HttpRequestInterceptor requestInterceptor;
 
     @Nonnull
     private final ApacheHttpClient5FactoryBuilder.TlsUpgrade tlsUpgrade;
-
-    DefaultApacheHttpClient5Factory(
-        @Nonnull final Duration timeout,
-        final int maxConnectionsTotal,
-        final int maxConnectionsPerRoute,
-        @Nullable final HttpRequestInterceptor requestInterceptor,
-        @Nonnull final ApacheHttpClient5FactoryBuilder.TlsUpgrade tlsUpgrade )
-    {
-        this.timeout = toTimeout(timeout);
-        this.maxConnectionsTotal = maxConnectionsTotal;
-        this.maxConnectionsPerRoute = maxConnectionsPerRoute;
-        this.requestInterceptor = requestInterceptor;
-        this.tlsUpgrade = tlsUpgrade;
-    }
 
     @Nonnull
     @Override
@@ -87,10 +59,13 @@ class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
         @Nullable final HttpDestinationProperties destination,
         @Nonnull final RequestConfig requestConfig )
     {
+        final HttpClientConnectionManager connManager =
+            connectionPoolManagerProvider.getConnectionManager(settings, destination);
+
         final HttpClientBuilder builder =
             HttpClients
                 .custom()
-                .setConnectionManager(getConnectionManager(destination))
+                .setConnectionManager(connManager)
                 .setDefaultRequestConfig(requestConfig)
                 .setProxy(getProxy(destination));
 
@@ -102,68 +77,12 @@ class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
     }
 
     @Nonnull
-    private HttpClientConnectionManager getConnectionManager( @Nullable final HttpDestinationProperties destination )
-    {
-        try {
-            return PoolingHttpClientConnectionManagerBuilder
-                .create()
-                .setTlsSocketStrategy(getTlsSocketStrategy(destination))
-                .setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeout).build())
-                .setDefaultConnectionConfig(
-                    ConnectionConfig.custom().setConnectTimeout(timeout).setSocketTimeout(timeout).build())
-                .setMaxConnTotal(maxConnectionsTotal)
-                .setMaxConnPerRoute(maxConnectionsPerRoute)
-                .build();
-        }
-        catch( final GeneralSecurityException | IOException e ) {
-            throw new HttpClientInstantiationException("Failed to create HTTP client connection manager.", e);
-        }
-    }
-
-    @Nonnull
-    private static Timeout toTimeout( @Nonnull final Duration duration )
-    {
-        return Timeout.ofMilliseconds(duration.toMillis());
-    }
-
-    @Nullable
-    private TlsSocketStrategy getTlsSocketStrategy( @Nullable final HttpDestinationProperties destination )
-        throws GeneralSecurityException,
-            IOException
-    {
-        if( !supportsTls(destination) ) {
-            return null;
-        }
-
-        log.debug("The destination uses HTTPS for target \"{}\".", destination.getUri());
-        final SSLContext sslContext = new SSLContextFactory().createSSLContext(destination);
-
-        final HostnameVerifier hostnameVerifier = getHostnameVerifier(destination);
-
-        return new DefaultClientTlsStrategy(sslContext, hostnameVerifier);
-    }
-
-    private boolean supportsTls( @Nullable final HttpDestinationProperties destination )
-    {
-        if( destination == null ) {
-            return false;
-        }
-        final String scheme = destination.getUri().getScheme();
-        return "https".equalsIgnoreCase(scheme) || StringUtils.isEmpty(scheme);
-    }
-
-    private HostnameVerifier getHostnameVerifier( final HttpDestinationProperties destination )
-    {
-        return destination.isTrustingAllCertificates() ? new NoopHostnameVerifier() : new DefaultHostnameVerifier();
-    }
-
-    @Nonnull
     private RequestConfig getRequestConfig( @Nullable final HttpDestinationProperties destination )
     {
         return RequestConfig
             .custom()
             .setProtocolUpgradeEnabled(isProtocolUpgradeEnabled(destination))
-            .setConnectionRequestTimeout(timeout)
+            .setConnectionRequestTimeout(Timeout.ofMilliseconds(settings.getConnectionRequestTimeout().toMillis()))
             .build();
     }
 

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5Factory.java
@@ -55,6 +55,7 @@ class DefaultApacheHttpClient5Factory implements ApacheHttpClient5Factory
     }
 
     @Nonnull
+    @SuppressWarnings( "PMD.CloseResource" ) // The HttpClient instance and the connection manager instance are not being closed here.
     private CloseableHttpClient buildHttpClient(
         @Nullable final HttpDestinationProperties destination,
         @Nonnull final RequestConfig requestConfig )

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
@@ -25,11 +25,13 @@ import lombok.With;
  * ConnectionPoolSettings settings = DefaultConnectionPoolSettings.ofDefaults();
  *
  * // Using builder
- * ConnectionPoolSettings settings = DefaultConnectionPoolSettings.builder()
- *     .connectTimeout(Duration.ofSeconds(30))
- *     .socketTimeout(Duration.ofMinutes(1))
- *     .maxConnectionsTotal(500)
- *     .build();
+ * ConnectionPoolSettings settings =
+ *     DefaultConnectionPoolSettings
+ *         .builder()
+ *         .connectTimeout(Duration.ofSeconds(30))
+ *         .socketTimeout(Duration.ofMinutes(1))
+ *         .maxConnectionsTotal(500)
+ *         .build();
  *
  * // Using with() for copy-with-modification
  * DefaultConnectionPoolSettings modified = settings.withMaxConnectionsTotal(1000);
@@ -37,7 +39,7 @@ import lombok.With;
  * </pre>
  *
  * @see ConnectionPoolSettings
- * @since 5.XX.0
+ * @since 5.27.0
  */
 @Beta
 @Value

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
@@ -52,33 +52,33 @@ public class DefaultConnectionPoolSettings implements ConnectionPoolSettings
      */
     @Nonnull
     @Builder.Default
-    Duration connectTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+    Duration connectTimeout = DEFAULT_TIMEOUT;
 
     /**
      * The default socket timeout value for I/O operations on connections.
      */
     @Nonnull
     @Builder.Default
-    Duration socketTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+    Duration socketTimeout = DEFAULT_TIMEOUT;
 
     /**
      * The timeout when requesting a connection lease from the connection pool.
      */
     @Nonnull
     @Builder.Default
-    Duration connectionRequestTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+    Duration connectionRequestTimeout = DEFAULT_TIMEOUT;
 
     /**
      * The maximum number of total connections in the pool.
      */
     @Builder.Default
-    int maxConnectionsTotal = ConnectionPoolSettings.DEFAULT_MAX_CONNECTIONS_TOTAL;
+    int maxConnectionsTotal = DEFAULT_MAX_CONNECTIONS_TOTAL;
 
     /**
      * The maximum number of connections per route (e.g., per remote host).
      */
     @Builder.Default
-    int maxConnectionsPerRoute = ConnectionPoolSettings.DEFAULT_MAX_CONNECTIONS_PER_ROUTE;
+    int maxConnectionsPerRoute = DEFAULT_MAX_CONNECTIONS_PER_ROUTE;
 
     /**
      * Creates a new {@link DefaultConnectionPoolSettings} with default values.

--- a/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultConnectionPoolSettings.java
@@ -1,0 +1,101 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import java.time.Duration;
+
+import javax.annotation.Nonnull;
+
+import com.google.common.annotations.Beta;
+
+import lombok.Builder;
+import lombok.Value;
+import lombok.With;
+
+/**
+ * Default implementation of {@link ConnectionPoolSettings} using Lombok's {@code @Value} for immutability.
+ * <p>
+ * Use {@link #ofDefaults()} to create an instance with default values, or {@link #builder()} to create instances with
+ * custom values.
+ * </p>
+ *
+ * <h2>Example Usage</h2>
+ *
+ * <pre>
+ * {@code
+ * // Using defaults
+ * ConnectionPoolSettings settings = DefaultConnectionPoolSettings.ofDefaults();
+ *
+ * // Using builder
+ * ConnectionPoolSettings settings = DefaultConnectionPoolSettings.builder()
+ *     .connectTimeout(Duration.ofSeconds(30))
+ *     .socketTimeout(Duration.ofMinutes(1))
+ *     .maxConnectionsTotal(500)
+ *     .build();
+ *
+ * // Using with() for copy-with-modification
+ * DefaultConnectionPoolSettings modified = settings.withMaxConnectionsTotal(1000);
+ * }
+ * </pre>
+ *
+ * @see ConnectionPoolSettings
+ * @since 5.XX.0
+ */
+@Beta
+@Value
+@Builder
+@With
+public class DefaultConnectionPoolSettings implements ConnectionPoolSettings
+{
+    /**
+     * The timeout until a new connection is fully established.
+     */
+    @Nonnull
+    @Builder.Default
+    Duration connectTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+
+    /**
+     * The default socket timeout value for I/O operations on connections.
+     */
+    @Nonnull
+    @Builder.Default
+    Duration socketTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+
+    /**
+     * The timeout when requesting a connection lease from the connection pool.
+     */
+    @Nonnull
+    @Builder.Default
+    Duration connectionRequestTimeout = ConnectionPoolSettings.DEFAULT_TIMEOUT;
+
+    /**
+     * The maximum number of total connections in the pool.
+     */
+    @Builder.Default
+    int maxConnectionsTotal = ConnectionPoolSettings.DEFAULT_MAX_CONNECTIONS_TOTAL;
+
+    /**
+     * The maximum number of connections per route (e.g., per remote host).
+     */
+    @Builder.Default
+    int maxConnectionsPerRoute = ConnectionPoolSettings.DEFAULT_MAX_CONNECTIONS_PER_ROUTE;
+
+    /**
+     * Creates a new {@link DefaultConnectionPoolSettings} with default values.
+     * <p>
+     * Default values:
+     * <ul>
+     * <li>Connect timeout: 2 minutes</li>
+     * <li>Socket timeout: 2 minutes</li>
+     * <li>Connection request timeout: 2 minutes</li>
+     * <li>Max connections total: 200</li>
+     * <li>Max connections per route: 100</li>
+     * </ul>
+     * </p>
+     *
+     * @return A new instance with default settings.
+     */
+    @Nonnull
+    public static DefaultConnectionPoolSettings ofDefaults()
+    {
+        return builder().build();
+    }
+}

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
@@ -3,18 +3,23 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
-import java.net.URI;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.junit.jupiter.api.Test;
 
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
+
+import javax.annotation.Nonnull;
+import java.util.Collections;
+import java.util.List;
 
 class ConnectionPoolManagerProvidersTest
 {
@@ -41,8 +46,7 @@ class ConnectionPoolManagerProvidersTest
         final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
         final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
 
-        final HttpDestinationProperties destination =
-            DefaultHttpDestination.builder(URI.create("http://example.com")).build();
+        final HttpDestinationProperties destination = DefaultHttpDestination.builder("http://example.com").build();
         final HttpClientConnectionManager manager3 = provider.getConnectionManager(DEFAULT_SETTINGS, destination);
 
         assertThat(manager1).isNotNull();
@@ -56,11 +60,11 @@ class ConnectionPoolManagerProvidersTest
         final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byDestinationName();
 
         final HttpDestinationProperties dest1 =
-            DefaultHttpDestination.builder(URI.create("http://example1.com")).name("dest-a").build();
+            DefaultHttpDestination.builder("http://example1.com").name("dest-a").build();
         final HttpDestinationProperties dest2 =
-            DefaultHttpDestination.builder(URI.create("http://example2.com")).name("dest-a").build();
+            DefaultHttpDestination.builder("http://example2.com").name("dest-a").build();
         final HttpDestinationProperties dest3 =
-            DefaultHttpDestination.builder(URI.create("http://example3.com")).name("dest-b").build();
+            DefaultHttpDestination.builder("http://example3.com").name("dest-b").build();
 
         final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, dest1);
         final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, dest2);
@@ -88,8 +92,7 @@ class ConnectionPoolManagerProvidersTest
     {
         final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byDestinationName();
 
-        final HttpDestinationProperties unnamedDest =
-            DefaultHttpDestination.builder(URI.create("http://example.com")).build();
+        final HttpDestinationProperties unnamedDest = DefaultHttpDestination.builder("http://example.com").build();
 
         final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, unnamedDest);
         final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
@@ -144,20 +147,16 @@ class ConnectionPoolManagerProvidersTest
     void testCachedWithCacheKeyCustomExtractor()
     {
         // Custom extractor that uses the URI host as cache key
-        final ConnectionPoolManagerProvider provider =
-            ConnectionPoolManagerProviders.cached().by(dest -> {
-                if( dest == null ) {
-                    return "no-destination";
-                }
-                return dest.getUri().getHost();
-            });
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().by(dest -> {
+            if( dest == null ) {
+                return "no-destination";
+            }
+            return dest.getUri().getHost();
+        });
 
-        final HttpDestinationProperties dest1 =
-            DefaultHttpDestination.builder(URI.create("http://host-a.com/path1")).build();
-        final HttpDestinationProperties dest2 =
-            DefaultHttpDestination.builder(URI.create("http://host-a.com/path2")).build();
-        final HttpDestinationProperties dest3 =
-            DefaultHttpDestination.builder(URI.create("http://host-b.com/path1")).build();
+        final HttpDestinationProperties dest1 = DefaultHttpDestination.builder("http://host-a.com/path1").build();
+        final HttpDestinationProperties dest2 = DefaultHttpDestination.builder("http://host-a.com/path2").build();
+        final HttpDestinationProperties dest3 = DefaultHttpDestination.builder("http://host-b.com/path1").build();
 
         final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, dest1);
         final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, dest2);
@@ -178,7 +177,7 @@ class ConnectionPoolManagerProvidersTest
             ConnectionPoolManagerProviders.cached(customCache::computeIfAbsent).byDestinationName();
 
         final HttpDestinationProperties dest =
-            DefaultHttpDestination.builder(URI.create("http://example.com")).name("my-dest").build();
+            DefaultHttpDestination.builder("http://example.com").name("my-dest").build();
 
         final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, dest);
         final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, dest);
@@ -246,5 +245,146 @@ class ConnectionPoolManagerProvidersTest
 
         final HttpClientConnectionManager manager = lambdaProvider.getConnectionManager(DEFAULT_SETTINGS, null);
         assertThat(manager).isNotNull();
+    }
+
+    @Test
+    void testCachedByIndicatedBehalfOfWithCurrentTenantHeaderProvider()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+
+        // Create a header provider that indicates NAMED_USER_CURRENT_TENANT
+        final DestinationHeaderProvider namedUserProvider =
+            new TestHeaderProvider(OnBehalfOf.NAMED_USER_CURRENT_TENANT);
+
+        // Create destinations with the header provider
+        final DefaultHttpDestination destTenant1 =
+            DefaultHttpDestination.builder("http://example.com").headerProviders(namedUserProvider).build();
+
+        final DefaultHttpDestination destTenant2 =
+            DefaultHttpDestination.builder("http://example.com").headerProviders(namedUserProvider).build();
+
+        // Same destination with same tenant should return same manager
+        final DefaultTenant tenant1 = new DefaultTenant("tenant-1");
+        final HttpClientConnectionManager managerTenant1 =
+            TenantAccessor
+                .executeWithTenant(tenant1, () -> provider.getConnectionManager(DEFAULT_SETTINGS, destTenant1));
+
+        final HttpClientConnectionManager managerTenant1Again =
+            TenantAccessor
+                .executeWithTenant(tenant1, () -> provider.getConnectionManager(DEFAULT_SETTINGS, destTenant2));
+
+        // Different tenant should return different manager
+        final DefaultTenant tenant2 = new DefaultTenant("tenant-2");
+        final HttpClientConnectionManager managerTenant2 =
+            TenantAccessor
+                .executeWithTenant(tenant2, () -> provider.getConnectionManager(DEFAULT_SETTINGS, destTenant1));
+
+        assertThat(managerTenant1).isNotNull();
+        assertThat(managerTenant1).isSameAs(managerTenant1Again); // Same tenant, same destination
+        assertThat(managerTenant1).isNotSameAs(managerTenant2); // Different tenant
+    }
+
+    @Test
+    void testCachedByIndicatedBehalfOfWithTechnicalUserCurrentTenant()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+
+        final DefaultHttpDestination dest =
+            DefaultHttpDestination
+                .builder("http://example.com")
+                .headerProviders(new TestHeaderProvider(OnBehalfOf.TECHNICAL_USER_CURRENT_TENANT))
+                .build();
+
+        // Different tenants should get different managers
+        final DefaultTenant tenant1 = new DefaultTenant("tenant-1");
+        final HttpClientConnectionManager managerTenant1 =
+            TenantAccessor.executeWithTenant(tenant1, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        final DefaultTenant tenant2 = new DefaultTenant("tenant-2");
+        final HttpClientConnectionManager managerTenant2 =
+            TenantAccessor.executeWithTenant(tenant2, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        assertThat(managerTenant1).isNotNull();
+        assertThat(managerTenant2).isNotNull();
+        assertThat(managerTenant1).isNotSameAs(managerTenant2); // Different tenant
+    }
+
+    @Test
+    void testCachedByIndicatedBehalfOfWithProviderUserSharesAcrossTenants()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+
+        // Create a header provider that indicates TECHNICAL_USER_PROVIDER (not current tenant)
+        final DefaultHttpDestination dest =
+            DefaultHttpDestination
+                .builder("http://example.com")
+                .headerProviders(new TestHeaderProvider(OnBehalfOf.TECHNICAL_USER_PROVIDER))
+                .build();
+
+        // Different tenants should share the same manager since it's not on behalf of current tenant
+        final DefaultTenant tenant1 = new DefaultTenant("tenant-1");
+        final HttpClientConnectionManager managerTenant1 =
+            TenantAccessor.executeWithTenant(tenant1, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        final DefaultTenant tenant2 = new DefaultTenant("tenant-2");
+        final HttpClientConnectionManager managerTenant2 =
+            TenantAccessor.executeWithTenant(tenant2, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        assertThat(managerTenant1).isNotNull();
+        assertThat(managerTenant1).isSameAs(managerTenant2); // Same manager shared across tenants
+    }
+
+    @Test
+    void testCachedByIndicatedBehalfOfWithNoHeaderProvider()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+
+        // Destination without any header provider
+        final DefaultHttpDestination dest = DefaultHttpDestination.builder("http://example.com").build();
+
+        // Different tenants should share the same manager since there's no on-behalf-of indication
+        final DefaultTenant tenant1 = new DefaultTenant("tenant-1");
+        final HttpClientConnectionManager managerTenant1 =
+            TenantAccessor.executeWithTenant(tenant1, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        final DefaultTenant tenant2 = new DefaultTenant("tenant-2");
+        final HttpClientConnectionManager managerTenant2 =
+            TenantAccessor.executeWithTenant(tenant2, () -> provider.getConnectionManager(DEFAULT_SETTINGS, dest));
+
+        assertThat(managerTenant1).isNotNull();
+        assertThat(managerTenant1).isSameAs(managerTenant2); // Same manager shared across tenants
+    }
+
+    @Test
+    void testCachedByIndicatedBehalfOfWithNonDefaultHttpDestination()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+
+        // Non-DefaultHttpDestination should return null key and create new manager each time
+        final HttpDestinationProperties nonDefaultDest = DefaultHttpDestination.builder("http://example.com").build();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, nonDefaultDest);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, nonDefaultDest);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager2).isNotNull();
+        assertThat(manager1).isSameAs(manager2); // New manager each time for non-DefaultHttpDestination
+    }
+
+    /**
+     * Test implementation of DestinationHeaderProvider that also implements IsOnBehalfOf.
+     */
+    @RequiredArgsConstructor
+    private static class TestHeaderProvider implements DestinationHeaderProvider, IsOnBehalfOf
+    {
+        @Getter
+        private final OnBehalfOf onBehalfOf;
+
+        @Nonnull
+        @Override
+        public List<Header> getHeaders( @Nonnull final DestinationRequestContext requestContext )
+        {
+            return Collections.emptyList();
+        }
     }
 }

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
@@ -1,0 +1,183 @@
+package com.sap.cloud.sdk.cloudplatform.connectivity;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNullPointerException;
+
+import java.net.URI;
+
+import org.apache.hc.client5.http.io.HttpClientConnectionManager;
+import org.junit.jupiter.api.Test;
+
+import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
+import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
+
+class ConnectionPoolManagerProvidersTest
+{
+    private static final ConnectionPoolSettings DEFAULT_SETTINGS = DefaultConnectionPoolSettings.ofDefaults();
+
+    @Test
+    void testNoCacheCreatesNewManagerEachTime()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.noCache();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager2).isNotNull();
+        assertThat(manager1).isNotSameAs(manager2);
+    }
+
+    @Test
+    void testGlobalReturnsSameManagerForAllCalls()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.global();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+
+        final HttpDestinationProperties destination =
+            DefaultHttpDestination.builder(URI.create("http://example.com")).build();
+        final HttpClientConnectionManager manager3 = provider.getConnectionManager(DEFAULT_SETTINGS, destination);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2);
+        assertThat(manager1).isSameAs(manager3);
+    }
+
+    @Test
+    void testByDestinationNameCachesByName()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.byDestinationName();
+
+        final HttpDestinationProperties dest1 =
+            DefaultHttpDestination.builder(URI.create("http://example1.com")).name("dest-a").build();
+        final HttpDestinationProperties dest2 =
+            DefaultHttpDestination.builder(URI.create("http://example2.com")).name("dest-a").build();
+        final HttpDestinationProperties dest3 =
+            DefaultHttpDestination.builder(URI.create("http://example3.com")).name("dest-b").build();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, dest1);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, dest2);
+        final HttpClientConnectionManager manager3 = provider.getConnectionManager(DEFAULT_SETTINGS, dest3);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2); // Same name "dest-a"
+        assertThat(manager1).isNotSameAs(manager3); // Different name "dest-b"
+    }
+
+    @Test
+    void testByDestinationNameHandlesNullDestination()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.byDestinationName();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2);
+    }
+
+    @Test
+    void testByDestinationNameHandlesUnnamedDestination()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.byDestinationName();
+
+        final HttpDestinationProperties unnamedDest =
+            DefaultHttpDestination.builder(URI.create("http://example.com")).build();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, unnamedDest);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+
+        // Both should use the same "null key" bucket
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2);
+    }
+
+    @Test
+    void testByTenantCachesByTenant()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.byTenant();
+
+        final HttpClientConnectionManager managerTenant1 =
+            TenantAccessor
+                .executeWithTenant(
+                    new DefaultTenant("tenant-1"),
+                    () -> provider.getConnectionManager(DEFAULT_SETTINGS, null));
+
+        final HttpClientConnectionManager managerTenant1Again =
+            TenantAccessor
+                .executeWithTenant(
+                    new DefaultTenant("tenant-1"),
+                    () -> provider.getConnectionManager(DEFAULT_SETTINGS, null));
+
+        final HttpClientConnectionManager managerTenant2 =
+            TenantAccessor
+                .executeWithTenant(
+                    new DefaultTenant("tenant-2"),
+                    () -> provider.getConnectionManager(DEFAULT_SETTINGS, null));
+
+        assertThat(managerTenant1).isNotNull();
+        assertThat(managerTenant1).isSameAs(managerTenant1Again); // Same tenant
+        assertThat(managerTenant1).isNotSameAs(managerTenant2); // Different tenant
+    }
+
+    @Test
+    void testByTenantHandlesNoTenant()
+    {
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.byTenant();
+
+        // Without tenant context
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, null);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2);
+    }
+
+    @Test
+    void testWithCacheKeyCustomExtractor()
+    {
+        // Custom extractor that uses the URI host as cache key
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.withCacheKey(dest -> {
+            if( dest == null ) {
+                return "no-destination";
+            }
+            return dest.getUri().getHost();
+        });
+
+        final HttpDestinationProperties dest1 =
+            DefaultHttpDestination.builder(URI.create("http://host-a.com/path1")).build();
+        final HttpDestinationProperties dest2 =
+            DefaultHttpDestination.builder(URI.create("http://host-a.com/path2")).build();
+        final HttpDestinationProperties dest3 =
+            DefaultHttpDestination.builder(URI.create("http://host-b.com/path1")).build();
+
+        final HttpClientConnectionManager manager1 = provider.getConnectionManager(DEFAULT_SETTINGS, dest1);
+        final HttpClientConnectionManager manager2 = provider.getConnectionManager(DEFAULT_SETTINGS, dest2);
+        final HttpClientConnectionManager manager3 = provider.getConnectionManager(DEFAULT_SETTINGS, dest3);
+
+        assertThat(manager1).isNotNull();
+        assertThat(manager1).isSameAs(manager2); // Same host "host-a.com"
+        assertThat(manager1).isNotSameAs(manager3); // Different host "host-b.com"
+    }
+
+    @Test
+    void testNullCacheKeyExtractorThrowsException()
+    {
+        assertThatNullPointerException()
+            .isThrownBy(() -> ConnectionPoolManagerProviders.withCacheKey(null))
+            .withMessageContaining("Cache key extractor must not be null");
+    }
+
+    @Test
+    void testFunctionalInterfaceCanBeUsedWithLambda()
+    {
+        // Verify that ConnectionPoolManagerProvider can be used as a lambda
+        final ConnectionPoolManagerProvider lambdaProvider =
+            ( settings, dest ) -> ConnectionPoolManagerProviders.noCache().getConnectionManager(settings, dest);
+
+        final HttpClientConnectionManager manager = lambdaProvider.getConnectionManager(DEFAULT_SETTINGS, null);
+        assertThat(manager).isNotNull();
+    }
+}

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
@@ -249,9 +249,9 @@ class ConnectionPoolManagerProvidersTest
     }
 
     @Test
-    void testCachedByIndicatedBehalfOfWithCurrentTenantHeaderProvider()
+    void testCachedByOnBehalfOfWithCurrentTenantHeaderProvider()
     {
-        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byOnBehalfOf();
 
         // Create a header provider that indicates NAMED_USER_CURRENT_TENANT
         final DestinationHeaderProvider namedUserProvider =
@@ -286,9 +286,9 @@ class ConnectionPoolManagerProvidersTest
     }
 
     @Test
-    void testCachedByIndicatedBehalfOfWithTechnicalUserCurrentTenant()
+    void testCachedByOnBehalfOfWithTechnicalUserCurrentTenant()
     {
-        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byOnBehalfOf();
 
         final DefaultHttpDestination dest =
             DefaultHttpDestination
@@ -311,9 +311,9 @@ class ConnectionPoolManagerProvidersTest
     }
 
     @Test
-    void testCachedByIndicatedBehalfOfWithProviderUserSharesAcrossTenants()
+    void testCachedByOnBehalfOfWithProviderUserSharesAcrossTenants()
     {
-        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byOnBehalfOf();
 
         // Create a header provider that indicates TECHNICAL_USER_PROVIDER (not current tenant)
         final DefaultHttpDestination dest =
@@ -336,9 +336,9 @@ class ConnectionPoolManagerProvidersTest
     }
 
     @Test
-    void testCachedByIndicatedBehalfOfWithNoHeaderProvider()
+    void testCachedByOnBehalfOfWithNoHeaderProvider()
     {
-        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byOnBehalfOf();
 
         // Destination without any header provider
         final DefaultHttpDestination dest = DefaultHttpDestination.builder("http://example.com").build();
@@ -357,9 +357,9 @@ class ConnectionPoolManagerProvidersTest
     }
 
     @Test
-    void testCachedByIndicatedBehalfOfWithNonDefaultHttpDestination()
+    void testCachedByOnBehalfOfWithNonDefaultHttpDestination()
     {
-        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf();
+        final ConnectionPoolManagerProvider provider = ConnectionPoolManagerProviders.cached().byOnBehalfOf();
 
         // Non-DefaultHttpDestination should return null key and create new manager each time
         final HttpDestinationProperties nonDefaultDest = DefaultHttpDestination.builder("http://example.com").build();

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ConnectionPoolManagerProvidersTest.java
@@ -3,23 +3,24 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatNullPointerException;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
 import java.util.function.Function;
 
-import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import javax.annotation.Nonnull;
+
 import org.apache.hc.client5.http.io.HttpClientConnectionManager;
 import org.junit.jupiter.api.Test;
 
 import com.sap.cloud.sdk.cloudplatform.tenant.DefaultTenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 
-import javax.annotation.Nonnull;
-import java.util.Collections;
-import java.util.List;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
 
 class ConnectionPoolManagerProvidersTest
 {

--- a/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
+++ b/cloudplatform/connectivity-apache-httpclient5/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/DefaultApacheHttpClient5CacheTest.java
@@ -46,9 +46,8 @@ class DefaultApacheHttpClient5CacheTest
 
     private static final ApacheHttpClient5Factory FACTORY =
         new DefaultApacheHttpClient5Factory(
-            DefaultApacheHttpClient5Factory.DEFAULT_TIMEOUT,
-            DefaultApacheHttpClient5Factory.DEFAULT_MAX_CONNECTIONS_TOTAL,
-            DefaultApacheHttpClient5Factory.DEFAULT_MAX_CONNECTIONS_PER_ROUTE,
+            DefaultConnectionPoolSettings.ofDefaults(),
+            ConnectionPoolManagerProviders.noCache(),
             null,
             ApacheHttpClient5FactoryBuilder.TlsUpgrade.AUTOMATIC);
     private static final long NANOSECONDS_IN_MINUTE = 60_000_000_000L;

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
@@ -11,14 +11,23 @@ import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 
 import io.vavr.control.Option;
 import lombok.RequiredArgsConstructor;
+import org.jetbrains.annotations.Nullable;
 
 @RequiredArgsConstructor
-class OAuth2HeaderProvider implements DestinationHeaderProvider
+class OAuth2HeaderProvider implements DestinationHeaderProvider, IsOnBehalfOf
 {
     @Nonnull
     private final OAuth2Service oauth2service;
+
     @Nonnull
     private final String authHeaderName;
+
+    @Nullable
+    @Override
+    public OnBehalfOf getOnBehalfOf()
+    {
+        return oauth2service.getOnBehalfOf();
+    }
 
     @Nonnull
     @Override

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2HeaderProvider.java
@@ -5,13 +5,13 @@ import static java.util.Collections.singletonList;
 import java.util.List;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import com.sap.cloud.sdk.cloudplatform.tenant.Tenant;
 import com.sap.cloud.sdk.cloudplatform.tenant.TenantAccessor;
 
 import io.vavr.control.Option;
 import lombok.RequiredArgsConstructor;
-import org.jetbrains.annotations.Nullable;
 
 @RequiredArgsConstructor
 class OAuth2HeaderProvider implements DestinationHeaderProvider, IsOnBehalfOf

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2Service.java
@@ -54,7 +54,7 @@ import lombok.extern.slf4j.Slf4j;
  */
 @RequiredArgsConstructor( access = AccessLevel.PACKAGE )
 @Slf4j
-class OAuth2Service
+class OAuth2Service implements IsOnBehalfOf
 {
     /**
      * Cache to reuse OAuth2TokenService and with that reuse the underlying response cache.
@@ -83,6 +83,7 @@ class OAuth2Service
     @Nonnull
     private final ClientIdentity identity;
     @Nonnull
+    @Getter
     private final OnBehalfOf onBehalfOf;
     @Nonnull
     private final TenantPropagationStrategy tenantPropagationStrategy;

--- a/release_notes.md
+++ b/release_notes.md
@@ -14,6 +14,16 @@
 ### ✨ New Functionality
 
 - [OpenAPI] Cloud SDK OpenAPI Generator now supports `apache-httpclient` library besides Spring RestTemplate through the newly introduced module `openapi-core-apache`.
+- [Connectivity HttpClient5] _(Experimental)_ Added opt-in API for caching HTTP connection pool managers to reduce memory consumption. 
+  Connection pool managers can consume ~100KB each, and this feature allows sharing them based on configurable caching strategies:
+  ```java
+  ApacheHttpClient5Factory factory = new ApacheHttpClient5FactoryBuilder()
+    .connectionPoolManagerProvider(ConnectionPoolManagerProviders.noCache()) // new API (default behavior)
+    .connectionPoolManagerProvider(ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf()) // new API
+    .build();
+  ```
+  Available caching strategies include `byCurrentTenant()`, `byDestinationName()`, `byIndicatedBehalfOf()`, and custom key extractors via `by(Function)`.
+  The `byIndicatedBehalfOf()` strategy intelligently determines tenant isolation requirements based on the destination's `OnBehalfOf` indication.
 
 ### 📈 Improvements
 

--- a/release_notes.md
+++ b/release_notes.md
@@ -19,11 +19,11 @@
   ```java
   ApacheHttpClient5Factory factory = new ApacheHttpClient5FactoryBuilder()
     .connectionPoolManagerProvider(ConnectionPoolManagerProviders.noCache()) // new API (default behavior)
-    .connectionPoolManagerProvider(ConnectionPoolManagerProviders.cached().byIndicatedBehalfOf()) // new API
+    .connectionPoolManagerProvider(ConnectionPoolManagerProviders.cached().byOnBehalfOf()) // new API
     .build();
   ```
-  Available caching strategies include `byCurrentTenant()`, `byDestinationName()`, `byIndicatedBehalfOf()`, and custom key extractors via `by(Function)`.
-  The `byIndicatedBehalfOf()` strategy intelligently determines tenant isolation requirements based on the destination's `OnBehalfOf` indication.
+  Available caching strategies include `byCurrentTenant()`, `byDestinationName()`, `byOnBehalfOf()`, and custom key extractors via `by(Function)`.
+  The `byOnBehalfOf()` strategy intelligently determines tenant isolation requirements based on the destination's `OnBehalfOf` indication.
 
 ### 📈 Improvements
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://github.com/SAP/cloud-sdk-java-backlog/issues/501

### Tasks
- [x] Initial implementation
- [ ] Measurement
- [ ] Feedback from CAP
  - [ ] Decision on / whether closing connection manager


This PR introduces a new opt-in API for caching HTTP connection pool managers in the Apache HttpClient 5 module. Connection pool managers can consume significant memory (~100KB each), and this feature allows users to reduce memory consumption by sharing connection managers based on configurable caching strategies.

###

Some users have reported high memory consumption due to the creation of many connection pool managers. By default, a new connection manager is created for each HTTP client, which provides maximum isolation but can lead to excessive memory usage in multi-tenant applications with many destinations.


This PR provides an opt-in mechanism to cache and reuse connection managers based on various strategies, including a smart `byOnBehalfOf()` strategy that automatically determines tenant isolation requirements based on the destination's header providers.

### Usage Example

```java
ApacheHttpClient5Factory factory = new ApacheHttpClient5FactoryBuilder()
    .connectionPoolManagerProvider(ConnectionPoolManagerProviders.cached().byOnBehalfOf()) // new API
    .build();

ApacheHttpClient5Accessor.setHttpClientFactory(factory);
```

### New API

#### `ConnectionPoolManagerProviders.noCache()`

A singleton reference to indicate no caching / no re-use.
This is the **default** value, the behavior we've had before the change.

#### `ConnectionPoolManagerProviders.cached()`

A fluent builder API for creating cached connection pool manager providers:

```java
// Use SINGLE connection pool manager by current tenant
ConnectionPoolManagerProviders.cached().byCurrentTenant()

// Cache SINGLE connection pool manager destination name
ConnectionPoolManagerProviders.cached().byDestinationName()

// Smart caching based on OnBehalfOf indication (recommended)
ConnectionPoolManagerProviders.cached().byOnBehalfOf()

// Custom cache key
ConnectionPoolManagerProviders.cached().by(dest -> dest.getUri().getHost())
```

#### Custom Cache Support

Users can supply their own cache implementation (e.g., Caffeine with expiration):

```java
// Using Caffeine cache with expiration
Cache<Object, HttpClientConnectionManager> cache = Caffeine.newBuilder()
    .expireAfterAccess(Duration.ofMinutes(30))
    .maximumSize(100)
    .build();

ConnectionPoolManagerProviders.cached(cache::get).byOnBehalfOf()
```

#### `byOnBehalfOf()` Strategy

This strategy intelligently determines whether tenant isolation is required by inspecting the destination's header providers for `IsOnBehalfOf` implementations:

- If a header provider indicates `NAMED_USER_CURRENT_TENANT` or `TECHNICAL_USER_CURRENT_TENANT`, the connection manager is cached per tenant
- If a header provider indicates `TECHNICAL_USER_PROVIDER` or no custom header provider exist on the destination, the connection manager is shared across tenants


### Breaking Changes

__None.__ This is a purely additive change:

- ✅ All existing public APIs remain unchanged
- ✅ Default behavior is unchanged (`noCache()` is still the default)
- ✅ Users must explicitly opt-in to use the new caching features
- ✅ All new APIs are marked as `@Beta`


## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
