### PR TITLE
fix: [OpenAPI] Pin file upload parameter to `File` type

### DIFF
--- a/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/java/com/sap/cloud/sdk/datamodel/openapi/apache/sodastore/api/SodasApi.java
@@ -4,6 +4,7 @@
 
 package com.sap.cloud.sdk.datamodel.openapi.apache.sodastore.api;
 
+import java.io.File;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -21,6 +22,7 @@ import com.sap.cloud.sdk.services.openapi.apache.apiclient.ApiClient;
 import com.sap.cloud.sdk.services.openapi.apache.apiclient.BaseApi;
 import com.sap.cloud.sdk.services.openapi.apache.apiclient.Pair;
 import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiResponse;
 
 /**
  * SodaStore API in version 1.0.0.
@@ -232,6 +234,68 @@ public class SodasApi extends BaseApi
             .invokeAPI(
                 localVarPath,
                 "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType);
+    }
+
+    /**
+     * <p>
+     * Import soda data from a file
+     * <p>
+     * <p>
+     * <b>200</b> - Imported successfully
+     *
+     * @param _file
+     *            The value for the parameter _file
+     * @return An OpenApiResponse containing the status code of the HttpResponse.
+     * @throws OpenApiRequestException
+     *             if an error occurs while attempting to invoke the API
+     */
+    @Nonnull
+    public OpenApiResponse sodasImportPost( @Nonnull final File _file )
+        throws OpenApiRequestException
+    {
+
+        // verify the required parameter '_file' is set
+        if( _file == null ) {
+            throw new OpenApiRequestException("Missing the required parameter '_file' when calling sodasImportPost")
+                .statusCode(400);
+        }
+
+        // create path and map variables
+        final String localVarPath = "/sodas/upload";
+
+        final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+        final List<Pair> localVarQueryParams = new ArrayList<Pair>();
+        final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+        final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
+        final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+
+        if( _file != null )
+            localVarFormParams.put("file", _file);
+
+        final String[] localVarAccepts = {
+
+        };
+        final String localVarAccept = ApiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = { "multipart/form-data" };
+        final String localVarContentType = ApiClient.selectHeaderContentType(localVarContentTypes);
+
+        final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>()
+        {
+        };
+
+        return apiClient
+            .invokeAPI(
+                localVarPath,
+                "POST",
                 localVarQueryParams,
                 localVarCollectionQueryParams,
                 localVarQueryStringJoiner.toString(),

--- a/datamodel/openapi/openapi-api-apache-sample/src/main/resources/sodastore.yaml
+++ b/datamodel/openapi/openapi-api-apache-sample/src/main/resources/sodastore.yaml
@@ -281,6 +281,27 @@ paths:
                 format: binary
         '404':
           description: Soda product not found
+  /sodas/upload:
+    post:
+      summary: Import soda data from a file
+      operationId: sodasImportPost
+      tags:
+        - Sodas
+      requestBody:
+        required: true
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: Imported successfully
   /orders:
     post:
       summary: Create a new order

--- a/datamodel/openapi/openapi-api-apache-sample/src/test/java/com/sap/cloud/sdk/services/openapi/apache/SerializationTest.java
+++ b/datamodel/openapi/openapi-api-apache-sample/src/test/java/com/sap/cloud/sdk/services/openapi/apache/SerializationTest.java
@@ -1,6 +1,13 @@
 package com.sap.cloud.sdk.services.openapi.apache;
 
+import static com.github.tomakehurst.wiremock.client.WireMock.aMultipart;
+import static com.github.tomakehurst.wiremock.client.WireMock.containing;
+import static com.github.tomakehurst.wiremock.client.WireMock.postRequestedFor;
+import static com.github.tomakehurst.wiremock.client.WireMock.urlEqualTo;
 import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.File;
+import java.io.IOException;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -98,12 +105,28 @@ class SerializationTest
         assertThat(new ObjectMapper().readValue(expected, Order.class)).isEqualTo(order);
     }
 
+    @Test
+    void testFileUploadHasFilenameInContentDisposition()
+        throws IOException
+    {
+        WireMock.stubFor(WireMock.post(urlEqualTo("/sodas/upload")).willReturn(WireMock.ok()));
+
+        final var tempFile = File.createTempFile("test-soda-import", ".csv");
+        tempFile.deleteOnExit();
+
+        sut.sodasImportPost(tempFile);
+
+        final var filePart =
+            aMultipart("file").withHeader("Content-Disposition", containing(tempFile.getName())).build();
+        WireMock.verify(postRequestedFor(urlEqualTo("/sodas/upload")).withRequestBodyPart(filePart));
+    }
+
     private void verify( String requestBody )
     {
         WireMock
             .verify(
                 WireMock
-                    .putRequestedFor(WireMock.urlEqualTo("/sodas"))
+                    .putRequestedFor(urlEqualTo("/sodas"))
                     .withHeader("Content-Type", WireMock.equalTo("application/json; charset=UTF-8"))
                     .withRequestBody(WireMock.equalToJson(requestBody)));
     }

--- a/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/api.mustache
+++ b/datamodel/openapi/openapi-generator/src/main/resources/openapi-generator/mustache-templates/libraries/apache-httpclient/api.mustache
@@ -146,7 +146,7 @@ public class {{classname}} extends BaseApi {
             @Deprecated
             {{/isDeprecated}}
             {{#vendorExtensions.x-return-nullable}}@Nullable{{/vendorExtensions.x-return-nullable}}{{^vendorExtensions.x-return-nullable}}@Nonnull{{/vendorExtensions.x-return-nullable}}
-            public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}OpenApiResponse {{/returnType}}{{#vendorExtensions.x-sap-cloud-sdk-operation-name}}{{vendorExtensions.x-sap-cloud-sdk-operation-name}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}{{^vendorExtensions.x-sap-cloud-sdk-operation-name}}{{operationId}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}({{#allParams}}{{>nullable_var_annotations}} final {{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/allParams}}) throws OpenApiRequestException {
+            public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}OpenApiResponse {{/returnType}}{{#vendorExtensions.x-sap-cloud-sdk-operation-name}}{{vendorExtensions.x-sap-cloud-sdk-operation-name}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}{{^vendorExtensions.x-sap-cloud-sdk-operation-name}}{{operationId}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}({{#allParams}}{{>nullable_var_annotations}} final {{#isFile}}File{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}} {{^-last}}, {{/-last}}{{/allParams}}) throws OpenApiRequestException {
             {{>operationBody}}
             }
         {{/hasOptionalParams}}
@@ -185,7 +185,7 @@ public class {{classname}} extends BaseApi {
             @Deprecated
         {{/isDeprecated}}
         {{#vendorExtensions.x-return-nullable}}@Nullable{{/vendorExtensions.x-return-nullable}}{{^vendorExtensions.x-return-nullable}}@Nonnull{{/vendorExtensions.x-return-nullable}}
-        public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}OpenApiResponse {{/returnType}}{{#vendorExtensions.x-sap-cloud-sdk-operation-name}}{{vendorExtensions.x-sap-cloud-sdk-operation-name}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}{{^vendorExtensions.x-sap-cloud-sdk-operation-name}}{{operationId}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}({{#requiredParams}}{{>nullable_var_annotations}} final {{{dataType}}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}) throws OpenApiRequestException {
+        public {{#returnType}}{{{returnType}}} {{/returnType}}{{^returnType}}OpenApiResponse {{/returnType}}{{#vendorExtensions.x-sap-cloud-sdk-operation-name}}{{vendorExtensions.x-sap-cloud-sdk-operation-name}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}{{^vendorExtensions.x-sap-cloud-sdk-operation-name}}{{operationId}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}({{#requiredParams}}{{>nullable_var_annotations}} final {{#isFile}}File{{/isFile}}{{^isFile}}{{{dataType}}}{{/isFile}} {{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}) throws OpenApiRequestException {
         {{#hasOptionalParams}}
             return {{#vendorExtensions.x-sap-cloud-sdk-operation-name}}{{vendorExtensions.x-sap-cloud-sdk-operation-name}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}{{^vendorExtensions.x-sap-cloud-sdk-operation-name}}{{operationId}}{{/vendorExtensions.x-sap-cloud-sdk-operation-name}}({{#hasRequiredParams}}{{#requiredParams}}{{paramName}}{{^-last}}, {{/-last}}{{/requiredParams}}, {{/hasRequiredParams}}{{#optionalParams}}null{{^-last}}, {{/-last}}{{/optionalParams}});
         {{/hasOptionalParams}}

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorApacheIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorApacheIntegrationTest.java
@@ -57,7 +57,8 @@ class DataModelGeneratorApacheIntegrationTest extends DataModelGeneratorIntegrat
                 .withSapCopyrightHeader(true)
                 .oneOfAnyOfGenerationEnabled(testCase.anyOfOneOfGenerationEnabled)
                 .additionalProperty("useAbstractionForFiles", "true")
-                .additionalProperty("library", LIBRARY);
+                .additionalProperty("library", LIBRARY)
+                .typeMappings(testCase.typeMappings);
 
         testCase.additionalProperties.forEach(generationConfiguration::additionalProperty);
 
@@ -103,7 +104,8 @@ class DataModelGeneratorApacheIntegrationTest extends DataModelGeneratorIntegrat
                 .withSapCopyrightHeader(true)
                 .oneOfAnyOfGenerationEnabled(testCase.anyOfOneOfGenerationEnabled)
                 .additionalProperty("useAbstractionForFiles", "true")
-                .additionalProperty("library", LIBRARY);
+                .additionalProperty("library", LIBRARY)
+                .typeMappings(testCase.typeMappings);
         testCase.additionalProperties.forEach(generationConfiguration::additionalProperty);
 
         GenerationConfiguration build = generationConfiguration.build();

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -36,7 +36,8 @@ class DataModelGeneratorIntegrationTest
             true,
             true,
             6,
-            Map.of("aiSdkConstructor", "true", "fixRedundantIsBooleanPrefix", "true", "useFloatArrays", "true")),
+            Map.of("aiSdkConstructor", "true", "fixRedundantIsBooleanPrefix", "true", "useFloatArrays", "true"),
+            Map.of()),
         API_CLASS_VENDOR_EXTENSION_YAML(
             "api-class-vendor-extension-yaml",
             "sodastore.yaml",
@@ -46,6 +47,7 @@ class DataModelGeneratorIntegrationTest
             false,
             true,
             4,
+            Map.of(),
             Map.of()),
         API_CLASS_VENDOR_EXTENSION_JSON(
             "api-class-vendor-extension-json",
@@ -56,6 +58,7 @@ class DataModelGeneratorIntegrationTest
             false,
             true,
             6,
+            Map.of(),
             Map.of()),
         INLINEOBJECT_SCHEMA_NAME(
             "inlineobject-schemas-enabled",
@@ -66,7 +69,8 @@ class DataModelGeneratorIntegrationTest
             true,
             true,
             5,
-            Map.of("fixResponseSchemaTitles", "true")),
+            Map.of("fixResponseSchemaTitles", "true"),
+            Map.of()),
         PARTIAL_GENERATION(
             "partial-generation",
             "sodastore.json",
@@ -80,7 +84,8 @@ class DataModelGeneratorIntegrationTest
                 .ofEntries(
                     entry("excludePaths", "/sodas,/foobar/{baz}"),
                     entry("excludeProperties", "Foo.bar,Soda.embedding,Soda.flavor,UpdateSoda.flavor,SodaWithFoo.foo"),
-                    entry("removeUnusedComponents", "true"))),
+                    entry("removeUnusedComponents", "true")),
+            Map.of()),
         INPUT_SPEC_WITH_UPPERCASE_FILE_EXTENSION(
             "input-spec-with-uppercase-file-extension",
             "sodastore.JSON",
@@ -90,6 +95,7 @@ class DataModelGeneratorIntegrationTest
             false,
             true,
             6,
+            Map.of(),
             Map.of()),
         ONE_OF_INTERFACES_DISABLED(
             "oneof-interfaces-disabled",
@@ -100,6 +106,7 @@ class DataModelGeneratorIntegrationTest
             false,
             true,
             9,
+            Map.of(),
             Map.of()),
         ONE_OF_INTERFACES_ENABLED(
             "oneof-interfaces-enabled",
@@ -110,7 +117,8 @@ class DataModelGeneratorIntegrationTest
             true,
             true,
             11,
-            Map.of("useOneOfInterfaces", "true", "useOneOfCreators", "true", "useFloatArrays", "true")),
+            Map.of("useOneOfInterfaces", "true", "useOneOfCreators", "true", "useFloatArrays", "true"),
+            Map.of()),
         INPUT_SPEC_WITH_BUILDER(
             "input-spec-with-builder",
             "sodastore.JSON",
@@ -127,7 +135,8 @@ class DataModelGeneratorIntegrationTest
                     "pojoBuildMethodName",
                     "build",
                     "pojoConstructorVisibility",
-                    "private")),
+                    "private"),
+            Map.of()),
         REMOVE_OPERATION_ID_PREFIX(
             "remove-operation-id-prefix",
             "sodastore.json",
@@ -144,7 +153,8 @@ class DataModelGeneratorIntegrationTest
                     "removeOperationIdPrefixDelimiter",
                     "\\.",
                     "removeOperationIdPrefixCount",
-                    "3")),
+                    "3"),
+            Map.of()),
         GENERATE_APIS(
             "generate-apis",
             "sodastore.yaml",
@@ -154,7 +164,19 @@ class DataModelGeneratorIntegrationTest
             true,
             false,
             7,
-            Map.of());
+            Map.of(),
+            Map.of()),
+        FILE_HANDLING(
+            "file-handling",
+            "file-handling.yaml",
+            "com.sap.cloud.sdk.services.filehandling.api",
+            "com.sap.cloud.sdk.services.filehandling.model",
+            ApiMaturity.RELEASED,
+            false,
+            true,
+            1,
+            Map.of(),
+            Map.of("File", "byte[]"));
 
         final String testCaseName;
         final String inputSpecFileName;
@@ -165,10 +187,11 @@ class DataModelGeneratorIntegrationTest
         final boolean generateApis;
         final int expectedNumberOfGeneratedFiles;
         final Map<String, String> additionalProperties;
+        final Map<String, String> typeMappings;
     }
 
     @ParameterizedTest
-    @EnumSource( TestCase.class )
+    @EnumSource( value = TestCase.class, mode = EnumSource.Mode.EXCLUDE, names = { "FILE_HANDLING" } )
     void integrationTests( final TestCase testCase, @TempDir final Path path )
         throws Throwable
     {
@@ -194,7 +217,8 @@ class DataModelGeneratorIntegrationTest
                 .outputDirectory(tempOutputDirectory.toAbsolutePath().toString())
                 .withSapCopyrightHeader(true)
                 .oneOfAnyOfGenerationEnabled(testCase.anyOfOneOfGenerationEnabled)
-                .additionalProperty("useAbstractionForFiles", "true");
+                .additionalProperty("useAbstractionForFiles", "true")
+                .typeMappings(testCase.typeMappings);
         testCase.additionalProperties.forEach(generationConfiguration::additionalProperty);
 
         final Try<GenerationResult> maybeGenerationResult =
@@ -229,7 +253,8 @@ class DataModelGeneratorIntegrationTest
                 .deleteOutputDirectory(true)
                 .withSapCopyrightHeader(true)
                 .oneOfAnyOfGenerationEnabled(testCase.anyOfOneOfGenerationEnabled)
-                .additionalProperty("useAbstractionForFiles", "true");
+                .additionalProperty("useAbstractionForFiles", "true")
+                .typeMappings(testCase.typeMappings);
         testCase.additionalProperties.forEach(generationConfiguration::additionalProperty);
 
         GenerationConfiguration build = generationConfiguration.build();

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/file-handling/input/file-handling.yaml
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/file-handling/input/file-handling.yaml
@@ -1,0 +1,41 @@
+openapi: 3.0.0
+info:
+  title: Soda Store API
+  version: 1.0.0
+  description: API for managing sodas in a soda store
+
+paths:
+  /files/import:
+    post:
+      operationId: importFile
+      tags:
+        - Files
+      summary: Upload a file
+      requestBody:
+        content:
+          multipart/form-data:
+            schema:
+              type: object
+              required:
+                - file
+              properties:
+                file:
+                  type: string
+                  format: binary
+      responses:
+        '200':
+          description: File imported successfully
+  /files/export:
+    get:
+      operationId: exportFile
+      tags:
+        - Files
+      summary: Download a file
+      responses:
+        '200':
+          description: File content as binary
+          content:
+            application/octet-stream:
+              schema:
+                type: string
+                format: binary

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/file-handling/output/com/sap/cloud/sdk/services/filehandling/api/FilesApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/file-handling/output/com/sap/cloud/sdk/services/filehandling/api/FilesApi.java
@@ -1,0 +1,174 @@
+/*
+ * Copyright (c) 2026 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.sdk.services.filehandling.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiResponse;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.ApiClient;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.BaseApi;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.Pair;
+
+
+import java.io.File;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
+
+
+/**
+ * Soda Store API in version 1.0.0.
+ * <p>
+ * API for managing sodas in a soda store
+ */
+public class FilesApi extends BaseApi {
+
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API.
+     *
+     * @param httpDestination The destination that API should be used with
+     */
+    public FilesApi( @Nonnull final Destination httpDestination )
+    {
+    super(httpDestination);
+    }
+
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API based on a given {@link ApiClient}.
+     *
+     * @param apiClient
+     *            ApiClient to invoke the API on
+     */
+    public FilesApi(@Nonnull final ApiClient apiClient) {
+    super(apiClient);
+    }
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public FilesApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new FilesApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
+
+        /**
+         * <p>Download a file
+         * <p>
+         * <p><b>200</b> - File content as binary
+         * @return byte[]
+         * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+         */
+        @Nonnull
+        public byte[] exportFile() throws OpenApiRequestException {
+            
+            // create path and map variables
+            final String localVarPath = "/files/export";
+            
+            final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+            final List<Pair> localVarQueryParams = new ArrayList<Pair>();
+            final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
+            final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+            
+                                    
+            final String[] localVarAccepts = {
+            "application/octet-stream"
+            };
+            final String localVarAccept = ApiClient.selectHeaderAccept(localVarAccepts);
+            final String[] localVarContentTypes = {
+            
+            };
+            final String localVarContentType = ApiClient.selectHeaderContentType(localVarContentTypes);
+            
+            final TypeReference<byte[]> localVarReturnType = new TypeReference<byte[]>() {};
+                        
+            return apiClient.invokeAPI(
+                localVarPath,
+                "GET",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType
+            );
+        }
+
+        /**
+         * <p>Upload a file
+         * <p>
+         * <p><b>200</b> - File imported successfully
+         * @param _file
+             *      The value for the parameter _file
+         * @return An OpenApiResponse containing the status code of the HttpResponse.
+         * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+         */
+        @Nonnull
+        public OpenApiResponse importFile(@Nonnull final File _file) throws OpenApiRequestException {
+            
+            // verify the required parameter '_file' is set
+            if (_file == null) {
+            throw new OpenApiRequestException("Missing the required parameter '_file' when calling importFile")
+            .statusCode(400);
+            }
+            
+            // create path and map variables
+            final String localVarPath = "/files/import";
+            
+            final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+            final List<Pair> localVarQueryParams = new ArrayList<Pair>();
+            final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
+            final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+            
+                        if (_file != null)
+                localVarFormParams.put("file", _file);
+            
+            final String[] localVarAccepts = {
+            
+            };
+            final String localVarAccept = ApiClient.selectHeaderAccept(localVarAccepts);
+            final String[] localVarContentTypes = {
+            "multipart/form-data"
+            };
+            final String localVarContentType = ApiClient.selectHeaderContentType(localVarContentTypes);
+            
+                        final TypeReference<OpenApiResponse> localVarReturnType = new TypeReference<OpenApiResponse>() {};
+            
+            return apiClient.invokeAPI(
+                localVarPath,
+                "POST",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType
+            );
+        }
+        }

--- a/release_notes.md
+++ b/release_notes.md
@@ -4,19 +4,20 @@
 
 ### 🚧 Known Issues
 
-- 
+-
 
 ### 🔧 Compatibility Notes
 
-- 
+- [OpenAPI] In Apache HttpClient generator, file upload parameters are now pinned to type `java.io.File`, unmodifiable with `<typeMappings>` in generator configuration.
 
 ### ✨ New Functionality
 
-- 
+-
 
 ### 📈 Improvements
 
-- Enable Retry behavior for HttpClient5 instances, to mirror legacy behvior for HttpClient4: `1` retry with `1s` delay for response codes `429` (Too Many Requests) and `503` (Service Unavailable).
+- Enable Retry behavior for HttpClient5 instances, to mirror legacy behvior for HttpClient4: `1` retry with `1s` delay
+  for response codes `429` (Too Many Requests) and `503` (Service Unavailable).
 
 ### 🐛 Fixed Issues
 


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

- https://github.com/SAP/ai-sdk-java-backlog/issues/391

On file uploads, the remote service may expect (here Prompt Registry) `Content-Disposition` header to contain the `filename`. At the moment, setting `<typeMappings>File=byte[]<typeMappings>` can replace all occurrence of `File` type with `byte[]`.

This means on upload operations, we end up losing filename information, critical for correct successful response.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Pin the parameter type to `File` in upload operation 
  - [x] Unmodifiable with `<typeMappings>File=byte[]<typeMappings>` override. Now only influence return type on download operations.

**This is a breaking change.**

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [x] Release notes updated

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [ ] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
