### PR TITLE
feat: [OpenAPI] `withDefaultHeader` on Api classes

### DIFF
--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/petstore/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/petstore/api/DefaultApi.java
@@ -54,6 +54,21 @@ public class DefaultApi extends BaseApi
     }
 
     /**
+     * Creates a new API instance with additional default headers.
+     *
+     * @param defaultHeaders
+     *            Additional headers to include in all requests
+     * @return A new API instance with the combined headers
+     */
+    public DefaultApi withDefaultHeaders( @Nonnull final Map<String, String> defaultHeaders )
+    {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
+    /**
      * <p>
      * <p>
      * Creates a new pet in the store. Duplicates are allowed
@@ -97,19 +112,18 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "POST",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                pet,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "POST",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            pet,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -159,19 +173,18 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "DELETE",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "DELETE",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -221,19 +234,18 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "GET",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "GET",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -281,19 +293,18 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "GET",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "GET",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/petstore/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/petstore/api/DefaultApi.java
@@ -100,7 +100,7 @@ public class DefaultApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -112,18 +112,19 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "POST",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            pet,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "POST",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                pet,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -159,7 +160,7 @@ public class DefaultApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -173,18 +174,19 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "DELETE",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "DELETE",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -220,7 +222,7 @@ public class DefaultApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json", "application/xml", "text/xml", "text/html" };
@@ -234,18 +236,19 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "GET",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -276,7 +279,7 @@ public class DefaultApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         localVarCollectionQueryParams.addAll(ApiClient.parameterToPairs("csv", "tags", tags));
@@ -293,18 +296,19 @@ public class DefaultApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "GET",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/OrdersApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/OrdersApi.java
@@ -95,7 +95,7 @@ public class OrdersApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -107,17 +107,18 @@ public class OrdersApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "POST",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            order,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "POST",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                order,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 }

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/OrdersApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/OrdersApi.java
@@ -51,6 +51,21 @@ public class OrdersApi extends BaseApi
     }
 
     /**
+     * Creates a new API instance with additional default headers.
+     *
+     * @param defaultHeaders
+     *            Additional headers to include in all requests
+     * @return A new API instance with the combined headers
+     */
+    public OrdersApi withDefaultHeaders( @Nonnull final Map<String, String> defaultHeaders )
+    {
+        final var api = new OrdersApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
+    /**
      * <p>
      * Create a new order
      * <p>
@@ -92,18 +107,17 @@ public class OrdersApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "POST",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                order,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "POST",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            order,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 }

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
@@ -53,6 +53,21 @@ public class SodasApi extends BaseApi
     }
 
     /**
+     * Creates a new API instance with additional default headers.
+     *
+     * @param defaultHeaders
+     *            Additional headers to include in all requests
+     * @return A new API instance with the combined headers
+     */
+    public SodasApi withDefaultHeaders( @Nonnull final Map<String, String> defaultHeaders )
+    {
+        final var api = new SodasApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
+    /**
      * <p>
      * Download soda product data as binary
      * <p>
@@ -100,19 +115,18 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "GET",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "GET",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -151,19 +165,18 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "GET",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "GET",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -213,19 +226,18 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "GET",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                null,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "GET",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            null,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 
     /**
@@ -274,18 +286,17 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return apiClient
-            .invokeAPI(
-                localVarPath,
-                "PUT",
-                localVarQueryParams,
-                localVarCollectionQueryParams,
-                localVarQueryStringJoiner.toString(),
-                sodaWithId,
-                localVarHeaderParams,
-                localVarFormParams,
-                localVarAccept,
-                localVarContentType,
-                localVarReturnType);
+        return invokeAPI(
+            localVarPath,
+            "PUT",
+            localVarQueryParams,
+            localVarCollectionQueryParams,
+            localVarQueryStringJoiner.toString(),
+            sodaWithId,
+            localVarHeaderParams,
+            localVarFormParams,
+            localVarAccept,
+            localVarContentType,
+            localVarReturnType);
     }
 }

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
@@ -101,7 +101,7 @@ public class SodasApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/octet-stream" };
@@ -115,18 +115,19 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "GET",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -151,7 +152,7 @@ public class SodasApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -165,18 +166,19 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "GET",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -212,7 +214,7 @@ public class SodasApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -226,18 +228,19 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "GET",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            null,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 
     /**
@@ -274,7 +277,7 @@ public class SodasApi extends BaseApi
         final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
         final List<Pair> localVarQueryParams = new ArrayList<Pair>();
         final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-        final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
         final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
         final String[] localVarAccepts = { "application/json" };
@@ -286,17 +289,18 @@ public class SodasApi extends BaseApi
         {
         };
 
-        return invokeAPI(
-            localVarPath,
-            "PUT",
-            localVarQueryParams,
-            localVarCollectionQueryParams,
-            localVarQueryStringJoiner.toString(),
-            sodaWithId,
-            localVarHeaderParams,
-            localVarFormParams,
-            localVarAccept,
-            localVarContentType,
-            localVarReturnType);
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "PUT",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                sodaWithId,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
     }
 }

--- a/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
+++ b/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
@@ -12,8 +12,14 @@
 
 package com.sap.cloud.sdk.services.openapi.apache.apiclient;
 
-import javax.annotation.Nonnull;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
 
 /**
@@ -25,6 +31,8 @@ public abstract class BaseApi
      * The API client used to execute HTTP requests.
      */
     protected final ApiClient apiClient;
+
+    protected final Map<String, String> defaultHeaders = new HashMap<>();
 
     /**
      * Creates a new BaseApi instance with default configuration.
@@ -54,5 +62,37 @@ public abstract class BaseApi
     protected BaseApi( @Nonnull final ApiClient apiClient )
     {
         this.apiClient = apiClient;
+    }
+
+    @Nonnull
+    protected <T> T invokeAPI(
+        @Nonnull final String path,
+        @Nonnull final String method,
+        @Nullable final List<Pair> queryParams,
+        @Nullable final List<Pair> collectionQueryParams,
+        @Nullable final String urlQueryDeepObject,
+        @Nullable final Object body,
+        @Nonnull final Map<String, String> headerParams,
+        @Nonnull final Map<String, Object> formParams,
+        @Nullable final String accept,
+        @Nonnull final String contentType,
+        @Nonnull final TypeReference<T> returnType )
+    {
+
+        final var mergedHeaderParams = new HashMap<>(defaultHeaders);
+        mergedHeaderParams.putAll(headerParams);
+        return apiClient
+            .invokeAPI(
+                path,
+                method,
+                queryParams,
+                collectionQueryParams,
+                urlQueryDeepObject,
+                body,
+                mergedHeaderParams,
+                formParams,
+                accept,
+                contentType,
+                returnType);
     }
 }

--- a/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
+++ b/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
@@ -13,15 +13,11 @@
 package com.sap.cloud.sdk.services.openapi.apache.apiclient;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
-import com.fasterxml.jackson.core.type.TypeReference;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
-import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
 
 /**
  * Base class for generated API classes, providing common functionality for API client management.
@@ -66,68 +62,5 @@ public abstract class BaseApi
     protected BaseApi( @Nonnull final ApiClient apiClient )
     {
         this.apiClient = apiClient;
-    }
-
-    /**
-     * Invoke API by sending HTTP request with the given options.
-     *
-     * @param <T>
-     *            Type
-     * @param path
-     *            The sub-path of the HTTP URL
-     * @param method
-     *            The request method, one of "GET", "POST", "PUT", and "DELETE"
-     * @param queryParams
-     *            The query parameters
-     * @param collectionQueryParams
-     *            The collection query parameters
-     * @param urlQueryDeepObject
-     *            A URL query string for deep object parameters
-     * @param body
-     *            The request body object - if it is not binary, otherwise null
-     * @param headerParams
-     *            The header parameters
-     * @param formParams
-     *            The form parameters
-     * @param accept
-     *            The request's Accept header
-     * @param contentType
-     *            The request's Content-Type header
-     * @param returnType
-     *            Return type
-     * @return The response body in type of string
-     * @throws OpenApiRequestException
-     *             API exception
-     */
-    @Nonnull
-    protected <T> T invokeAPI(
-        @Nonnull final String path,
-        @Nonnull final String method,
-        @Nullable final List<Pair> queryParams,
-        @Nullable final List<Pair> collectionQueryParams,
-        @Nullable final String urlQueryDeepObject,
-        @Nullable final Object body,
-        @Nonnull final Map<String, String> headerParams,
-        @Nonnull final Map<String, Object> formParams,
-        @Nullable final String accept,
-        @Nonnull final String contentType,
-        @Nonnull final TypeReference<T> returnType )
-    {
-
-        final var mergedHeaderParams = new HashMap<>(defaultHeaders);
-        mergedHeaderParams.putAll(headerParams);
-        return apiClient
-            .invokeAPI(
-                path,
-                method,
-                queryParams,
-                collectionQueryParams,
-                urlQueryDeepObject,
-                body,
-                mergedHeaderParams,
-                formParams,
-                accept,
-                contentType,
-                returnType);
     }
 }

--- a/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
+++ b/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
@@ -33,6 +33,9 @@ public abstract class BaseApi
      */
     protected final ApiClient apiClient;
 
+    /**
+     * Default headers to be included in every request.
+     */
     protected final Map<String, String> defaultHeaders = new HashMap<>();
 
     /**

--- a/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
+++ b/datamodel/openapi/openapi-core-apache/src/main/java/com/sap/cloud/sdk/services/openapi/apache/apiclient/BaseApi.java
@@ -21,6 +21,7 @@ import javax.annotation.Nullable;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
 
 /**
  * Base class for generated API classes, providing common functionality for API client management.
@@ -64,6 +65,37 @@ public abstract class BaseApi
         this.apiClient = apiClient;
     }
 
+    /**
+     * Invoke API by sending HTTP request with the given options.
+     *
+     * @param <T>
+     *            Type
+     * @param path
+     *            The sub-path of the HTTP URL
+     * @param method
+     *            The request method, one of "GET", "POST", "PUT", and "DELETE"
+     * @param queryParams
+     *            The query parameters
+     * @param collectionQueryParams
+     *            The collection query parameters
+     * @param urlQueryDeepObject
+     *            A URL query string for deep object parameters
+     * @param body
+     *            The request body object - if it is not binary, otherwise null
+     * @param headerParams
+     *            The header parameters
+     * @param formParams
+     *            The form parameters
+     * @param accept
+     *            The request's Accept header
+     * @param contentType
+     *            The request's Content-Type header
+     * @param returnType
+     *            Return type
+     * @return The response body in type of string
+     * @throws OpenApiRequestException
+     *             API exception
+     */
     @Nonnull
     protected <T> T invokeAPI(
         @Nonnull final String path,

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/api.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/api.mustache
@@ -91,7 +91,24 @@ public class {{classname}} extends BaseApi {
     {
     super(aiCoreService.getApiClient());
     }
+
+    private {{classname}}(@Nonnull final ApiClient apiClient) {
+        super(apiClient);
+    }
     {{/aiSdkConstructor}}
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public {{classname}} withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new {{classname}}(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
 
     {{#operation}}
         {{#hasOptionalParams}}

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/operationBody.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/operationBody.mustache
@@ -12,7 +12,7 @@ final String localVarPath = "{{{path}}}"{{#pathParams}}
 final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
 final List<Pair> localVarQueryParams = new ArrayList<Pair>();
 final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
 final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
 
 {{#queryParams}}
@@ -75,7 +75,7 @@ final TypeReference<{{{returnType}}}> localVarReturnType = new TypeReference<{{{
 final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
 {{/returnType}}
 
-return invokeAPI(
+return apiClient.invokeAPI(
     localVarPath,
     "{{httpMethod}}",
     localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/operationBody.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/operationBody.mustache
@@ -75,7 +75,7 @@ final TypeReference<{{{returnType}}}> localVarReturnType = new TypeReference<{{{
 final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
 {{/returnType}}
 
-return apiClient.invokeAPI(
+return invokeAPI(
     localVarPath,
     "{{httpMethod}}",
     localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodaApi.java
@@ -55,6 +55,23 @@ public class AwesomeSodaApi extends BaseApi {
     super(aiCoreService.getApiClient());
     }
 
+    private AwesomeSodaApi(@Nonnull final ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public AwesomeSodaApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new AwesomeSodaApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Add a new soda to the store
@@ -95,7 +112,7 @@ public class AwesomeSodaApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodaApi.java
@@ -97,7 +97,7 @@ public class AwesomeSodaApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -112,7 +112,7 @@ public class AwesomeSodaApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodasApi.java
@@ -54,6 +54,23 @@ public class AwesomeSodasApi extends BaseApi {
     super(aiCoreService.getApiClient());
     }
 
+    private AwesomeSodasApi(@Nonnull final ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public AwesomeSodasApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new AwesomeSodasApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Get a list of all sodas
@@ -86,7 +103,7 @@ public class AwesomeSodasApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/AwesomeSodasApi.java
@@ -88,7 +88,7 @@ public class AwesomeSodasApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -103,7 +103,7 @@ public class AwesomeSodasApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
@@ -99,7 +99,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -114,7 +114,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -155,7 +155,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -170,7 +170,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -219,7 +219,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -234,7 +234,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-for-ai-sdk/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
@@ -55,6 +55,23 @@ public class DefaultApi extends BaseApi {
     super(aiCoreService.getApiClient());
     }
 
+    private DefaultApi(@Nonnull final ApiClient apiClient) {
+        super(apiClient);
+    }
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public DefaultApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Delete a specific soda from the store
@@ -97,7 +114,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -153,7 +170,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -217,7 +234,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
@@ -57,6 +57,19 @@ public class AwesomeSodaApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public AwesomeSodaApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new AwesomeSodaApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Add a new soda to the store
@@ -97,7 +110,7 @@ public class AwesomeSodaApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodaApi.java
@@ -95,7 +95,7 @@ public class AwesomeSodaApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -110,7 +110,7 @@ public class AwesomeSodaApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
@@ -56,6 +56,19 @@ public class AwesomeSodasApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public AwesomeSodasApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new AwesomeSodasApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Get a list of all sodas
@@ -88,7 +101,7 @@ public class AwesomeSodasApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/AwesomeSodasApi.java
@@ -86,7 +86,7 @@ public class AwesomeSodasApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -101,7 +101,7 @@ public class AwesomeSodasApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -57,6 +57,19 @@ public class DefaultApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public DefaultApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Delete a specific soda from the store
@@ -99,7 +112,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -155,7 +168,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -219,7 +232,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-json/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -97,7 +97,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -112,7 +112,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -153,7 +153,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -168,7 +168,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -217,7 +217,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -232,7 +232,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -58,6 +58,19 @@ public class DefaultApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public DefaultApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Add a new soda to the store
@@ -98,7 +111,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,
@@ -154,7 +167,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -210,7 +223,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -256,7 +269,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -320,7 +333,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/DefaultApi.java
@@ -96,7 +96,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -111,7 +111,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,
@@ -152,7 +152,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -167,7 +167,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -208,7 +208,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -223,7 +223,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -254,7 +254,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -269,7 +269,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -318,7 +318,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -333,7 +333,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/inlineobject-schemas-enabled/output/com/sap/cloud/sdk/services/inlineobject/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/inlineobject-schemas-enabled/output/com/sap/cloud/sdk/services/inlineobject/api/DefaultApi.java
@@ -100,7 +100,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -115,7 +115,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/inlineobject-schemas-enabled/output/com/sap/cloud/sdk/services/inlineobject/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/inlineobject-schemas-enabled/output/com/sap/cloud/sdk/services/inlineobject/api/DefaultApi.java
@@ -59,6 +59,19 @@ public class DefaultApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public DefaultApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Get details of a specific soda
@@ -102,7 +115,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/partial-generation/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/partial-generation/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
@@ -98,7 +98,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -113,7 +113,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -154,7 +154,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -169,7 +169,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<SodaWithFoo> localVarReturnType = new TypeReference<SodaWithFoo>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -218,7 +218,7 @@ public class DefaultApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -233,7 +233,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/partial-generation/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/partial-generation/output/com/sap/cloud/sdk/services/builder/api/DefaultApi.java
@@ -58,6 +58,19 @@ public class DefaultApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public DefaultApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new DefaultApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Delete a specific soda from the store
@@ -100,7 +113,7 @@ public class DefaultApi extends BaseApi {
             
                         final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
             
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "DELETE",
                 localVarQueryParams,
@@ -156,7 +169,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<SodaWithFoo> localVarReturnType = new TypeReference<SodaWithFoo>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -220,7 +233,7 @@ public class DefaultApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/OrdersApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/OrdersApi.java
@@ -94,7 +94,7 @@ public class OrdersApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -109,7 +109,7 @@ public class OrdersApi extends BaseApi {
             
             final TypeReference<Order> localVarReturnType = new TypeReference<Order>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/OrdersApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/OrdersApi.java
@@ -56,6 +56,19 @@ public class OrdersApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public OrdersApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new OrdersApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Create a new order
@@ -96,7 +109,7 @@ public class OrdersApi extends BaseApi {
             
             final TypeReference<Order> localVarReturnType = new TypeReference<Order>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "POST",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/SodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/SodasApi.java
@@ -57,6 +57,19 @@ public class SodasApi extends BaseApi {
     super(apiClient);
     }
 
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public SodasApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new SodasApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
 
         /**
          * <p>Get all soda products
@@ -89,7 +102,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<List<SodaWithId>> localVarReturnType = new TypeReference<List<SodaWithId>>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -145,7 +158,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<SodaWithId> localVarReturnType = new TypeReference<SodaWithId>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -201,7 +214,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return apiClient.invokeAPI(
+            return invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/SodasApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/remove-operation-id-prefix/output/com/sap/cloud/sdk/services/builder/api/SodasApi.java
@@ -87,7 +87,7 @@ public class SodasApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -102,7 +102,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<List<SodaWithId>> localVarReturnType = new TypeReference<List<SodaWithId>>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -143,7 +143,7 @@ public class SodasApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -158,7 +158,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<SodaWithId> localVarReturnType = new TypeReference<SodaWithId>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "GET",
                 localVarQueryParams,
@@ -199,7 +199,7 @@ public class SodasApi extends BaseApi {
             final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
             final List<Pair> localVarQueryParams = new ArrayList<Pair>();
             final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
-            final Map<String, String> localVarHeaderParams = new HashMap<String, String>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
             final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
             
                                     
@@ -214,7 +214,7 @@ public class SodasApi extends BaseApi {
             
             final TypeReference<Soda> localVarReturnType = new TypeReference<Soda>() {};
                         
-            return invokeAPI(
+            return apiClient.invokeAPI(
                 localVarPath,
                 "PUT",
                 localVarQueryParams,


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

https://github.com/SAP/ai-sdk-java-backlog/issues/379

API enabling users to add custom headers from generated `*Api` classes.

This is simply alternative to what is presented in https://github.com/SAP/cloud-sdk-java/pull/1129

**Pro:** custom header api directly visible to user without directly instantiating `ApiClient` instance
**Con:** Its only the header that is customizable. Any addition customization (eg: query params) -> addition of new api 

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
