### PR TITLE
chore: Remove potential flakyness in OAuth2ServiceTest

### DIFF
--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
@@ -287,7 +287,8 @@ class OAuth2ServiceTest
                     .willReturn(okJson(RESPONSE_TEMPLATE.formatted(TOKEN_1)).withHeader("Set-Cookie", "myCookie=123")));
 
         final OAuth2Service service =
-            OAuth2Service.builder()
+            OAuth2Service
+                .builder()
                 .withTokenUri(SERVER_1.baseUrl())
                 .withIdentity(IDENTITY_1)
                 .withTimeLimiter(ResilienceConfiguration.TimeLimiterConfiguration.disabled())

--- a/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
+++ b/cloudplatform/connectivity-oauth/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/OAuth2ServiceTest.java
@@ -287,7 +287,11 @@ class OAuth2ServiceTest
                     .willReturn(okJson(RESPONSE_TEMPLATE.formatted(TOKEN_1)).withHeader("Set-Cookie", "myCookie=123")));
 
         final OAuth2Service service =
-            OAuth2Service.builder().withTokenUri(SERVER_1.baseUrl()).withIdentity(IDENTITY_1).build();
+            OAuth2Service.builder()
+                .withTokenUri(SERVER_1.baseUrl())
+                .withIdentity(IDENTITY_1)
+                .withTimeLimiter(ResilienceConfiguration.TimeLimiterConfiguration.disabled())
+                .build();
 
         TenantAccessor.executeWithTenant(new DefaultTenant("tenant1"), service::retrieveAccessToken);
         TenantAccessor.executeWithTenant(new DefaultTenant("tenant2"), service::retrieveAccessToken);


### PR DESCRIPTION
## Context

Our unit tests in `OAuth2ServiceTest` can fail when running on slow systems. This seems to be due to a shared `ResilienceConfiguration` state among multiple test resulting in a TimeOutException. It has resulted in workflow failures multiple times ([ex1](https://github.com/SAP/cloud-sdk-java/actions/runs/28682071706/job/85067436747#step:4:8552), [ex2](https://github.com/SAP/cloud-sdk-java/actions/runs/26601604921/job/78386371471#step:4:8038), both from the last 2 months).

This PR tries to fix this by removing the TimeLimiter from the slow call.