### PR TITLE
fix: [OpenAPI] Api client method with oneOf primitive param stays simplified in OpenAPI generator 7.22.0

### DIFF
--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
@@ -2,6 +2,8 @@ package com.sap.cloud.sdk.datamodel.openapi.generator;
 
 import java.util.Map;
 
+import javax.annotation.Nonnull;
+
 import org.openapitools.codegen.OpenAPINormalizer;
 import org.openapitools.codegen.utils.ModelUtils;
 
@@ -22,7 +24,7 @@ public class CustomOpenAPINormalizer extends OpenAPINormalizer
      * @param inputRules
      *            a map of rules
      */
-    public CustomOpenAPINormalizer( final OpenAPI openAPI, final Map<String, String> inputRules )
+    public CustomOpenAPINormalizer( final @Nonnull OpenAPI openAPI, final @Nonnull Map<String, String> inputRules )
     {
         super(openAPI, inputRules);
     }
@@ -35,7 +37,7 @@ public class CustomOpenAPINormalizer extends OpenAPINormalizer
      */
     @Override
     @SuppressWarnings( { "unchecked", "rawtypes" } )
-    protected void normalizeReferenceSchema( Schema schema )
+    protected void normalizeReferenceSchema( final @Nonnull Schema schema )
     {
         if( schema.getType() != null || schema.getTypes() != null && !schema.getTypes().isEmpty() ) {
             // clears type(s) given that $ref is set
@@ -70,7 +72,7 @@ public class CustomOpenAPINormalizer extends OpenAPINormalizer
             // The swagger-parser may copy properties (description, example, etc.) from the
             // referenced schema onto the $ref schema object. Wrapping primitives in allOf
             // prevents proper type simplification (e.g., oneOf with a single primitive).
-            Schema referencedSchema = ModelUtils.getReferencedSchema(openAPI, schema);
+            final Schema referencedSchema = ModelUtils.getReferencedSchema(openAPI, schema);
             if( referencedSchema != null
                 && (ModelUtils.isStringSchema(referencedSchema)
                     || ModelUtils.isIntegerSchema(referencedSchema)

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
@@ -8,9 +8,20 @@ import org.openapitools.codegen.utils.ModelUtils;
 import io.swagger.v3.oas.models.OpenAPI;
 import io.swagger.v3.oas.models.media.Schema;
 
+/**
+ * Fix Api client methods with oneOf primitive param to stay simplified from OpenAPI generator 7.22.0
+ */
 public class CustomOpenAPINormalizer extends OpenAPINormalizer
 {
 
+    /**
+     * Initializes OpenAPI Normalizer with a set of rules
+     *
+     * @param openAPI
+     *            OpenAPI
+     * @param inputRules
+     *            a map of rules
+     */
     public CustomOpenAPINormalizer( final OpenAPI openAPI, final Map<String, String> inputRules )
     {
         super(openAPI, inputRules);

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/CustomOpenAPINormalizer.java
@@ -1,0 +1,77 @@
+package com.sap.cloud.sdk.datamodel.openapi.generator;
+
+import java.util.Map;
+
+import org.openapitools.codegen.OpenAPINormalizer;
+import org.openapitools.codegen.utils.ModelUtils;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.media.Schema;
+
+public class CustomOpenAPINormalizer extends OpenAPINormalizer
+{
+
+    public CustomOpenAPINormalizer( final OpenAPI openAPI, final Map<String, String> inputRules )
+    {
+        super(openAPI, inputRules);
+    }
+
+    /**
+     * Normalize reference schema with allOf to support sibling properties
+     *
+     * @param schema
+     *            Schema
+     */
+    @Override
+    @SuppressWarnings( { "unchecked", "rawtypes" } )
+    protected void normalizeReferenceSchema( Schema schema )
+    {
+        if( schema.getType() != null || schema.getTypes() != null && !schema.getTypes().isEmpty() ) {
+            // clears type(s) given that $ref is set
+            schema.setType(null);
+            schema.setTypes(null);
+            LOGGER.warn("Type(s) cleared (set to null) given $ref is set to {}.", schema.get$ref());
+        }
+
+        if( schema.getTitle() != null
+            || schema.getDescription() != null
+            || schema.getNullable() != null
+            || schema.getDefault() != null
+            || schema.getDeprecated() != null
+            || schema.getMaximum() != null
+            || schema.getMinimum() != null
+            || schema.getExclusiveMaximum() != null
+            || schema.getExclusiveMinimum() != null
+            || schema.getMaxItems() != null
+            || schema.getMinItems() != null
+            || schema.getMaxProperties() != null
+            || schema.getMinProperties() != null
+            || schema.getMaxLength() != null
+            || schema.getMinLength() != null
+            || schema.getWriteOnly() != null
+            || schema.getReadOnly() != null
+            || schema.getExample() != null
+            || (schema.getExamples() != null && !schema.getExamples().isEmpty())
+            || schema.getMultipleOf() != null
+            || schema.getPattern() != null
+            || (schema.getExtensions() != null && !schema.getExtensions().isEmpty()) ) {
+            // Don't wrap in allOf if the referenced schema is a primitive type.
+            // The swagger-parser may copy properties (description, example, etc.) from the
+            // referenced schema onto the $ref schema object. Wrapping primitives in allOf
+            // prevents proper type simplification (e.g., oneOf with a single primitive).
+            Schema referencedSchema = ModelUtils.getReferencedSchema(openAPI, schema);
+            if( referencedSchema != null
+                && (ModelUtils.isStringSchema(referencedSchema)
+                    || ModelUtils.isIntegerSchema(referencedSchema)
+                    || ModelUtils.isNumberSchema(referencedSchema)
+                    || ModelUtils.isBooleanSchema(referencedSchema)) ) {
+                return;
+            }
+
+            // create allOf with a $ref schema
+            schema.addAllOfItem(new Schema<>().$ref(schema.get$ref()));
+            // clear $ref in original schema
+            schema.set$ref(null);
+        }
+    }
+}

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -10,7 +10,6 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -47,7 +46,7 @@ class GenerationConfigurationConverter
     static final String COPYRIGHT_PROPERTY_KEY = "copyrightHeader";
 
     static final String SAP_COPYRIGHT_HEADER =
-        "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. " + "All rights reserved.";
+        "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. All rights reserved.";
     static final String TEMPLATE_DIRECTORY = Paths.get("openapi-generator").resolve("mustache-templates").toString();
     static final String LIBRARY_NAME = JavaClientCodegen.RESTTEMPLATE;
     static final String SUPPORT_URL_QUERY = "supportUrlQuery";
@@ -69,6 +68,7 @@ class GenerationConfigurationConverter
         config.additionalProperties().putAll(getAdditionalProperties(generationConfiguration));
         config.typeMapping().putAll(generationConfiguration.getTypeMappings());
         config.importMapping().putAll(generationConfiguration.getImportMappings());
+        config.openapiNormalizer().put("NORMALIZER_CLASS", CustomOpenAPINormalizer.class.getName());
 
         final var openAPI = parseOpenApiSpec(inputSpecFile, generationConfiguration);
 
@@ -133,9 +133,6 @@ class GenerationConfigurationConverter
         void
         preprocessSpecification( @Nonnull final OpenAPI openAPI, @Nonnull final GenerationConfiguration config )
     {
-        // Simplify oneOf/anyOf schemas that have only a single option
-        //simplifyComposedSchemas(openAPI);
-
         if( !FIX_RESPONSE_SCHEMA_TITLES.isEnabled(config) ) {
             return;
         }
@@ -159,182 +156,6 @@ class GenerationConfigurationConverter
                 }
             });
         });
-    }
-
-    /**
-     * Simplifies oneOf/anyOf schemas that have only a single option by removing the composition constraint and
-     * flattening to the referenced schema. This prevents the creation of unnecessary wrapper classes.
-     *
-     * @param openAPI
-     *            the OpenAPI specification to preprocess
-     */
-    @SuppressWarnings( "rawtypes" )
-    private static void simplifyComposedSchemas( @Nonnull final OpenAPI openAPI )
-    {
-        final Components components = openAPI.getComponents();
-        if( components == null || components.getSchemas() == null ) {
-            return;
-        }
-
-        final Map<String, Schema> schemas = components.getSchemas();
-        final Map<String, String> schemaReplacements = identifyWrapperSchemas(schemas);
-
-        if( !schemaReplacements.isEmpty() ) {
-            replaceSchemaReferences(openAPI, schemaReplacements);
-            schemaReplacements.keySet().forEach(schemas::remove);
-        }
-
-        // Simplify remaining composed schemas
-        new HashMap<>(schemas).forEach(( name, schema ) -> simplifyComposedSchema(schema));
-    }
-
-    /**
-     * Identifies wrapper schemas that have only oneOf/anyOf with a single reference.
-     */
-    @SuppressWarnings( { "rawtypes" } )
-    private static Map<String, String> identifyWrapperSchemas( @Nonnull final Map<String, Schema> schemas )
-    {
-        final Map<String, String> replacements = new HashMap<>();
-
-        for( final Map.Entry<String, Schema> entry : schemas.entrySet() ) {
-            final Schema schema = entry.getValue();
-            final Schema referencedSchema = extractSingleComposedOption(schema);
-
-            if( referencedSchema != null && referencedSchema.get$ref() != null ) {
-                final String refName = extractRefName(referencedSchema.get$ref());
-                replacements.put(entry.getKey(), refName);
-                log.error("Identified wrapper schema {} that should be replaced with {}", entry.getKey(), refName);
-            }
-        }
-
-        return replacements;
-    }
-
-    /**
-     * Extracts the single referenced schema from oneOf or anyOf, if it's the only composition option.
-     */
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
-    @Nullable
-    private static Schema extractSingleComposedOption( @Nonnull final Schema schema )
-    {
-        if( schema.getEnum() != null ) {
-            return null;
-        }
-
-        if( isSimpleComposition(schema.getOneOf(), schema.getAnyOf(), schema.getAllOf(), schema.getProperties()) ) {
-            if( schema.getOneOf() != null && schema.getOneOf().size() == 1 ) {
-                return (Schema) schema.getOneOf().get(0);
-            }
-            if( schema.getAnyOf() != null && schema.getAnyOf().size() == 1 ) {
-                return (Schema) schema.getAnyOf().get(0);
-            }
-        }
-        return null;
-    }
-
-    /**
-     * Checks if a schema has only a single composition type with no other composition or properties.
-     */
-    private static boolean isSimpleComposition(
-        @Nullable final java.util.List<?> oneOf,
-        @Nullable final java.util.List<?> anyOf,
-        @Nullable final java.util.List<?> allOf,
-        @Nullable final Map<String, ?> properties )
-    {
-        final boolean hasOneOf = oneOf != null && oneOf.size() == 1;
-        final boolean hasAnyOf = anyOf != null && anyOf.size() == 1;
-
-        // Ensure only one composition type is present, and no properties
-        return ((hasOneOf ^ hasAnyOf) && allOf == null && properties == null);
-    }
-
-    /**
-     * Extracts the schema name from a $ref string like "#/components/schemas/SchemaName".
-     */
-    private static String extractRefName( @Nonnull final String ref )
-    {
-        return ref.substring(ref.lastIndexOf('/') + 1);
-    }
-
-    /**
-     * Replaces all references to wrapper schemas with the actual referenced schema throughout the OpenAPI spec.
-     */
-    private static
-        void
-        replaceSchemaReferences( @Nonnull final OpenAPI openAPI, @Nonnull final Map<String, String> replacements )
-    {
-        final Components components = openAPI.getComponents();
-        if( components != null && components.getParameters() != null ) {
-            components.getParameters().values().forEach(param -> replaceSchemaRef(param.getSchema(), replacements));
-        }
-
-        if( openAPI.getPaths() != null ) {
-            openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperationsMap().values().forEach(operation -> {
-                if( operation.getParameters() != null ) {
-                    operation.getParameters().forEach(param -> replaceSchemaRef(param.getSchema(), replacements));
-                }
-            }));
-        }
-    }
-
-    /**
-     * Replaces a schema reference if it matches one of the wrapper schemas.
-     */
-    @SuppressWarnings( "rawtypes" )
-    private static
-        void
-        replaceSchemaRef( @Nullable final Schema schema, @Nonnull final Map<String, String> replacements )
-    {
-        if( schema != null && schema.get$ref() != null ) {
-            final String refName = extractRefName(schema.get$ref());
-            final String newRefName = replacements.get(refName);
-            if( newRefName != null ) {
-                schema.set$ref("#/components/schemas/" + newRefName);
-                log.error("Replaced schema reference {} with {}", refName, newRefName);
-            }
-        }
-    }
-
-    /**
-     * Recursively simplifies a single schema by clearing oneOf/anyOf constraints and processing nested schemas.
-     */
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
-    private static void simplifyComposedSchema( @Nullable final Schema schema )
-    {
-        if( schema == null ) {
-            return;
-        }
-
-        // Clear single-option composition constraints
-        clearSingleOptionComposition(schema);
-
-        // Recursively simplify nested schemas
-        if( schema.getProperties() != null ) {
-            schema.getProperties().values().forEach(s -> simplifyComposedSchema((Schema) s));
-        }
-        if( schema.getItems() != null ) {
-            simplifyComposedSchema(schema.getItems());
-        }
-        if( schema.getAdditionalProperties() instanceof Schema ) {
-            simplifyComposedSchema((Schema) schema.getAdditionalProperties());
-        }
-        if( schema.getAllOf() != null ) {
-            schema.getAllOf().forEach(s -> simplifyComposedSchema((Schema) s));
-        }
-    }
-
-    /**
-     * Clears oneOf/anyOf constraints when they have only a single option.
-     */
-    @SuppressWarnings( { "rawtypes", "unchecked" } )
-    private static void clearSingleOptionComposition( @Nonnull final Schema schema )
-    {
-        if( schema.getOneOf() != null && schema.getOneOf().size() == 1 ) {
-            schema.setOneOf(null);
-        }
-        if( schema.getAnyOf() != null && schema.getAnyOf().size() == 1 ) {
-            schema.setAnyOf(null);
-        }
     }
 
     private static Map<String, Object> getAdditionalProperties( @Nonnull final GenerationConfiguration config )
