### PR TITLE
fix: [Connectivity-ZTIS] Deterministic SVID selection

### DIFF
--- a/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
+++ b/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
@@ -10,6 +10,7 @@ import java.security.cert.CertificateException;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Objects;
 
 import javax.annotation.Nonnull;
@@ -23,6 +24,7 @@ import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
 import io.spiffe.bundle.x509bundle.X509Bundle;
 import io.spiffe.exception.X509SvidException;
+import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.spiffeid.TrustDomain;
 import io.spiffe.svid.x509svid.X509Svid;
 import io.spiffe.workloadapi.DefaultX509Source;
@@ -109,14 +111,45 @@ public class ZeroTrustIdentityService
         final String socketPath = Option.of(System.getenv(SOCKET_ENVIRONMENT_VARIABLE)).getOrElse(DEFAULT_SOCKET_PATH);
         log.info("Using socket path {} for ZTIS agent.", socketPath);
 
-        final X509SourceOptions x509SourceOptions =
-            X509SourceOptions.builder().spiffeSocketPath(socketPath).initTimeout(DEFAULT_SOCKET_TIMEOUT).build();
+        // The SPIRE agent may return multiple SVIDs when overlapping registration selectors exist
+        // (e.g. a second service key on the same ZTIS instance, or a co-located workload). We must pick
+        // the one whose SPIFFE ID matches our binding — see pickSvid.
+        final SpiffeId expectedSpiffeId = SpiffeId.parse(mapView.getMapView("workload").getString("spiffeID"));
+        final X509SourceOptions options =
+            X509SourceOptions
+                .builder()
+                .spiffeSocketPath(socketPath)
+                .initTimeout(DEFAULT_SOCKET_TIMEOUT)
+                .svidPicker(svids -> pickSvid(svids, expectedSpiffeId))
+                .build();
         try {
-            return DefaultX509Source.newSource(x509SourceOptions);
+            return DefaultX509Source.newSource(options);
         }
         catch( final Exception e ) {
             throw new CloudPlatformException("Failed to load the certificate from the unix socket: " + socketPath, e);
         }
+    }
+
+    /**
+     * Selects the {@link X509Svid} whose SPIFFE ID equals {@code expectedSpiffeId} from the given list. Used as the
+     * {@code svidPicker} for {@link DefaultX509Source} to avoid non-deterministic selection when the SPIRE agent
+     * returns multiple SVIDs (e.g. after a second service key is created for the same ZTIS instance).
+     */
+    @Nonnull
+    static X509Svid pickSvid( @Nonnull final List<X509Svid> svids, @Nonnull final SpiffeId expectedSpiffeId )
+    {
+        log.debug("SPIRE agent returned {} SVID(s); selecting the one matching '{}'.", svids.size(), expectedSpiffeId);
+        return svids
+            .stream()
+            .filter(svid -> expectedSpiffeId.equals(svid.getSpiffeId()))
+            .findFirst()
+            .orElseThrow(
+                () -> new CloudPlatformException(
+                    "No SVID matching SPIFFE ID '"
+                        + expectedSpiffeId
+                        + "' among "
+                        + svids.size()
+                        + " returned by the SPIRE agent."));
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
+++ b/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
@@ -114,7 +114,12 @@ public class ZeroTrustIdentityService
         // The SPIRE agent may return multiple SVIDs when overlapping registration selectors exist
         // (e.g. a second service key on the same ZTIS instance, or a co-located workload). We must pick
         // the one whose SPIFFE ID matches our binding — see pickSvid.
-        final SpiffeId expectedSpiffeId = SpiffeId.parse(mapView.getMapView("workload").getString("spiffeID"));
+        final SpiffeId expectedSpiffeId;
+        try {
+            expectedSpiffeId = SpiffeId.parse(mapView.getMapView("workload").getString("spiffeID"));
+        } catch (Exception e) {
+            throw new CloudPlatformException("Invalid SPIFFE ID in Zero Trust Identity Service binding.", e);
+        }
         final X509SourceOptions options =
             X509SourceOptions
                 .builder()

--- a/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
+++ b/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
@@ -145,11 +145,11 @@ public class ZeroTrustIdentityService
             .findFirst()
             .orElseThrow(
                 () -> new CloudPlatformException(
-                    "No SVID matching SPIFFE ID '"
-                        + expectedSpiffeId
-                        + "' among "
-                        + svids.size()
-                        + " returned by the SPIRE agent."));
+                    String
+                        .format(
+                            "No SVID matching SPIFFE ID '%s' among %d returned by the SPIRE agent.",
+                            expectedSpiffeId,
+                            svids.size())));
     }
 
     @Nonnull

