### PR TITLE
chore: Bump service-binding library to newly released version

### DIFF
--- a/dependency-bundles/bom/pom.xml
+++ b/dependency-bundles/bom/pom.xml
@@ -45,7 +45,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<!-- do not modify the following line, it is updated by the versioning script -->
 		<sdk.version>5.28.0-SNAPSHOT</sdk.version>
-		<service-binding.version>0.21.0</service-binding.version>
+		<service-binding.version>0.30.0</service-binding.version>
 		<!-- HTTP stuff -->
 		<httpcore.version>4.4.16</httpcore.version>
 		<httpcore5.version>5.4.2</httpcore5.version>


### PR DESCRIPTION
## Context

This PR introduces the newly released version `0.30.0` of [btp environment variable access](https://github.com/SAP/btp-environment-variable-access).