@@ -366,8 +187,7 @@ class GenerationConfigurationConverter
         config.getAdditionalProperties().forEach(( k, v ) -> {
             if( result.containsKey(k) ) {
                 final var msg =
-                    "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user "
-                        + "provided configuration.";
+                    "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user provided configuration.";
                 log.info(msg, result.get(k), k, v);
             }
             result.put(k, v);

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -47,7 +47,7 @@ class GenerationConfigurationConverter
     static final String COPYRIGHT_PROPERTY_KEY = "copyrightHeader";
 
     static final String SAP_COPYRIGHT_HEADER =
-        "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. All rights reserved.";
+        "Copyright (c) " + Year.now() + " SAP SE or an SAP affiliate company. " + "All rights reserved.";
     static final String TEMPLATE_DIRECTORY = Paths.get("openapi-generator").resolve("mustache-templates").toString();
     static final String LIBRARY_NAME = JavaClientCodegen.RESTTEMPLATE;
     static final String SUPPORT_URL_QUERY = "supportUrlQuery";
@@ -191,7 +191,7 @@ class GenerationConfigurationConverter
     /**
      * Identifies wrapper schemas that have only oneOf/anyOf with a single reference.
      */
-    @SuppressWarnings( { "rawtypes"} )
+    @SuppressWarnings( { "rawtypes" } )
     private static Map<String, String> identifyWrapperSchemas( @Nonnull final Map<String, Schema> schemas )
     {
         final Map<String, String> replacements = new HashMap<>();
@@ -366,7 +366,8 @@ class GenerationConfigurationConverter
         config.getAdditionalProperties().forEach(( k, v ) -> {
             if( result.containsKey(k) ) {
                 final var msg =
-                    "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user provided configuration.";
+                    "Replacing default value \"{}\" for additional property \"{}\" with \"{}\" from user "
+                        + "provided configuration.";
                 log.info(msg, result.get(k), k, v);
             }
             result.put(k, v);

--- a/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
+++ b/datamodel/openapi/openapi-generator/src/main/java/com/sap/cloud/sdk/datamodel/openapi/generator/GenerationConfigurationConverter.java
@@ -10,6 +10,7 @@ import java.util.List;
 import java.util.Map;
 
 import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 import org.openapitools.codegen.ClientOptInput;
 import org.openapitools.codegen.CodegenConstants;
@@ -132,6 +133,9 @@ class GenerationConfigurationConverter
         void
         preprocessSpecification( @Nonnull final OpenAPI openAPI, @Nonnull final GenerationConfiguration config )
     {
+        // Simplify oneOf/anyOf schemas that have only a single option
+        //simplifyComposedSchemas(openAPI);
+
         if( !FIX_RESPONSE_SCHEMA_TITLES.isEnabled(config) ) {
             return;
         }
@@ -155,6 +159,182 @@ class GenerationConfigurationConverter
                 }
             });
         });
+    }
+
+    /**
+     * Simplifies oneOf/anyOf schemas that have only a single option by removing the composition constraint and
+     * flattening to the referenced schema. This prevents the creation of unnecessary wrapper classes.
+     *
+     * @param openAPI
+     *            the OpenAPI specification to preprocess
+     */
+    @SuppressWarnings( "rawtypes" )
+    private static void simplifyComposedSchemas( @Nonnull final OpenAPI openAPI )
+    {
+        final Components components = openAPI.getComponents();
+        if( components == null || components.getSchemas() == null ) {
+            return;
+        }
+
+        final Map<String, Schema> schemas = components.getSchemas();
+        final Map<String, String> schemaReplacements = identifyWrapperSchemas(schemas);
+
+        if( !schemaReplacements.isEmpty() ) {
+            replaceSchemaReferences(openAPI, schemaReplacements);
+            schemaReplacements.keySet().forEach(schemas::remove);
+        }
+
+        // Simplify remaining composed schemas
+        new HashMap<>(schemas).forEach(( name, schema ) -> simplifyComposedSchema(schema));
+    }
+
+    /**
+     * Identifies wrapper schemas that have only oneOf/anyOf with a single reference.
+     */
+    @SuppressWarnings( { "rawtypes"} )
+    private static Map<String, String> identifyWrapperSchemas( @Nonnull final Map<String, Schema> schemas )
+    {
+        final Map<String, String> replacements = new HashMap<>();
+
+        for( final Map.Entry<String, Schema> entry : schemas.entrySet() ) {
+            final Schema schema = entry.getValue();
+            final Schema referencedSchema = extractSingleComposedOption(schema);
+
+            if( referencedSchema != null && referencedSchema.get$ref() != null ) {
+                final String refName = extractRefName(referencedSchema.get$ref());
+                replacements.put(entry.getKey(), refName);
+                log.error("Identified wrapper schema {} that should be replaced with {}", entry.getKey(), refName);
+            }
+        }
+
+        return replacements;
+    }
+
+    /**
+     * Extracts the single referenced schema from oneOf or anyOf, if it's the only composition option.
+     */
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    @Nullable
+    private static Schema extractSingleComposedOption( @Nonnull final Schema schema )
+    {
+        if( schema.getEnum() != null ) {
+            return null;
+        }
+
+        if( isSimpleComposition(schema.getOneOf(), schema.getAnyOf(), schema.getAllOf(), schema.getProperties()) ) {
+            if( schema.getOneOf() != null && schema.getOneOf().size() == 1 ) {
+                return (Schema) schema.getOneOf().get(0);
+            }
+            if( schema.getAnyOf() != null && schema.getAnyOf().size() == 1 ) {
+                return (Schema) schema.getAnyOf().get(0);
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Checks if a schema has only a single composition type with no other composition or properties.
+     */
+    private static boolean isSimpleComposition(
+        @Nullable final java.util.List<?> oneOf,
+        @Nullable final java.util.List<?> anyOf,
+        @Nullable final java.util.List<?> allOf,
+        @Nullable final Map<String, ?> properties )
+    {
+        final boolean hasOneOf = oneOf != null && oneOf.size() == 1;
+        final boolean hasAnyOf = anyOf != null && anyOf.size() == 1;
+
+        // Ensure only one composition type is present, and no properties
+        return ((hasOneOf ^ hasAnyOf) && allOf == null && properties == null);
+    }
+
+    /**
+     * Extracts the schema name from a $ref string like "#/components/schemas/SchemaName".
+     */
+    private static String extractRefName( @Nonnull final String ref )
+    {
+        return ref.substring(ref.lastIndexOf('/') + 1);
+    }
+
+    /**
+     * Replaces all references to wrapper schemas with the actual referenced schema throughout the OpenAPI spec.
+     */
+    private static
+        void
+        replaceSchemaReferences( @Nonnull final OpenAPI openAPI, @Nonnull final Map<String, String> replacements )
+    {
+        final Components components = openAPI.getComponents();
+        if( components != null && components.getParameters() != null ) {
+            components.getParameters().values().forEach(param -> replaceSchemaRef(param.getSchema(), replacements));
+        }
+
+        if( openAPI.getPaths() != null ) {
+            openAPI.getPaths().values().forEach(pathItem -> pathItem.readOperationsMap().values().forEach(operation -> {
+                if( operation.getParameters() != null ) {
+                    operation.getParameters().forEach(param -> replaceSchemaRef(param.getSchema(), replacements));
+                }
+            }));
+        }
+    }
+
+    /**
+     * Replaces a schema reference if it matches one of the wrapper schemas.
+     */
+    @SuppressWarnings( "rawtypes" )
+    private static
+        void
+        replaceSchemaRef( @Nullable final Schema schema, @Nonnull final Map<String, String> replacements )
+    {
+        if( schema != null && schema.get$ref() != null ) {
+            final String refName = extractRefName(schema.get$ref());
+            final String newRefName = replacements.get(refName);
+            if( newRefName != null ) {
+                schema.set$ref("#/components/schemas/" + newRefName);
+                log.error("Replaced schema reference {} with {}", refName, newRefName);
+            }
+        }
+    }
+
+    /**
+     * Recursively simplifies a single schema by clearing oneOf/anyOf constraints and processing nested schemas.
+     */
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    private static void simplifyComposedSchema( @Nullable final Schema schema )
+    {
+        if( schema == null ) {
+            return;
+        }
+
+        // Clear single-option composition constraints
+        clearSingleOptionComposition(schema);
+
+        // Recursively simplify nested schemas
+        if( schema.getProperties() != null ) {
+            schema.getProperties().values().forEach(s -> simplifyComposedSchema((Schema) s));
+        }
+        if( schema.getItems() != null ) {
+            simplifyComposedSchema(schema.getItems());
+        }
+        if( schema.getAdditionalProperties() instanceof Schema ) {
+            simplifyComposedSchema((Schema) schema.getAdditionalProperties());
+        }
+        if( schema.getAllOf() != null ) {
+            schema.getAllOf().forEach(s -> simplifyComposedSchema((Schema) s));
+        }
+    }
+
+    /**
+     * Clears oneOf/anyOf constraints when they have only a single option.
+     */
+    @SuppressWarnings( { "rawtypes", "unchecked" } )
+    private static void clearSingleOptionComposition( @Nonnull final Schema schema )
+    {
+        if( schema.getOneOf() != null && schema.getOneOf().size() == 1 ) {
+            schema.setOneOf(null);
+        }
+        if( schema.getAnyOf() != null && schema.getAnyOf().size() == 1 ) {
+            schema.setAnyOf(null);
+        }
     }
 
     private static Map<String, Object> getAdditionalProperties( @Nonnull final GenerationConfiguration config )

--- a/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
+++ b/datamodel/openapi/openapi-generator/src/test/java/com/sap/cloud/sdk/datamodel/openapi/generator/DataModelGeneratorIntegrationTest.java
@@ -46,7 +46,7 @@ class DataModelGeneratorIntegrationTest
             ApiMaturity.RELEASED,
             false,
             true,
-            4,
+            5,
             Map.of(),
             Map.of()),
         API_CLASS_VENDOR_EXTENSION_JSON(

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/input/sodastore.yaml
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/input/sodastore.yaml
@@ -36,6 +36,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/Soda'
 
+    delete:
+      summary: String parameter test
+      description: Should simplify the parameter to a string
+      parameters:
+        - $ref: '#/components/parameters/OneOfStringParam'
+      tags:
+        - OneOfStringTest
+      responses:
+        '200':
+          description: A list of soda products
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Soda'
+
   /sodas/{sodaId}:
     get:
       summary: Get details of a specific soda
@@ -103,7 +120,26 @@ paths:
           description: Soda not found
 
 components:
+  parameters:
+    OneOfStringParam:
+      name: executionId
+      description: The Id of an execution
+      schema:
+        $ref: '#/components/schemas/OneOfString'
+      in: query
+      required: true
   schemas:
+    OneOfString:
+      type: string
+      example: aa97b177-9383-4934-8543-0f91b7a0283a
+      oneOf:
+        - $ref: '#/components/schemas/String'
+      description: ID of the deployment/execution
+    String:
+      description: Generic ID
+      pattern: ^[\w.-]{4,64}$
+      type: string
+      example: aa97b177-9383-4934-8543-0f91b7a0283a
     Soda:
       type: object
       properties:

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
@@ -13,7 +13,6 @@ import com.sap.cloud.sdk.services.openapi.apache.apiclient.BaseApi;
 import com.sap.cloud.sdk.services.openapi.apache.apiclient.Pair;
 
 
-import com.sap.cloud.sdk.services.apiclassvendorextension.model.OneOfString;
 import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
 
 import java.util.ArrayList;
@@ -81,7 +80,7 @@ public class OneOfStringTestApi extends BaseApi {
          * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
          */
         @Nonnull
-        public List<Soda> sodasDelete(@Nonnull final OneOfString executionId) throws OpenApiRequestException {
+        public List<Soda> sodasDelete(@Nonnull final String executionId) throws OpenApiRequestException {
             
             // verify the required parameter 'executionId' is set
             if (executionId == null) {

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorApacheIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
@@ -1,0 +1,128 @@
+/*
+ * Copyright (c) 2026 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.sdk.services.apiclassvendorextension.api;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiRequestException;
+import com.sap.cloud.sdk.services.openapi.apache.core.OpenApiResponse;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.ApiClient;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.BaseApi;
+import com.sap.cloud.sdk.services.openapi.apache.apiclient.Pair;
+
+
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.OneOfString;
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.StringJoiner;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+
+import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
+
+
+/**
+ * Soda Store API in version 1.0.0.
+ * <p>
+ * API for managing sodas in a soda store
+ */
+public class OneOfStringTestApi extends BaseApi {
+
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API.
+     *
+     * @param httpDestination The destination that API should be used with
+     */
+    public OneOfStringTestApi( @Nonnull final Destination httpDestination )
+    {
+    super(httpDestination);
+    }
+
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API based on a given {@link ApiClient}.
+     *
+     * @param apiClient
+     *            ApiClient to invoke the API on
+     */
+    public OneOfStringTestApi(@Nonnull final ApiClient apiClient) {
+    super(apiClient);
+    }
+
+    /**
+    * Creates a new API instance with additional default headers.
+    *
+    * @param defaultHeaders Additional headers to include in all requests
+    * @return A new API instance with the combined headers
+    */
+    public OneOfStringTestApi withDefaultHeaders(@Nonnull final Map<String, String> defaultHeaders) {
+        final var api = new OneOfStringTestApi(apiClient);
+        api.defaultHeaders.putAll(this.defaultHeaders);
+        api.defaultHeaders.putAll(defaultHeaders);
+        return api;
+    }
+
+
+        /**
+         * <p>String parameter test
+         * <p>Should simplify the parameter to a string
+         * <p><b>200</b> - A list of soda products
+         * @param executionId
+         *      The Id of an execution
+         * @return List&lt;Soda&gt;
+         * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+         */
+        @Nonnull
+        public List<Soda> sodasDelete(@Nonnull final OneOfString executionId) throws OpenApiRequestException {
+            
+            // verify the required parameter 'executionId' is set
+            if (executionId == null) {
+            throw new OpenApiRequestException("Missing the required parameter 'executionId' when calling sodasDelete")
+            .statusCode(400);
+            }
+            
+            // create path and map variables
+            final String localVarPath = "/sodas";
+            
+            final StringJoiner localVarQueryStringJoiner = new StringJoiner("&");
+            final List<Pair> localVarQueryParams = new ArrayList<Pair>();
+            final List<Pair> localVarCollectionQueryParams = new ArrayList<Pair>();
+            final Map<String, String> localVarHeaderParams = new HashMap<String, String>(defaultHeaders);
+            final Map<String, Object> localVarFormParams = new HashMap<String, Object>();
+            
+                                                                                                                    localVarQueryParams.addAll(ApiClient.parameterToPair("executionId", executionId));
+                                                                                                
+            final String[] localVarAccepts = {
+            "application/json"
+            };
+            final String localVarAccept = ApiClient.selectHeaderAccept(localVarAccepts);
+            final String[] localVarContentTypes = {
+            
+            };
+            final String localVarContentType = ApiClient.selectHeaderContentType(localVarContentTypes);
+            
+            final TypeReference<List<Soda>> localVarReturnType = new TypeReference<List<Soda>>() {};
+                        
+            return apiClient.invokeAPI(
+                localVarPath,
+                "DELETE",
+                localVarQueryParams,
+                localVarCollectionQueryParams,
+                localVarQueryStringJoiner.toString(),
+                null,
+                localVarHeaderParams,
+                localVarFormParams,
+                localVarAccept,
+                localVarContentType,
+                localVarReturnType
+            );
+        }
+        }

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/input/sodastore.yaml
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/input/sodastore.yaml
@@ -36,6 +36,23 @@ paths:
               schema:
                 $ref: '#/components/schemas/Soda'
 
+    delete:
+      summary: String parameter test
+      description: Should simplify the parameter to a string
+      parameters:
+        - $ref: '#/components/parameters/OneOfStringParam'
+      tags:
+        - OneOfStringTest
+      responses:
+        '200':
+          description: A list of soda products
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/Soda'
+
   /sodas/{sodaId}:
     get:
       summary: Get details of a specific soda
@@ -103,7 +120,26 @@ paths:
           description: Soda not found
 
 components:
+  parameters:
+    OneOfStringParam:
+      name: executionId
+      description: The Id of an execution
+      schema:
+        $ref: '#/components/schemas/OneOfString'
+      in: query
+      required: true
   schemas:
+    OneOfString:
+      type: string
+      example: aa97b177-9383-4934-8543-0f91b7a0283a
+      oneOf:
+        - $ref: '#/components/schemas/String'
+      description: ID of the deployment/execution
+    String:
+      description: Generic ID
+      pattern: ^[\w.-]{4,64}$
+      type: string
+      example: aa97b177-9383-4934-8543-0f91b7a0283a
     Soda:
       type: object
       properties:

--- a/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
+++ b/datamodel/openapi/openapi-generator/src/test/resources/DataModelGeneratorIntegrationTest/api-class-vendor-extension-yaml/output/com/sap/cloud/sdk/services/apiclassvendorextension/api/OneOfStringTestApi.java
@@ -1,0 +1,100 @@
+/*
+ * Copyright (c) 2026 SAP SE or an SAP affiliate company. All rights reserved.
+ */
+
+package com.sap.cloud.sdk.services.apiclassvendorextension.api;
+
+import com.sap.cloud.sdk.services.openapi.core.OpenApiRequestException;
+import com.sap.cloud.sdk.services.openapi.core.OpenApiResponse;
+import com.sap.cloud.sdk.services.openapi.core.AbstractOpenApiService;
+import com.sap.cloud.sdk.services.openapi.apiclient.ApiClient;
+
+import com.sap.cloud.sdk.services.apiclassvendorextension.model.Soda;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+import org.springframework.web.util.UriComponentsBuilder;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.core.io.FileSystemResource;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+
+import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
+import com.google.common.annotations.Beta;
+
+import com.sap.cloud.sdk.cloudplatform.connectivity.Destination;
+
+/**
+ * Soda Store API in version 1.0.0.
+ *
+ * API for managing sodas in a soda store
+ */
+public class OneOfStringTestApi extends AbstractOpenApiService {
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API.
+     *
+     * @param httpDestination The destination that API should be used with
+     */
+    public OneOfStringTestApi( @Nonnull final Destination httpDestination )
+    {
+        super(httpDestination);
+    }
+
+    /**
+     * Instantiates this API class to invoke operations on the Soda Store API based on a given {@link ApiClient}.
+     *
+     * @param apiClient
+     *            ApiClient to invoke the API on
+     */
+    @Beta
+    public OneOfStringTestApi( @Nonnull final ApiClient apiClient )
+    {
+         super(apiClient);
+    }
+
+        /**
+     * <p>String parameter test</p>
+     * <p>Should simplify the parameter to a string</p>
+     * <p><b>200</b> - A list of soda products
+     * @param executionId
+     *      The Id of an execution
+     * @return List&lt;Soda&gt;
+     * @throws OpenApiRequestException if an error occurs while attempting to invoke the API
+     */
+    @Nonnull
+    public List<Soda> sodasDelete( @Nonnull final String executionId) throws OpenApiRequestException {
+        final Object localVarPostBody = null;
+        
+        // verify the required parameter 'executionId' is set
+        if (executionId == null) {
+            throw new OpenApiRequestException("Missing the required parameter 'executionId' when calling sodasDelete");
+        }
+        
+        final String localVarPath = UriComponentsBuilder.fromPath("/sodas").build().toUriString();
+
+        final MultiValueMap<String, String> localVarQueryParams = new LinkedMultiValueMap<String, String>();
+        final HttpHeaders localVarHeaderParams = new HttpHeaders();
+        final MultiValueMap<String, Object> localVarFormParams = new LinkedMultiValueMap<String, Object>();
+
+        localVarQueryParams.putAll(apiClient.parameterToMultiValueMap(null, "executionId", executionId));
+
+        final String[] localVarAccepts = { 
+            "application/json"
+        };
+        final List<MediaType> localVarAccept = apiClient.selectHeaderAccept(localVarAccepts);
+        final String[] localVarContentTypes = { };
+        final MediaType localVarContentType = apiClient.selectHeaderContentType(localVarContentTypes);
+
+        final String[] localVarAuthNames = new String[] {  };
+
+        final ParameterizedTypeReference<List<Soda>> localVarReturnType = new ParameterizedTypeReference<List<Soda>>() {};
+        return apiClient.invokeAPI(localVarPath, HttpMethod.DELETE, localVarQueryParams, localVarPostBody, localVarHeaderParams, localVarFormParams, localVarAccept, localVarContentType, localVarAuthNames, localVarReturnType);
+    }
+}


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
## Context
<!-- If there is a GitHub item, please insert it here: --> 

- https://github.com/SAP/ai-sdk-java-backlog/issues/396

The OpenAPI generator `7.22.0` broke generated api classes.

`7.22.0` added description transfers in `ModelUtils.simplifyOneOfAnyOfWithOnlyOneNonNullSubSchema` when simplifying `oneOf` schemas,.
This triggered an existing normalizer step `OpenAPINormalizer.normalizeReferenceSchema` that thought the `description` was alongside the `$ref` in the spec, which is not allowed.

### Feature scope:

<!-- List any _done_ and _to be done_ tasks or steps here. -->
 
- [x] Added a reproducible unit test: `DataModelGeneratorIntegrationTest.integrationTests()` for enum `API_CLASS_VENDOR_EXTENSION_YAML`.
- [x] Added a `CustomOpenAPINormalizer`

## Definition of Done

<!--
Please fill in the below list. Check boxes to reflect that the items were either done or they do not apply. Please use ~strikethrough~ to mark items that do not apply. **Do not delete any items**. Only PRs with a complete list of all DoD items will be merged.

By default some items are marked not relevant because we don't need them frequently. Please still consider if they apply for your PR.
-->

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [ ] ~Error handling created / updated & covered by the tests above~
- [ ] ~Documentation updated~
- [ ] ~Release notes updated~

<!--
An example DoD that is not yet completed might look like this:

- [x] Functionality scope stated & covered
- [x] Tests created / updated _according to the scope_ above
- [x] ~Error handling created / updated & covered by the tests above~
- [x] ~Documentation updated~
- [ ] ~Release notes updated~

Which would mean:

> I implemented the functionality and declared the scope of my changes in the description above. 
> I still have to add some tests but don't have to change any error handling or documentation.
> However, I have not yet considered if we need release notes. 
-->
