### PR TITLE
chore: [DevOps] Change auto-merger schedule to daily

### DIFF
--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -3,7 +3,7 @@ name: dependabot merger
 on:
   workflow_dispatch:
   schedule:
-    - cron: '13 10 * * Tue' # trigger every Tuesday at 10:13, as our dependabot is configured to raise PRs every Tuesday at 8:00 a.m.
+    - cron: '13 10 * * *' # trigger daily at 10:13
 
 env:
   DEPENDABOT_GROUPS: |


### PR DESCRIPTION
We want to run the merger daily to pick up also off-schedule PRs.