### PR TITLE
fix: Upgrade minor netty version (transitive dependency patch)

### DIFF
--- a/cloudplatform/connectivity-ztis/pom.xml
+++ b/cloudplatform/connectivity-ztis/pom.xml
@@ -28,6 +28,9 @@
 			<organizationUrl>https://www.sap.com</organizationUrl>
 		</developer>
 	</developers>
+	<properties>
+		<netty.version>4.1.132.Final</netty.version>
+	</properties>
 	<dependencyManagement>
 		<dependencies>
 			<!-- resolve inconsistent versions coming from spiffe -> io.grpc -->
@@ -37,6 +40,64 @@
 				<version>1.80.0</version>
 				<type>pom</type>
 				<scope>import</scope>
+			</dependency>
+
+			<!-- Enforce minor netty dependency upgrade for grpc-netty -->
+			<!-- Remove if CVE-2026-33870 and CVE-2026-33871 are no longer affected. -->
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-handler-proxy</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-common</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-socks</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-buffer</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-resolver</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-codec-http2</artifactId>
+				<version>${netty.version}</version>
+			</dependency>
+			<dependency>
+				<groupId>io.netty</groupId>
+				<artifactId>netty-transport-native-unix-common</artifactId>
+				<version>${netty.version}</version>
 			</dependency>
 		</dependencies>
 	</dependencyManagement>


### PR DESCRIPTION
Currently blackduck scan is failing for 
* CVE-2026-33870 (7.5)
* CVE-2026-33871 (7.5)

Let's fix that by forcing a transitive dependency patch.