### PR TITLE
fix: Fix archetype tests in CI

### DIFF
--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -135,9 +135,9 @@ jobs:
 
       - name: "Build SDK"
         run: |
-          MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} clean install -DskipTests -DskipFormatting -pl '!archetypes,!archetypes/spring-boot3,!archetypes/spring-boot4'"
+          MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} clean install -DskipTests -DskipFormatting"
           echo "[DEBUG] Running Maven with following arguments: $MVN_ARGS"
-          mvn $MVN_ARGS
+          mvn $MVN_ARGS -pl '!archetypes,!archetypes/spring-boot3,!archetypes/spring-boot4'
           # Archetypes are built single-threaded to avoid a race condition on archetype-catalog.xml
           MVN_ARGS="${{ env.MVN_SINGLE_THREADED_ARGS }} install -DskipTests -DskipFormatting -pl archetypes,archetypes/spring-boot3,archetypes/spring-boot4"
           echo "[DEBUG] Running Maven with following arguments: $MVN_ARGS"

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -135,7 +135,11 @@ jobs:
 
       - name: "Build SDK"
         run: |
-          MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} clean install -DskipTests -DskipFormatting"
+          MVN_ARGS="${{ env.MVN_MULTI_THREADED_ARGS }} clean install -DskipTests -DskipFormatting -pl '!archetypes,!archetypes/spring-boot3,!archetypes/spring-boot4'"
+          echo "[DEBUG] Running Maven with following arguments: $MVN_ARGS"
+          mvn $MVN_ARGS
+          # Archetypes are built single-threaded to avoid a race condition on archetype-catalog.xml
+          MVN_ARGS="${{ env.MVN_SINGLE_THREADED_ARGS }} install -DskipTests -DskipFormatting -pl archetypes,archetypes/spring-boot3,archetypes/spring-boot4"
           echo "[DEBUG] Running Maven with following arguments: $MVN_ARGS"
           mvn $MVN_ARGS
 

--- a/.github/workflows/continuous-integration.yaml
+++ b/.github/workflows/continuous-integration.yaml
@@ -330,6 +330,11 @@ jobs:
             "javaVersion": 17,
             "startCommand": "mvn spring-boot:run -B",
           }
+          - {
+            "archetype": "spring-boot4",
+            "javaVersion": 17,
+            "startCommand": "mvn spring-boot:run -B",
+          }
     name: "Test ${{ matrix.task.archetype }} Archetype"
     steps:
       - name: "Setup java"


### PR DESCRIPTION
## Context

A new archetype (spring-boot4) [got added recently](https://github.com/SAP/cloud-sdk-java/pull/1248). Unfortunately, that caused a degradation in the CI pipeline:

The build job of the CI pipeline runs Maven with `--threads 1C` (multi-threaded) and thus both archetype modules write to the shared `~/.m2/repository/archetype-catalog.xml` during `mvn install`. This causes a race condition where one archetype's entry can overwrite the other's, leaving the catalog with potentially only one entry. The test-archetypes job then fails with "Specified archetype not found" for spring-boot3 — seemingly randomly depending on thread scheduling. (See for example [here](https://github.com/SAP/cloud-sdk-java/actions/runs/32833773472/job/97758523417?pr=1255).)

Additionally, the new archetype spring-boot4 is never tested in in the CI pipeline.

This PR addresses both issues by building the archetypes sequentially and adding the new archetype to the test matrix.

Successful CI run with the new setup [here](https://github.com/SAP/cloud-sdk-java/actions/runs/32847661065).