### PR TITLE
chore: [DevOps] Remove Workflow Failure Notifications for Potsdam Team

### DIFF
--- a/.github/workflows/blackduck.yaml
+++ b/.github/workflows/blackduck.yaml
@@ -20,20 +20,3 @@ jobs:
         uses: ./.github/actions/scan-with-blackduck
         with:
           token: ${{ secrets.BLACKDUCK_TOKEN }}
-
-  notify-job:
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    needs: [ scan ]
-    if: ${{ failure() && github.ref == 'refs/heads/main' }}
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-      - name: Notify
-        run: python .pipeline/scripts/notify.py
-        env:
-          SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
-          WORKFLOW: ${{ github.workflow }}
-          WORKFLOW_RUN_URL: https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}
-          BRANCH_NAME: ${{ github.ref_name }}

--- a/.github/workflows/deploy-snapshot.yaml
+++ b/.github/workflows/deploy-snapshot.yaml
@@ -38,17 +38,3 @@ jobs:
         env:
           DEPLOYMENT_USER: ${{ secrets.ARTIFACTORY_COMMON_USER }}
           DEPLOYMENT_PASS: ${{ secrets.ARTIFACTORY_COMMON_PASSWORD }}
-
-      - name: 'Slack Notification'
-        if: failure()
-        uses: slackapi/slack-github-action@v4.0.0
-        with:
-          webhook: ${{ secrets.SLACK_WEBHOOK }}
-          webhook-type: incoming-webhook
-          payload: |
-            blocks:
-              - type: "section"
-                text:
-                    type: "mrkdwn"
-                    text: "⚠️ Deploy Snapshot to SAP Common Artifactory failed! 😬 Please inspect & fix by clicking <https://github.com/SAP/cloud-sdk-java/actions/runs/${{ github.run_id }}|here>. Authentication problems can be fixed by updating the `ARTIFACTORY_COMMON_PASSWORD`: Go to <https://common.repositories.cloud.sap/|Artifactory>, login with user `asa1_fin_cloud_oper`, Edit Profile and Generate an Identity Token. "
-


### PR DESCRIPTION
## Context

Since the Potsdam team is no longer the main maintainer of this project, this PR removes the automatic notifications for that team.