### PR TITLE
fix: [DevOps] Fix link in Slack Notification of deploy-snapshot.yaml

### DIFF
--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -50,5 +50,5 @@ jobs:
               - type: "section"
                 text:
                     type: "mrkdwn"
-                    text: "⚠️ Deploy Snapshot to SAP Common Artifactory failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/ai-sdk-java/actions/runs/${{ github.run_id }}|here>. Authentication problems can be fixed by updating the `ARTIFACTORY_COMMON_PASSWORD`: Go to <https://common.repositories.cloud.sap/|Artifactory>, login with user `asa1_fin_cloud_oper`, Edit Profile and Generate an Identity Token. "
+                    text: "⚠️ Deploy Snapshot to SAP Common Artifactory failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}|here>. Authentication problems can be fixed by updating the `ARTIFACTORY_COMMON_PASSWORD`: Go to <https://common.repositories.cloud.sap/|Artifactory>, login with user `asa1_fin_cloud_oper`, Edit Profile and Generate an Identity Token. "
 


### PR DESCRIPTION
The link in the Slack notification pointed to the AI SDK repo before.