### PR TITLE
chore: [DevOps] Handle CVE-2026-55760

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -16,10 +16,24 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
-        with:
-          ref: cve-fixing
       - name: "Scan With Black Duck"
         uses: ./.github/actions/scan-with-blackduck
         with:
           token: ${{ secrets.BLACKDUCK_TOKEN }}
 
+  notify-job:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    needs: [ scan ]
+    if: ${{ failure() && github.ref == 'refs/heads/main' }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v7
+      - name: Notify
+        run: python .pipeline/scripts/notify.py
+        env:
+          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
+          WORKFLOW: ${{ github.workflow }}
+          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
+          BRANCH_NAME: ${{ github.ref_name }}

--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -16,24 +16,10 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
+        with:
+          ref: cve-fixing
       - name: "Scan With Black Duck"
         uses: ./.github/actions/scan-with-blackduck
         with:
           token: ${{ secrets.BLACKDUCK_TOKEN }}
 
-  notify-job:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: [ scan ]
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Notify
-        run: python .pipeline/scripts/notify.py
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          WORKFLOW: ${{ github.workflow }}
-          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
-          BRANCH_NAME: ${{ github.ref_name }}

--- a/pom.xml
+++ b/pom.xml
@@ -334,7 +334,6 @@
 				<groupId>com.github.jknack</groupId>
 				<artifactId>handlebars</artifactId>
 				<version>${handlebars.version}</version>
-				<scope>test</scope>
 			</dependency>
 			<!-- align commons-text version pulled transitively by handlebars and openapi-generator -->
 			<dependency>
@@ -802,7 +801,6 @@
 						<ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
 						<!-- Transitive dependencies explicitly declared to fic CVEs-->
 						<ignoredUnusedDeclaredDependency>commons-beanutils:commons-beanutils</ignoredUnusedDeclaredDependency>
-						<ignoredUnusedDeclaredDependency>com.github.jknack:handlebars</ignoredUnusedDeclaredDependency>
 					</ignoredUnusedDeclaredDependencies>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -123,6 +123,8 @@
 		<jakarta-activation.version>2.1.0</jakarta-activation.version>
 		<qdox.version>2.2.0</qdox.version>
 		<wiremock.version>3.13.2</wiremock.version>
+		<handlebars.version>4.5.3</handlebars.version>
+		<commons-text.version>1.15.0</commons-text.version>
 		<checkstyle.version>12.3.1</checkstyle.version>
 		<byte-buddy.version>1.18.11</byte-buddy.version>
 		<snakeyaml.version>2.6</snakeyaml.version>
@@ -326,6 +328,19 @@
 				<groupId>commons-beanutils</groupId>
 				<artifactId>commons-beanutils</artifactId>
 				<version>${commons-beanutils.version}</version>
+			</dependency>
+			<!-- resolve vulnerability CVE-2026-55760 (handlebars is used transitively via wiremock) -->
+			<dependency>
+				<groupId>com.github.jknack</groupId>
+				<artifactId>handlebars</artifactId>
+				<version>${handlebars.version}</version>
+				<scope>test</scope>
+			</dependency>
+			<!-- align commons-text version pulled transitively by handlebars and openapi-generator -->
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-text</artifactId>
+				<version>${commons-text.version}</version>
 			</dependency>
 			<!--Dependencies with test scope-->
 			<dependency>
@@ -787,6 +802,7 @@
 						<ignoredUnusedDeclaredDependency>org.junit.jupiter:junit-jupiter-engine</ignoredUnusedDeclaredDependency>
 						<!-- Transitive dependencies explicitly declared to fic CVEs-->
 						<ignoredUnusedDeclaredDependency>commons-beanutils:commons-beanutils</ignoredUnusedDeclaredDependency>
+						<ignoredUnusedDeclaredDependency>com.github.jknack:handlebars</ignoredUnusedDeclaredDependency>
 					</ignoredUnusedDeclaredDependencies>
 				</configuration>
 				<executions>

--- a/pom.xml
+++ b/pom.xml
@@ -334,6 +334,12 @@
 				<groupId>com.github.jknack</groupId>
 				<artifactId>handlebars</artifactId>
 				<version>${handlebars.version}</version>
+				<exclusions>
+					<exclusion>
+						<groupId>org.openjdk.nashorn</groupId>
+						<artifactId>nashorn-core</artifactId>
+					</exclusion>
+				</exclusions>
 			</dependency>
 			<!-- align commons-text version pulled transitively by handlebars and openapi-generator -->
 			<dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -335,6 +335,7 @@
 				<artifactId>handlebars</artifactId>
 				<version>${handlebars.version}</version>
 				<exclusions>
+					<!-- nashorn is not needed and violates Blackduck guidelines	-->
 					<exclusion>
 						<groupId>org.openjdk.nashorn</groupId>
 						<artifactId>nashorn-core</artifactId>


### PR DESCRIPTION
## Context

Blackduck flagged `com.github.jknack:handlebars`, which is transitively used, as vulnerable so this PR fixes its version to a non-vulnerable version and aligns versions for `org.apache.commons:commons-text`.

The new version of `handlebars` introduced a dependency on `org.openjdk.nashorn` which has multiple Blackduck issues. Since `nashorn` is apparently only used by `handlebars` for JavaScript-based template helpers which are not used by the openapi-generator, it can be excluded.

I checked locally that after the exclusion
  1) all generator tests in Cloud SDK are still green,
  2) AI SDK code is generated without any changes.

[Successful Blackduck run after changes](https://github.com/SAP/cloud-sdk-java/actions/runs/30341753006).