### PR TITLE
feat: [OpenAPI] GZIP encoding

### DIFF
--- a/datamodel/openapi/openapi-core-apache/pom.xml
+++ b/datamodel/openapi/openapi-core-apache/pom.xml
@@ -94,5 +94,15 @@
             <artifactId>junit-jupiter-params</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.vavr</groupId>
+            <artifactId>vavr</artifactId>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 </project>

--- a/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/ApiClient.java
+++ b/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/ApiClient.java
@@ -14,6 +14,7 @@ package com.sap.cloud.sdk.services.openapi.apache.apiclient;
 
 import static com.sap.cloud.sdk.services.openapi.apache.apiclient.DefaultApiResponseHandler.isJsonMime;
 import static lombok.AccessLevel.PRIVATE;
+import static org.apache.hc.core5.http.HttpHeaders.CONTENT_ENCODING;
 
 import java.io.ByteArrayOutputStream;
 import java.io.File;
@@ -492,7 +493,7 @@ public class ApiClient
         if( body != null || !formParams.isEmpty() ) {
             if( isBodyAllowed(Method.valueOf(method)) ) {
                 // Add entity if we have content and a valid method
-                builder.setEntity(serialize(body, formParams, contentTypeObj, headerParams.get("Content-Encoding")));
+                builder.setEntity(serialize(body, formParams, contentTypeObj, headerParams));
             } else {
                 throw new OpenApiRequestException("method " + method + " does not support a request body");
             }
@@ -520,6 +521,8 @@ public class ApiClient
      *            Content type
      * @param formParams
      *            Form parameters
+     * @param headerParams
+     *            Header parameters, used to check content encoding for JSON serialization
      * @return Object
      * @throws OpenApiRequestException
      *             API exception
@@ -529,12 +532,12 @@ public class ApiClient
         @Nullable final Object body,
         @Nonnull final Map<String, Object> formParams,
         @Nonnull final ContentType contentType,
-        @Nullable final String contentEncoding )
+        @Nonnull final Map<String, String> headerParams )
         throws OpenApiRequestException
     {
         final String mimeType = contentType.getMimeType();
         if( isJsonMime(mimeType) ) {
-            return serializeJson(body, contentType, contentEncoding);
+            return serializeJson(body, contentType, headerParams);
         } else if( mimeType.equals(ContentType.MULTIPART_FORM_DATA.getMimeType()) ) {
             return serializeMultipart(formParams, contentType);
         } else if( mimeType.equals(ContentType.APPLICATION_FORM_URLENCODED.getMimeType()) ) {
@@ -551,18 +554,22 @@ public class ApiClient
     private HttpEntity serializeJson(
         @Nullable final Object body,
         @Nonnull final ContentType contentType,
-        @Nullable final String contentEncoding )
+        @Nonnull final Map<String, String> headerParams )
         throws OpenApiRequestException
     {
-        if( "gzip".equals(contentEncoding) ) {
+        if( "gzip".equalsIgnoreCase(headerParams.get(CONTENT_ENCODING))
+            || "gzip".equalsIgnoreCase(headerParams.get(CONTENT_ENCODING.toLowerCase())) ) {
             val outputStream = new ByteArrayOutputStream();
             try( val gzip = new GZIPOutputStream(outputStream) ) {
                 gzip.write(objectMapper.writeValueAsBytes(body));
             }
             catch( IOException e ) {
-                throw new OpenApiRequestException(e);
+                throw new OpenApiRequestException("Failed to GZIP compress request body", e);
             }
-            return new ByteArrayEntity(outputStream.toByteArray(), contentType.withCharset(StandardCharsets.UTF_8));
+            return new ByteArrayEntity(
+                outputStream.toByteArray(),
+                contentType.withCharset(StandardCharsets.UTF_8),
+                "gzip");
         }
         try {
             return new StringEntity(

--- a/datamodel/openapi/openapi-core-apache/src/test/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/ApacheApiClientResponseHandlingTest.java
+++ b/datamodel/openapi/openapi-core-apache/src/test/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/ApacheApiClientResponseHandlingTest.java
@@ -10,22 +10,30 @@ import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static com.github.tomakehurst.wiremock.client.WireMock.verify;
 import static org.assertj.core.api.Assertions.assertThat;
 
+import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.zip.GZIPInputStream;
 
+import org.apache.hc.client5.http.impl.classic.CloseableHttpClient;
+import org.apache.hc.core5.http.protocol.HttpContext;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
 import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import com.sap.cloud.sdk.cloudplatform.connectivity.ApacheHttpClient5Accessor;
 import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
 import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiResponse;
 
+import io.vavr.control.Try;
 import lombok.Data;
+import lombok.SneakyThrows;
 
 @WireMockTest
 class ApacheApiClientResponseHandlingTest
@@ -88,14 +96,19 @@ class ApacheApiClientResponseHandlingTest
     }
 
     @Test
+    @SneakyThrows
     void testGzipEncodedPayload( final WireMockRuntimeInfo wmInfo )
     {
         stubFor(post(urlEqualTo(TEST_POST_PATH)).willReturn(aResponse().withStatus(200).withBody(TEST_RESPONSE_BODY)));
 
-        final ApiClient apiClient = ApiClient.create().withBasePath(wmInfo.getHttpBaseUrl());
-
+        final CloseableHttpClient client = Mockito.spy((CloseableHttpClient) ApacheHttpClient5Accessor.getHttpClient());
+        final ApiClient apiClient = ApiClient.fromHttpClient(client).withBasePath(wmInfo.getHttpBaseUrl());
         final TestPostApi api = new TestPostApi(apiClient);
         final TestResponse result = api.executeGzipRequest();
+        Mockito.verify(client, Mockito.times(1)).execute(Mockito.argThat(request -> {
+            final byte[] c = Try.of(() -> new GZIPInputStream(request.getEntity().getContent()).readAllBytes()).get();
+            return new String(c, StandardCharsets.UTF_8).contains("test payload");
+        }), Mockito.any(HttpContext.class), Mockito.any());
 
         assertThat(result).isNotNull();
         assertThat(result.getMessage()).isEqualTo("success");


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

Smaller payloads.
Corresponding AI SDK PR:
- https://github.com/SAP/ai-sdk-java/pull/779
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

SAP/cloud-sdk-java-backlog#363.


**Smaller payload.**
Corresponding AI SDK PR:
- https://github.com/SAP/ai-sdk-java/pull/779

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] If `Content-Encoding` is set to `gzip` -> compress the request payload

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [ ] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
