### PR TITLE
chore: Set permissions for GH workflows explicitly

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -5,10 +5,14 @@ on:
   schedule:
     - cron: 0 23 * * *
 
+permissions: {}
+
 jobs:
   scan:
     name: "Blackduck Scan"
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
@@ -19,6 +23,8 @@ jobs:
 
   notify-job:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     needs: [ scan ]
     if: ${{ failure() && github.ref == 'refs/heads/main' }}
     steps:

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -50,12 +50,16 @@ env:
   MVN_SINGLE_THREADED_ARGS: --batch-mode --no-transfer-progress --fail-at-end --show-version --threads 1
   MVN_SKIP_CI_PLUGINS: -DskipFormatting -Denforcer.skip -Djacoco.skip -Dmdep.analyze.skip
 
+permissions: {}
+
 jobs:
   context:
     name: "Collect Context"
     outputs:
       commit: ${{ steps.calculate-commit-sha.outputs.COMMIT }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Calculate Commit SHA"
         id: calculate-commit-sha
@@ -79,6 +83,8 @@ jobs:
     name: "Check Formatting"
     needs: [ context ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v6
@@ -106,6 +112,8 @@ jobs:
     name: "Build"
     needs: [ context, check-formatting ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # upload-artifacts does not use github-token
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
@@ -160,6 +168,8 @@ jobs:
     name: "Test"
     needs: [ context, build ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
@@ -202,6 +212,8 @@ jobs:
   static-code-analysis:
     needs: [ context, build ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         task:
@@ -262,6 +274,9 @@ jobs:
     name: "Run CodeQL Analysis"
     needs: [ context ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write # needed for Perform CodeQL Analysis
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
@@ -301,6 +316,8 @@ jobs:
   test-archetypes:
     runs-on: ubuntu-latest
     needs: [ context, build ]
+    permissions:
+      contents: read
     strategy:
       matrix:
         task:
@@ -396,6 +413,8 @@ jobs:
     if: ${{ github.event.inputs.run-blackduck-scan == 'true' }}
     needs: [ context ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6
@@ -412,6 +431,8 @@ jobs:
     if: ${{ github.event.inputs.run-security-rating == 'true' }}
     needs: [ context ]
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for Run FOSStars Rating
     steps:
       - name: "Checkout repository"
         uses: actions/checkout@v6

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -14,6 +14,8 @@ env:
 jobs:
   review-prs:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # all write operations use app token
     steps:
       - name: Checkout
         uses: actions/checkout@v6

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -9,6 +9,8 @@ jobs:
   deploy-snapshot:
     name: Deploy Snapshot
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: "Checkout Repository"
         uses: actions/checkout@v6

--- a/.github/workflows/fosstars-report.yml
+++ b/.github/workflows/fosstars-report.yml
@@ -8,6 +8,8 @@ jobs:
   create_fosstars_report:
     runs-on: ubuntu-latest
     name: "Security rating"
+    permissions:
+      contents: write # needed to push to branch
     steps:
       - uses: actions/checkout@v6
       - uses: SAP/fosstars-rating-core-action@v1.14.0

--- a/.github/workflows/javadoc.yaml
+++ b/.github/workflows/javadoc.yaml
@@ -17,6 +17,8 @@ jobs:
   build:
     name: 'JavaDoc to Documentation Portal'
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # all write operations use app token
 
     steps:
       - name: 'Prepare git'

--- a/.github/workflows/prepare-release.yaml
+++ b/.github/workflows/prepare-release.yaml
@@ -18,6 +18,8 @@ env:
   JAVA_VERSION: 17
   DOCS_REPO: SAP/cloud-sdk
 
+permissions: {}
+
 jobs:
   bump-version:
     name: 'Bump Version'
@@ -29,6 +31,8 @@ jobs:
       release-commit: ${{ steps.prepare-release.outputs.RELEASE_COMMIT_ID }}
       release-tag: ${{ steps.prepare-release.outputs.TAG_NAME }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: write # needed for git push
     steps:
       - name: 'Checkout Repository'
         uses: actions/checkout@v6
@@ -180,6 +184,8 @@ jobs:
     outputs:
       pr-url: ${{ steps.create-release-notes-pr.outputs.PR_URL }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # all write operations use app token
     steps:
       - name: 'Create GitHub App Token'
         id: app-token
@@ -269,6 +275,8 @@ jobs:
     outputs:
       pr-url: ${{ steps.create-code-pr.outputs.PR_URL }}
     runs-on: ubuntu-latest
+    permissions:
+      contents: read # all write operations use app token
     steps:
       - name: 'Create GitHub App Token'
         id: app-token

--- a/.github/workflows/reuse.yaml
+++ b/.github/workflows/reuse.yaml
@@ -11,6 +11,8 @@ on:
 jobs:
   test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@v6
     - name: REUSE Compliance Check


### PR DESCRIPTION
## Context

- https://github.com/SAP/ai-sdk-java-backlog/issues/398

This PR explicitly sets the least required permissions for github workflows.


## Successful Runs

- [Blackduck](https://github.com/SAP/cloud-sdk-java/actions/runs/26450311342)
- [CI](https://github.com/SAP/cloud-sdk-java/actions/runs/26450526100)
- [dependabot automerge](https://github.com/SAP/cloud-sdk-java/actions/runs/26450578006)
- [deploy snapshot](https://github.com/SAP/cloud-sdk-java/actions/runs/26450599318)
- [fosstar](https://github.com/SAP/cloud-sdk-java/actions/runs/26450613557)
- [javadoc](https://github.com/SAP/cloud-sdk-java/actions/runs/26450913784)
- [prepare release](https://github.com/SAP/cloud-sdk-java/actions/runs/26450952566)
