### PR TITLE
feat: add configurable token_format parameter for IAS token exchange

### DIFF
--- a/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
+++ b/cloudplatform/cloudplatform-connectivity/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServiceOptions.java
@@ -325,6 +325,23 @@ public final class BtpServiceOptions
         }
 
         /**
+         * Specifies the token format to request from IAS during token exchange.
+         * <p>
+         * If not specified, the {@code token_format} parameter is not included in the token exchange request, and IAS
+         * will use its default behavior (SAML). Explicitly set to {@code "jwt"} if the target service requires JWT
+         * tokens.
+         *
+         * @param format
+         *            The token format to request. Typically {@code "jwt"} or {@code "saml"}.
+         * @return An instance of {@link OptionsEnhancer} for the token format.
+         */
+        @Nonnull
+        public static OptionsEnhancer<?> withTokenFormat( @Nonnull final String format )
+        {
+            return new TokenFormat(format);
+        }
+
+        /**
          * An {@link OptionsEnhancer} that contains the target URI for an IAS-based destination. Also refer to
          * {@link #withTargetUri(String)}.
          *
@@ -381,6 +398,19 @@ public final class BtpServiceOptions
             {
                 return this;
             }
+        }
+
+        /**
+         * An {@link OptionsEnhancer} that specifies the token format for IAS token requests. If not provided, the
+         * {@code token_format} parameter is not included in the token exchange request. Also refer to
+         * {@link #withTokenFormat(String)}.
+         */
+        @Value
+        @AllArgsConstructor( access = AccessLevel.PRIVATE )
+        public static class TokenFormat implements OptionsEnhancer<String>
+        {
+            @Nonnull
+            String value;
         }
     }
 }

--- a/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
+++ b/cloudplatform/connectivity-oauth/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliers.java
@@ -2,6 +2,7 @@ package com.sap.cloud.sdk.cloudplatform.connectivity;
 
 import static com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.AuthenticationServiceOptions.TargetUri;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.IasOptions.IasCommunicationOptions;
+import static com.sap.cloud.sdk.cloudplatform.connectivity.BtpServiceOptions.IasOptions.TokenFormat;
 import static com.sap.cloud.sdk.cloudplatform.connectivity.MultiUrlPropertySupplier.REMOVE_PATH;
 
 import java.net.URI;
@@ -189,6 +190,9 @@ class BtpServicePropertySuppliers
             } else {
                 attachIasCommunicationOptions(builder);
                 builder.withTokenRetrievalParameter("app_tid", getCredentialOrThrow(String.class, "app_tid"));
+                options
+                    .getOption(TokenFormat.class)
+                    .peek(format -> builder.withTokenRetrievalParameter("token_format", format));
             }
             attachClientKeyStore(builder);
 

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/BtpServicePropertySuppliersTest.java
@@ -789,6 +789,75 @@ class BtpServicePropertySuppliersTest
             }
         }
 
+        @Test
+        void testTokenFormatExplicitJwt()
+        {
+            final ServiceBindingDestinationOptions options =
+                ServiceBindingDestinationOptions
+                    .forService(BINDING)
+                    .onBehalfOf(OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                    .withOption(IasOptions.withApplicationName("app-name"))
+                    .withOption(IasOptions.withTokenFormat("jwt"))
+                    .build();
+
+            final OAuth2PropertySupplier sut = IDENTITY_AUTHENTICATION.resolve(options);
+            final OAuth2Options oAuth2Options = sut.getOAuth2Options();
+
+            assertThat(oAuth2Options.getAdditionalTokenRetrievalParameters())
+                .containsExactlyInAnyOrderEntriesOf(
+                    Map
+                        .of(
+                            "resource",
+                            "urn:sap:identity:application:provider:name:app-name",
+                            "app_tid",
+                            PROVIDER_TENANT_ID,
+                            "token_format",
+                            "jwt"));
+        }
+
+        @Test
+        void testTokenFormatExplicitSaml()
+        {
+            final ServiceBindingDestinationOptions options =
+                ServiceBindingDestinationOptions
+                    .forService(BINDING)
+                    .onBehalfOf(OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                    .withOption(IasOptions.withApplicationName("app-name"))
+                    .withOption(IasOptions.withTokenFormat("saml"))
+                    .build();
+
+            final OAuth2PropertySupplier sut = IDENTITY_AUTHENTICATION.resolve(options);
+            final OAuth2Options oAuth2Options = sut.getOAuth2Options();
+
+            assertThat(oAuth2Options.getAdditionalTokenRetrievalParameters())
+                .containsExactlyInAnyOrderEntriesOf(
+                    Map
+                        .of(
+                            "resource",
+                            "urn:sap:identity:application:provider:name:app-name",
+                            "app_tid",
+                            PROVIDER_TENANT_ID,
+                            "token_format",
+                            "saml"));
+        }
+
+        @Test
+        void testTokenFormatWithoutApplicationName()
+        {
+            final ServiceBindingDestinationOptions options =
+                ServiceBindingDestinationOptions
+                    .forService(BINDING)
+                    .onBehalfOf(OnBehalfOf.NAMED_USER_CURRENT_TENANT)
+                    .withOption(IasOptions.withTokenFormat("jwt"))
+                    .build();
+
+            final OAuth2PropertySupplier sut = IDENTITY_AUTHENTICATION.resolve(options);
+            final OAuth2Options oAuth2Options = sut.getOAuth2Options();
+
+            assertThat(oAuth2Options.getAdditionalTokenRetrievalParameters())
+                .containsExactlyInAnyOrderEntriesOf(Map.of("app_tid", PROVIDER_TENANT_ID, "token_format", "jwt"));
+        }
+
         @SneakyThrows
         private static void assertThatClientCertificateIsContained( @Nonnull final KeyStore keyStore )
         {


### PR DESCRIPTION
## Context

- Add `IasOptions.withTokenFormat()` to allow specifying token format
- Token format parameter only sent when explicitly configured
- Add comprehensive tests for JWT and SAML token format options

Users can now explicitly request JWT tokens from IAS:

```
.withOption(IasOptions.withTokenFormat("jwt"))
```

If not specified, `token_format` parameter is not included in the request, preserving existing IAS default behavior.

Fixes [Add token_format=jwt parameter to IAS principal propagation token requests #1111](https://github.com/SAP/cloud-sdk-java/issues/1111)

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

