### PR TITLE
chore: [DevOps] Update Jackson to 2.22.0 

### DIFF
--- a/dependency-bundles/bom/pom.xml
+++ b/dependency-bundles/bom/pom.xml
@@ -77,7 +77,7 @@
 		<resilience4j.version>2.4.0</resilience4j.version>
 		<!-- JSON & XML stuff -->
 		<gson.version>2.14.0</gson.version>
-		<jackson.version>2.21.4</jackson.version>
+		<jackson.version>2.22.0</jackson.version>
 		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<owasp-json-sanitizer.version>1.2.3</owasp-json-sanitizer.version>
 		<!-- end of essential versions -->

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
 		<codeAnalysisExclusions>**/testclasses/**</codeAnalysisExclusions>
 		<!--  Non-essential dependencies  -->
 		<jco-api.version>4.87.9</jco-api.version>
-		<jackson.version>2.21.4</jackson.version>
+		<jackson.version>2.22.0</jackson.version>
 		<jackson.annotations.version>2.22</jackson.annotations.version>
 		<!--  WordUtils used twice in OData generator  -->
 		<json.version>20260522</json.version>


### PR DESCRIPTION
Failing blackduck scan : 
- https://github.com/SAP/cloud-sdk-java/actions/runs/26919666992

Update jackson to also update the transitive dependency `com.fasterxml.woodstox: woodstox-core`