### PR TITLE
Add test for tenant subdomain logic

### DIFF
--- a/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantFacadeXsuaaTest.java
+++ b/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantFacadeXsuaaTest.java
@@ -47,7 +47,7 @@ class DefaultTenantFacadeXsuaaTest
     }
 
     @Test
-    @DisplayName("Subdomains don't resolve from issuers without an http prefix")
+    @DisplayName( "Subdomains don't resolve from issuers without an http prefix" )
     void givenIssuerWithoutSchemeThenExceptionIsReturned()
     {
         final String userTenant = "someUserTenant";
@@ -60,9 +60,11 @@ class DefaultTenantFacadeXsuaaTest
 
         final Try<Tenant> tenantTry = new DefaultTenantFacade().tryGetCurrentTenant();
 
-        VavrAssertions.assertThat(tenantTry)
-                .describedAs("issuers without an https:// prefix should lead to a failure")
-                .isFailure().failBecauseOf(TenantAccessException.class);
+        VavrAssertions
+            .assertThat(tenantTry)
+            .describedAs("issuers without an https:// prefix should lead to a failure")
+            .isFailure()
+            .failBecauseOf(TenantAccessException.class);
     }
 
     private DefaultAuthTokenFacade mockCurrentTenant( final String userTenant )

--- a/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantFacadeXsuaaTest.java
+++ b/cloudplatform/tenant/src/test/java/com/sap/cloud/sdk/cloudplatform/tenant/DefaultTenantFacadeXsuaaTest.java
@@ -6,6 +6,7 @@ import static org.mockito.Mockito.when;
 
 import org.assertj.vavr.api.VavrAssertions;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 
 import com.auth0.jwt.JWT;
@@ -45,6 +46,25 @@ class DefaultTenantFacadeXsuaaTest
         VavrAssertions.assertThat(tenantTry).isFailure().failBecauseOf(TenantAccessException.class);
     }
 
+    @Test
+    @DisplayName("Subdomains don't resolve from issuers without an http prefix")
+    void givenIssuerWithoutSchemeThenExceptionIsReturned()
+    {
+        final String userTenant = "someUserTenant";
+        final String issuerWithoutScheme = "foo.accounts.sap.com";
+        final AuthToken jwtWithTenant = createJwtWithTenantAndIssuer(userTenant, issuerWithoutScheme);
+
+        final DefaultAuthTokenFacade mockedFacade = mock(DefaultAuthTokenFacade.class);
+        when(mockedFacade.tryGetCurrentToken()).thenReturn(Try.success(jwtWithTenant));
+        AuthTokenAccessor.setAuthTokenFacade(mockedFacade);
+
+        final Try<Tenant> tenantTry = new DefaultTenantFacade().tryGetCurrentTenant();
+
+        VavrAssertions.assertThat(tenantTry)
+                .describedAs("issuers without an https:// prefix should lead to a failure")
+                .isFailure().failBecauseOf(TenantAccessException.class);
+    }
+
     private DefaultAuthTokenFacade mockCurrentTenant( final String userTenant )
     {
         final AuthToken jwtWithTenant = createJwtWithTenant(userTenant);
@@ -58,12 +78,13 @@ class DefaultTenantFacadeXsuaaTest
 
     private AuthToken createJwtWithTenant( final String tenantId )
     {
+        return createJwtWithTenantAndIssuer(tenantId, "https://sudomain-of-" + tenantId + ".localhost:8080");
+    }
+
+    private AuthToken createJwtWithTenantAndIssuer( final String tenantId, final String issuer )
+    {
         final String encodedJwt =
-            JWT
-                .create()
-                .withClaim("zid", tenantId)
-                .withClaim("iss", "https://sudomain-of-" + tenantId + ".localhost:8080")
-                .sign(Algorithm.none());
+            JWT.create().withClaim("zid", tenantId).withClaim("iss", issuer).sign(Algorithm.none());
         final DecodedJWT decodedJwt = JWT.decode(encodedJwt);
         return new AuthToken(decodedJwt);
     }


### PR DESCRIPTION
## Context

This test reproduces a recent customer issue and for now is mainly for documentation purposes, since this behavior isn't obvious.
