### PR TITLE
feat: expose slowCallDurationThreshold in CircuitBreakerConfiguration

### DIFF
--- a/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
+++ b/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
@@ -429,6 +429,18 @@ public class ResilienceConfiguration
         public static final Duration DEFAULT_WAIT_DURATION = Duration.ofSeconds(10);
 
         /**
+         * The default duration threshold above which calls are considered as slow.
+         * Matches the Resilience4j default of 60 seconds.
+         */
+        public static final Duration DEFAULT_SLOW_CALL_DURATION_THRESHOLD = Duration.ofSeconds(60);
+
+        /**
+         * The default slow call rate threshold (as percentage within [0, 100]).
+         * Matches the Resilience4j default of 100%.
+         */
+        public static final float DEFAULT_SLOW_CALL_RATE_THRESHOLD = 100;
+
+        /**
          * Flag to indicate active CircuitBreakerConfiguration.
          */
         @Getter( AccessLevel.NONE )
@@ -460,6 +472,22 @@ public class ResilienceConfiguration
          * is the maximum number of requests that may take place in parallel during the <i>HALF OPEN</i> state.
          */
         private int halfOpenBufferSize = DEFAULT_HALF_OPEN_BUFFER_SIZE;
+
+        /**
+         * The duration threshold above which calls are considered as slow and increase the slow call rate.
+         * When the percentage of slow calls is equal to or greater than {@link #slowCallRateThreshold},
+         * the CircuitBreaker transitions to <i>OPEN</i> and starts short-circuiting calls.
+         */
+        @Nonnull
+        private Duration slowCallDurationThreshold = DEFAULT_SLOW_CALL_DURATION_THRESHOLD;
+
+        /**
+         * The slow call rate threshold (as percentage within [0, 100]). The CircuitBreaker considers a call as slow
+         * when the call duration is greater than {@link #slowCallDurationThreshold}. When the percentage of slow calls
+         * is equal to or greater than the threshold, the CircuitBreaker transitions to <i>OPEN</i> and starts
+         * short-circuiting calls.
+         */
+        private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
 
         /**
          * Get the status indicator for the CircuitBreaker.

--- a/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
+++ b/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
@@ -477,6 +477,8 @@ public class ResilienceConfiguration
          * The duration threshold above which calls are considered as slow and increase the slow call rate. When the
          * percentage of slow calls is equal to or greater than {@link #slowCallRateThreshold}, the CircuitBreaker
          * transitions to <i>OPEN</i> and starts short-circuiting calls.
+         *
+         * @since 5.29.0
          */
         @Nonnull
         private Duration slowCallDurationThreshold = DEFAULT_SLOW_CALL_DURATION_THRESHOLD;
@@ -486,6 +488,8 @@ public class ResilienceConfiguration
          * when the call duration is greater than {@link #slowCallDurationThreshold}. When the percentage of slow calls
          * is equal to or greater than the threshold, the CircuitBreaker transitions to <i>OPEN</i> and starts
          * short-circuiting calls.
+         *
+         * @since 5.29.0
          */
         private float slowCallRateThreshold = DEFAULT_SLOW_CALL_RATE_THRESHOLD;
 

--- a/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
+++ b/cloudplatform/resilience-api/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience/ResilienceConfiguration.java
@@ -429,14 +429,14 @@ public class ResilienceConfiguration
         public static final Duration DEFAULT_WAIT_DURATION = Duration.ofSeconds(10);
 
         /**
-         * The default duration threshold above which calls are considered as slow.
-         * Matches the Resilience4j default of 60 seconds.
+         * The default duration threshold above which calls are considered as slow. Matches the Resilience4j default of
+         * 60 seconds.
          */
         public static final Duration DEFAULT_SLOW_CALL_DURATION_THRESHOLD = Duration.ofSeconds(60);
 
         /**
-         * The default slow call rate threshold (as percentage within [0, 100]).
-         * Matches the Resilience4j default of 100%.
+         * The default slow call rate threshold (as percentage within [0, 100]). Matches the Resilience4j default of
+         * 100%.
          */
         public static final float DEFAULT_SLOW_CALL_RATE_THRESHOLD = 100;
 
@@ -474,9 +474,9 @@ public class ResilienceConfiguration
         private int halfOpenBufferSize = DEFAULT_HALF_OPEN_BUFFER_SIZE;
 
         /**
-         * The duration threshold above which calls are considered as slow and increase the slow call rate.
-         * When the percentage of slow calls is equal to or greater than {@link #slowCallRateThreshold},
-         * the CircuitBreaker transitions to <i>OPEN</i> and starts short-circuiting calls.
+         * The duration threshold above which calls are considered as slow and increase the slow call rate. When the
+         * percentage of slow calls is equal to or greater than {@link #slowCallRateThreshold}, the CircuitBreaker
+         * transitions to <i>OPEN</i> and starts short-circuiting calls.
          */
         @Nonnull
         private Duration slowCallDurationThreshold = DEFAULT_SLOW_CALL_DURATION_THRESHOLD;

--- a/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/DefaultCircuitBreakerProvider.java
+++ b/cloudplatform/resilience4j/src/main/java/com/sap/cloud/sdk/cloudplatform/resilience4j/DefaultCircuitBreakerProvider.java
@@ -55,6 +55,8 @@ public class DefaultCircuitBreakerProvider implements CircuitBreakerProvider, Ge
                 .slidingWindowSize(configuration.circuitBreakerConfiguration().closedBufferSize())
                 .minimumNumberOfCalls(configuration.circuitBreakerConfiguration().closedBufferSize())
                 .permittedNumberOfCallsInHalfOpenState(configuration.circuitBreakerConfiguration().halfOpenBufferSize())
+                .slowCallDurationThreshold(configuration.circuitBreakerConfiguration().slowCallDurationThreshold())
+                .slowCallRateThreshold(configuration.circuitBreakerConfiguration().slowCallRateThreshold())
                 .build();
 
         val circuitBreaker = circuitBreakerRegistry.circuitBreaker(identifier, customCircuitBreakerConfig);


### PR DESCRIPTION
## Summary

Exposes the `slowCallDurationThreshold` and `slowCallRateThreshold` properties from resilience4j's `CircuitBreakerConfig` in the SAP Cloud SDK's `ResilienceConfiguration.CircuitBreakerConfiguration` wrapper.

## Motivation
Currently, users who need to configure slow-call detection for their circuit breakers must resort to reflection to access the underlying resilience4j configuration, which is fragile and not officially supported.
The resilience4j `CircuitBreakerConfig` supports:
- `slowCallDurationThreshold` — duration above which a call is considered slow
- `slowCallRateThreshold` — percentage of slow calls that triggers the circuit breaker to open
These are common production requirements, especially when integrating with external systems (e.g., SAP OData services) that may degrade gradually rather than fail outright.

## Changes
- Added `slowCallDurationThreshold(Duration)` and `slowCallRateThreshold(int)` to `CircuitBreakerConfiguration`
- These values are forwarded to the underlying resilience4j `CircuitBreakerConfig.Builder`
- Closes https://github.com/SAP/cloud-sdk-java/issues/1148