--- a/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
+++ b/cloudplatform/connectivity-ztis/src/main/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityService.java
@@ -117,22 +117,27 @@ public class ZeroTrustIdentityService
         final SpiffeId expectedSpiffeId;
         try {
             expectedSpiffeId = SpiffeId.parse(mapView.getMapView("workload").getString("spiffeID"));
-        } catch (Exception e) {
+        }
+        catch( Exception e ) {
             throw new CloudPlatformException("Invalid SPIFFE ID in Zero Trust Identity Service binding.", e);
         }
-        final X509SourceOptions options =
-            X509SourceOptions
-                .builder()
-                .spiffeSocketPath(socketPath)
-                .initTimeout(DEFAULT_SOCKET_TIMEOUT)
-                .svidPicker(svids -> pickSvid(svids, expectedSpiffeId))
-                .build();
         try {
-            return DefaultX509Source.newSource(options);
+            return DefaultX509Source.newSource(buildX509SourceOptions(socketPath, expectedSpiffeId));
         }
         catch( final Exception e ) {
             throw new CloudPlatformException("Failed to load the certificate from the unix socket: " + socketPath, e);
         }
+    }
+
+    X509SourceOptions
+        buildX509SourceOptions( @Nonnull final String socketPath, @Nonnull final SpiffeId expectedSpiffeId )
+    {
+        return X509SourceOptions
+            .builder()
+            .spiffeSocketPath(socketPath)
+            .initTimeout(DEFAULT_SOCKET_TIMEOUT)
+            .svidPicker(svids -> pickSvid(svids, expectedSpiffeId))
+            .build();
     }
 
     /**

--- a/cloudplatform/connectivity-ztis/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityServiceTest.java
+++ b/cloudplatform/connectivity-ztis/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityServiceTest.java
@@ -15,6 +15,7 @@ import java.security.KeyStore;
 import java.security.cert.X509Certificate;
 import java.time.Instant;
 import java.util.Date;
+import java.util.List;
 import java.util.Map;
 
 import org.junit.jupiter.api.BeforeEach;
@@ -26,6 +27,7 @@ import com.sap.cloud.environment.servicebinding.api.ServiceBinding;
 import com.sap.cloud.environment.servicebinding.api.exception.ServiceBindingAccessException;
 import com.sap.cloud.sdk.cloudplatform.exception.CloudPlatformException;
 
+import io.spiffe.spiffeid.SpiffeId;
 import io.spiffe.svid.x509svid.X509Svid;
 
 class ZeroTrustIdentityServiceTest
@@ -152,6 +154,31 @@ class ZeroTrustIdentityServiceTest
             .isInstanceOf(IllegalStateException.class);
     }
 
+    @Test
+    void testPickSvidSelectsMatchingSvid()
+    {
+        final SpiffeId expected = SpiffeId.parse("spiffe://example.org/my-app");
+        final X509Svid own = mockSvidWithSpiffeId(expected);
+        final X509Svid other = mockSvidWithSpiffeId(SpiffeId.parse("spiffe://example.org/other-app"));
+
+        assertThat(ZeroTrustIdentityService.pickSvid(List.of(own), expected)).isSameAs(own);
+        assertThat(ZeroTrustIdentityService.pickSvid(List.of(other, own), expected)).isSameAs(own);
+        assertThat(ZeroTrustIdentityService.pickSvid(List.of(own, other), expected)).isSameAs(own);
+    }
+
+    @Test
+    void testPickSvidThrowsWhenNoMatch()
+    {
+        final SpiffeId expected = SpiffeId.parse("spiffe://example.org/my-app");
+        final X509Svid other = mockSvidWithSpiffeId(SpiffeId.parse("spiffe://example.org/other-app"));
+
+        assertThatThrownBy(() -> ZeroTrustIdentityService.pickSvid(List.of(other), expected))
+            .isInstanceOf(CloudPlatformException.class)
+            .hasMessageContaining("spiffe://example.org/my-app");
+        assertThatThrownBy(() -> ZeroTrustIdentityService.pickSvid(List.of(), expected))
+            .isInstanceOf(CloudPlatformException.class);
+    }
+
     private void mockSvid( Instant notAfter )
     {
         final X509Svid svid = mock(X509Svid.class);
@@ -160,6 +187,13 @@ class ZeroTrustIdentityServiceTest
         doReturn(certificate).when(svid).getLeaf();
         doReturn(svid).when(sut).getX509Svid();
         svidMock = svid;
+    }
+
+    private static X509Svid mockSvidWithSpiffeId( final SpiffeId spiffeId )
+    {
+        final X509Svid svid = mock(X509Svid.class);
+        doReturn(spiffeId).when(svid).getSpiffeId();
+        return svid;
     }
 
     private static ServiceBinding mockBinding()

--- a/cloudplatform/connectivity-ztis/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityServiceTest.java
+++ b/cloudplatform/connectivity-ztis/src/test/java/com/sap/cloud/sdk/cloudplatform/connectivity/ZeroTrustIdentityServiceTest.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -155,28 +156,22 @@ class ZeroTrustIdentityServiceTest
     }
 
     @Test
-    void testPickSvidSelectsMatchingSvid()
+    void testSvidPickerIsWiredAndSelectsMatchingSvid()
     {
         final SpiffeId expected = SpiffeId.parse("spiffe://example.org/my-app");
         final X509Svid own = mockSvidWithSpiffeId(expected);
         final X509Svid other = mockSvidWithSpiffeId(SpiffeId.parse("spiffe://example.org/other-app"));
 
-        assertThat(ZeroTrustIdentityService.pickSvid(List.of(own), expected)).isSameAs(own);
-        assertThat(ZeroTrustIdentityService.pickSvid(List.of(other, own), expected)).isSameAs(own);
-        assertThat(ZeroTrustIdentityService.pickSvid(List.of(own, other), expected)).isSameAs(own);
-    }
+        final Function<List<X509Svid>, X509Svid> picker =
+            sut.buildX509SourceOptions("unix:///tmp/test.sock", expected).getSvidPicker();
 
-    @Test
-    void testPickSvidThrowsWhenNoMatch()
-    {
-        final SpiffeId expected = SpiffeId.parse("spiffe://example.org/my-app");
-        final X509Svid other = mockSvidWithSpiffeId(SpiffeId.parse("spiffe://example.org/other-app"));
-
-        assertThatThrownBy(() -> ZeroTrustIdentityService.pickSvid(List.of(other), expected))
+        assertThat(picker).isNotNull();
+        assertThat(picker.apply(List.of(own))).isSameAs(own);
+        assertThat(picker.apply(List.of(other, own))).isSameAs(own);
+        assertThatThrownBy(() -> picker.apply(List.of(other)))
             .isInstanceOf(CloudPlatformException.class)
             .hasMessageContaining("spiffe://example.org/my-app");
-        assertThatThrownBy(() -> ZeroTrustIdentityService.pickSvid(List.of(), expected))
-            .isInstanceOf(CloudPlatformException.class);
+        assertThatThrownBy(() -> picker.apply(List.of())).isInstanceOf(CloudPlatformException.class);
     }
 
     private void mockSvid( Instant notAfter )

--- a/release_notes.md
+++ b/release_notes.md
@@ -20,4 +20,4 @@
 
 ### 🐛 Fixed Issues
 
-- 
+- [Connectivity] Fixed a bug in `ZeroTrustIdentityService` where a non-deterministic SVID could be selected when the SPIRE agent returns multiple SVIDs to the workload (e.g. after creating a second service key for the same ZTIS instance).


### PR DESCRIPTION
<!--
Thank your for contributing to the SAP Cloud SDK!
If this is your first contribution, please take a few minutes to read our [contribution guidelines](https://github.com/SAP/cloud-sdk-java/blob/main/CONTRIBUTING.md).

The following sections are designed to help you in providing context for your pull request.
-->
Fixes 
- SAP/cloud-sdk-java#1243.

`ZeroTrustIdentityService` did not configure an `svidPicker` when building `X509SourceOptions`, causing `java-spiffe-core` to fall back to `getDefaultSvid()` which simply returns the first SVID in an unordered list. When the SPIRE agent returns multiple SVIDs to a workload (e.g., after creating a second service key for the same ZTIS instance, or when a co-located workload has overlapping selectors), this resulted in non-deterministic SVID selection that could silently present the wrong identity during mTLS handshakes.

This change configures an `svidPicker` that deterministically selects the SVID whose SPIFFE ID matches the expected ID from the ZTIS service binding (`credentials.workload.spiffeID`), as required by the SPIFFE specification.

### Feature scope:
 
- [x] Configure `svidPicker` in `ZeroTrustIdentityService.initX509Source()` to select SVID by SPIFFE ID
- [x] Add `pickSvid` helper method with proper error handling for no-match scenarios
- [x] Add unit tests covering happy path (single/multiple SVIDs) and error cases
- [x] Update release notes with bug fix entry

## Definition of Done

- [x] Functionality scope stated & covered
- [x] Tests cover the scope above
- [x] Error handling created / updated & covered by the tests above
- [x] ~Documentation updated~
- [x] Release notes updated
